### PR TITLE
feat: implement multi-sprint time allocation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/infrastructure/classifier"
 	cliui "github.com/helmedeiros/digital-asset-capitalization/internal/tasks/infrastructure/cli"
 	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/infrastructure/jira"
+	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/infrastructure/migration"
 	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/infrastructure/storage"
 )
 
@@ -810,6 +811,109 @@ For more information about a command:
 								Name:     "key",
 								Usage:    "Task key (e.g., FN-1015)",
 								Required: true,
+							},
+						},
+					},
+					{
+						Name:  "migrate",
+						Usage: "Migrate sprint data from comma-separated strings to arrays",
+						Action: func(ctx *cli.Context) error {
+							filePath := ctx.String("file")
+							if filePath == "" {
+								filePath = migration.DefaultTasksFilePath()
+							}
+
+							dryRun := ctx.Bool("dry-run")
+							stats := ctx.Bool("stats")
+							rollback := ctx.Bool("rollback")
+
+							// Create storage repository
+							storageDir := filepath.Dir(filePath)
+							storageFile := filepath.Base(filePath)
+							localStorage := storage.NewJSONStorage(storageDir, storageFile)
+
+							// Create backup directory
+							backupDir := filepath.Join(storageDir, "backups")
+
+							migrator := migration.NewSprintMigration(localStorage, backupDir)
+
+							if rollback {
+								if err := migrator.RollbackMigration(context.Background()); err != nil {
+									return fmt.Errorf("failed to rollback migration: %w", err)
+								}
+								fmt.Printf("✓ Successfully rolled back migration for %s\n", filePath)
+								return nil
+							}
+
+							if stats {
+								result, err := migrator.GetMigrationStats(context.Background())
+								if err != nil {
+									return fmt.Errorf("failed to get migration stats: %w", err)
+								}
+
+								fmt.Printf("Migration Statistics for %s:\n", filePath)
+								fmt.Printf("========================================\n")
+								fmt.Printf("Total tasks:      %d\n", result.TasksProcessed)
+								fmt.Printf("Tasks to migrate: %d\n", result.Statistics["needs_migration"])
+								fmt.Printf("Already migrated: %d\n", result.Statistics["already_migrated"])
+								fmt.Printf("Migration %%:      %.1f%%\n", result.Statistics["migration_percentage"])
+								return nil
+							}
+
+							// Validate compatibility before running migration
+							if err := migrator.ValidateCompatibility(context.Background()); err != nil {
+								return fmt.Errorf("migration compatibility check failed: %w", err)
+							}
+
+							result, err := migrator.MigrateToArrayFormat(context.Background(), dryRun)
+							if err != nil {
+								return fmt.Errorf("failed to migrate sprint data: %w", err)
+							}
+
+							fmt.Printf("Migration Results for %s:\n", filePath)
+							fmt.Printf("========================================\n")
+							fmt.Printf("Total tasks:       %d\n", result.TasksProcessed)
+							fmt.Printf("Migrated tasks:    %d\n", result.TasksMigrated)
+							fmt.Printf("Skipped tasks:     %d\n", result.TasksSkipped)
+							if len(result.Errors) > 0 {
+								fmt.Printf("Errors:            %d\n", len(result.Errors))
+								for _, err := range result.Errors {
+									fmt.Printf("  - %s\n", err)
+								}
+							}
+
+							if dryRun {
+								fmt.Printf("\n🔍 DRY RUN: No changes were made\n")
+								fmt.Printf("   Run without --dry-run to apply changes\n")
+							} else {
+								if result.BackupCreated {
+									fmt.Printf("Backup created:    %s\n", result.BackupPath)
+								}
+								fmt.Printf("\n✓ Migration completed successfully!\n")
+								fmt.Printf("   Use --rollback to revert changes if needed\n")
+							}
+
+							return nil
+						},
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:  "file",
+								Usage: "Path to tasks.json file (default: .assetcap/tasks.json)",
+							},
+							&cli.BoolFlag{
+								Name:  "dry-run",
+								Usage: "Preview migration without making changes",
+								Value: false,
+							},
+							&cli.BoolFlag{
+								Name:  "stats",
+								Usage: "Show migration statistics without running migration",
+								Value: false,
+							},
+							&cli.BoolFlag{
+								Name:  "rollback",
+								Usage: "Rollback previous migration using backup file",
+								Value: false,
 							},
 						},
 					},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -202,11 +202,23 @@ For more information about a command:
 							project := ctx.String("project")
 							sprint := ctx.String("sprint")
 							override := ctx.String("override")
-							result, err := a.sprintService.ProcessJiraIssues(project, sprint, override)
-							if err != nil {
-								return err
+							sprintBounded := ctx.Bool("sprint-bounded")
+
+							if sprintBounded {
+								// Use the new sprint-bounded calculation
+								result, err := a.sprintService.ProcessJiraIssuesWithStrategy(project, sprint, override, true)
+								if err != nil {
+									return err
+								}
+								fmt.Print(result)
+							} else {
+								// Use legacy calculation (default)
+								result, err := a.sprintService.ProcessJiraIssues(project, sprint, override)
+								if err != nil {
+									return err
+								}
+								fmt.Print(result)
 							}
-							fmt.Print(result)
 							return nil
 						},
 						Flags: []cli.Flag{
@@ -226,6 +238,12 @@ For more information about a command:
 								Name:    "override",
 								Aliases: []string{"o"},
 								Usage:   "Manual percentage adjustments as JSON where key is IssueID and value is amount of working hours being spent (e.g. '{\"ISSUE-1\": 6, \"ISSUE-2\": 36}')",
+							},
+							&cli.BoolFlag{
+								Name:    "sprint-bounded",
+								Aliases: []string{"sb"},
+								Usage:   "Use sprint-bounded time calculation (respects sprint date boundaries)",
+								Value:   false,
 							},
 						},
 					},

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -163,6 +163,11 @@ func (m *MockSprintService) ListSprints(project, period string) (*sprintusecase.
 	return args.Get(0).(*sprintusecase.ListSprintsResult), args.Error(1)
 }
 
+func (m *MockSprintService) ProcessJiraIssuesWithStrategy(project, sprint, override string, useSprintBounded bool) (string, error) {
+	args := m.Called(project, sprint, override, useSprintBounded)
+	return args.String(0), args.Error(1)
+}
+
 // MockTaskRepository is a mock implementation of TaskRepository
 type MockTaskRepository struct {
 	mock.Mock

--- a/internal/sprint/application/service.go
+++ b/internal/sprint/application/service.go
@@ -69,6 +69,16 @@ func (s *SprintServiceImpl) ProcessJiraIssues(project, sprint, override string) 
 	return processor.Process()
 }
 
+// ProcessJiraIssuesWithStrategy processes Jira issues with configurable time calculation strategy
+func (s *SprintServiceImpl) ProcessJiraIssuesWithStrategy(project, sprint, override string, useSprintBoundedCalculation bool) (string, error) {
+	processor, err := usecase.NewSprintTimeAllocationUseCaseWithStrategy(project, sprint, override, useSprintBoundedCalculation)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Jira processor with strategy: %w", err)
+	}
+
+	return processor.Process()
+}
+
 // ListSprints lists sprints for a project and time period
 func (s *SprintServiceImpl) ListSprints(project, period string) (*usecase.ListSprintsResult, error) {
 	listSprintsUseCase := usecase.NewListSprintsUseCase(s.jiraPort)

--- a/internal/sprint/application/service_test.go
+++ b/internal/sprint/application/service_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -108,6 +109,10 @@ func (m *mockJiraPort) GetSprintsForProjectWithBoardInfo(_ string, _ []string) (
 	return m.sprints, m.boardInfo, m.err
 }
 
+func (m *mockJiraPort) GetSprintByName(_ string, _ string) (*ports.Sprint, error) {
+	return nil, nil
+}
+
 func TestSprintService_ProcessJiraIssues(t *testing.T) {
 	cleanup := setupTestEnv(t)
 	defer cleanup()
@@ -125,7 +130,7 @@ func TestSprintService_ProcessJiraIssues(t *testing.T) {
 							"displayName": "Test User 1",
 						},
 						"status": map[string]interface{}{
-							"name": "Done",
+							"name": domain.StatusDone,
 						},
 						"customfield_13192": 5.0,
 					},
@@ -158,7 +163,7 @@ func TestSprintService_ProcessJiraIssues(t *testing.T) {
 				Key:         "TEST-123",
 				Summary:     "Test Issue 1",
 				Assignee:    "Test User 1",
-				Status:      "Done",
+				Status:      domain.StatusDone,
 				StoryPoints: float64Ptr(5.0),
 			},
 		},
@@ -180,6 +185,117 @@ func TestSprintService_ProcessJiraIssues(t *testing.T) {
 	})
 }
 
+func TestSprintService_ProcessJiraIssuesWithStrategy(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	// Create a test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if strings.Contains(r.URL.Path, "/search") {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"issues": []map[string]interface{}{
+					{
+						"key": "TEST-123",
+						"fields": map[string]interface{}{
+							"summary": "Test Issue 1",
+							"assignee": map[string]interface{}{
+								"displayName": "Test User 1",
+							},
+							"status": map[string]interface{}{
+								"name": domain.StatusDone,
+							},
+							"customfield_13192": 5.0,
+						},
+						"changelog": map[string]interface{}{
+							"histories": []map[string]interface{}{
+								{
+									"created": "2024-03-01T10:00:00.000+0000",
+									"items": []map[string]interface{}{
+										{
+											"field":      "status",
+											"fromString": "To Do",
+											"toString":   "In Progress",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+		} else if strings.Contains(r.URL.Path, "/board") && !strings.Contains(r.URL.Path, "/sprint") {
+			// Boards endpoint
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{
+						"id":   1,
+						"name": "Test Board",
+						"type": "scrum",
+					},
+				},
+			})
+		} else if strings.Contains(r.URL.Path, "/sprint") {
+			// Sprints endpoint
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{
+						"id":        "8802",
+						"name":      "Sprint 1",
+						"state":     "active",
+						"startDate": "2024-03-01T00:00:00.000Z",
+						"endDate":   "2024-03-15T00:00:00.000Z",
+						"goal":      "Sprint goal",
+					},
+				},
+				"isLast":     true,
+				"startAt":    0,
+				"maxResults": 50,
+			})
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	// Set the base URL to our test server
+	os.Setenv("JIRA_BASE_URL", server.URL)
+
+	mockJira := &mockJiraPort{
+		issues: []ports.JiraIssue{
+			{
+				Key:         "TEST-123",
+				Summary:     "Test Issue 1",
+				Assignee:    "Test User 1",
+				Status:      domain.StatusDone,
+				StoryPoints: float64Ptr(5.0),
+			},
+		},
+	}
+
+	service := NewSprintService(mockJira)
+
+	// Test successful processing with legacy strategy
+	t.Run("successful processing with legacy strategy", func(t *testing.T) {
+		result, err := service.ProcessJiraIssuesWithStrategy("TEST", "Sprint 1", "", false)
+		require.NoError(t, err, "ProcessJiraIssuesWithStrategy should not return error")
+		assert.NotEmpty(t, result, "Result should not be empty")
+	})
+
+	// Test successful processing with sprint-bounded strategy
+	t.Run("successful processing with sprint-bounded strategy", func(t *testing.T) {
+		result, err := service.ProcessJiraIssuesWithStrategy("TEST", "Sprint 1", "", true)
+		require.NoError(t, err, "ProcessJiraIssuesWithStrategy should not return error")
+		assert.NotEmpty(t, result, "Result should not be empty")
+	})
+
+	// Test invalid project
+	t.Run("invalid project", func(t *testing.T) {
+		_, err := service.ProcessJiraIssuesWithStrategy("INVALID", "Sprint 1", "", false)
+		assert.Error(t, err, "ProcessJiraIssuesWithStrategy should return error for invalid project")
+	})
+}
+
 func TestSprintService_ProcessSprint(t *testing.T) {
 	cleanup := setupTestEnv(t)
 	defer cleanup()
@@ -197,7 +313,7 @@ func TestSprintService_ProcessSprint(t *testing.T) {
 							"displayName": "Test User 1",
 						},
 						"status": map[string]interface{}{
-							"name": "Done",
+							"name": domain.StatusDone,
 						},
 						"customfield_13192": 5.0,
 					},
@@ -230,7 +346,7 @@ func TestSprintService_ProcessSprint(t *testing.T) {
 				Key:         "TEST-123",
 				Summary:     "Test Issue 1",
 				Assignee:    "Test User 1",
-				Status:      "Done",
+				Status:      domain.StatusDone,
 				StoryPoints: float64Ptr(5.0),
 			},
 		},
@@ -291,7 +407,7 @@ func TestSprintService_ProcessTeamIssues(t *testing.T) {
 							"displayName": "Test User 1",
 						},
 						"status": map[string]interface{}{
-							"name": "Done",
+							"name": domain.StatusDone,
 						},
 						"customfield_13192": 5.0,
 					},
@@ -324,7 +440,7 @@ func TestSprintService_ProcessTeamIssues(t *testing.T) {
 				Key:         "TEST-123",
 				Summary:     "Test Issue 1",
 				Assignee:    "Test User 1",
-				Status:      "Done",
+				Status:      domain.StatusDone,
 				StoryPoints: float64Ptr(5.0),
 			},
 		},

--- a/internal/sprint/application/sprint_service.go
+++ b/internal/sprint/application/sprint_service.go
@@ -16,6 +16,9 @@ type SprintService interface {
 	// ProcessJiraIssues processes Jira issues and returns CSV data
 	ProcessJiraIssues(project, sprint, override string) (string, error)
 
+	// ProcessJiraIssuesWithStrategy processes Jira issues with configurable time calculation strategy
+	ProcessJiraIssuesWithStrategy(project, sprint, override string, useSprintBoundedCalculation bool) (string, error)
+
 	// ListSprints lists sprints for a project and time period
 	ListSprints(project, period string) (*usecase.ListSprintsResult, error)
 }

--- a/internal/sprint/application/usecase/list_sprints_test.go
+++ b/internal/sprint/application/usecase/list_sprints_test.go
@@ -49,6 +49,10 @@ func (m *MockJiraPort) GetTeamIssues(_ *domain.Team) ([]ports.JiraIssue, error) 
 	return nil, nil
 }
 
+func (m *MockJiraPort) GetSprintByName(_ string, _ string) (*ports.Sprint, error) {
+	return nil, nil
+}
+
 func TestListSprintsUseCase_Execute(t *testing.T) {
 	t.Run("should list sprints for a project in Q2 2025", func(t *testing.T) {
 		// Given

--- a/internal/sprint/application/usecase/sprint_time_allocation.go
+++ b/internal/sprint/application/usecase/sprint_time_allocation.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"context"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -17,22 +18,29 @@ import (
 
 const (
 	issueTypeSubTask = "Sub-task"
-	statusDone       = "Done"
-	statusWontDo     = "Won't Do"
+	statusDone       = domain.StatusDone
+	statusWontDo     = domain.StatusWontDo
 )
 
 // SprintTimeAllocationUseCase handles the processing of Jira issues and time calculations
 type SprintTimeAllocationUseCase struct {
-	config   *config.JiraConfig
-	teams    domain.TeamMap
-	project  string
-	sprint   string
-	override string
-	jiraPort ports.JiraPort
+	config         *config.JiraConfig
+	teams          domain.TeamMap
+	project        string
+	sprint         string
+	override       string
+	jiraPort       ports.JiraPort
+	timeCalculator *domain.WorkTimeCalculator
+	sprintBoundary *domain.SprintBoundary
 }
 
 // NewSprintTimeAllocationUseCase creates a new JiraProcessor instance
 func NewSprintTimeAllocationUseCase(project, sprint, override string) (*SprintTimeAllocationUseCase, error) {
+	return NewSprintTimeAllocationUseCaseWithStrategy(project, sprint, override, false)
+}
+
+// NewSprintTimeAllocationUseCaseWithStrategy creates a new use case with configurable time calculation strategy
+func NewSprintTimeAllocationUseCaseWithStrategy(project, sprint, override string, useSprintBoundedCalculation bool) (*SprintTimeAllocationUseCase, error) {
 	// Create Jira adapter with shared configuration
 	jiraAdapter, err := infrastructure.NewJiraAdapter()
 	if err != nil {
@@ -55,13 +63,53 @@ func NewSprintTimeAllocationUseCase(project, sprint, override string) (*SprintTi
 		return nil, fmt.Errorf("failed to load team configuration: %w", err)
 	}
 
+	// Set up time calculation strategy
+	var timeCalculator *domain.WorkTimeCalculator
+	var sprintBoundary *domain.SprintBoundary
+
+	if useSprintBoundedCalculation {
+		// Get sprint details to create sprint boundary
+		sprintDetails, err := jiraAdapter.GetSprintByName(project, sprint)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get sprint details for %s: %w", sprint, err)
+		}
+
+		// Parse sprint dates
+		startDate, err := time.Parse(time.RFC3339, sprintDetails.StartDate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse sprint start date %s: %w", sprintDetails.StartDate, err)
+		}
+
+		endDate, err := time.Parse(time.RFC3339, sprintDetails.EndDate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse sprint end date %s: %w", sprintDetails.EndDate, err)
+		}
+
+		// Create sprint boundary
+		boundary, err := domain.NewSprintBoundary(startDate, endDate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create sprint boundary: %w", err)
+		}
+		sprintBoundary = &boundary
+
+		// Use sprint-bounded time calculator
+		strategy := domain.NewSprintBoundedTimeCalculator()
+		timeCalculator = domain.NewWorkTimeCalculator(strategy)
+	} else {
+		// Use legacy time calculator for backward compatibility
+		strategy := domain.NewLegacyTimeCalculator()
+		timeCalculator = domain.NewWorkTimeCalculator(strategy)
+	}
+
 	return &SprintTimeAllocationUseCase{
-		config:   jiraConfig,
-		teams:    teams,
-		project:  project,
-		sprint:   sprint,
-		override: override,
-		jiraPort: jiraAdapter,
+		config:         jiraConfig,
+		teams:          teams,
+		project:        project,
+		sprint:         sprint,
+		override:       override,
+		jiraPort:       jiraAdapter,
+		timeCalculator: timeCalculator,
+		sprintBoundary: sprintBoundary,
 	}, nil
 }
 
@@ -178,12 +226,8 @@ func (p *SprintTimeAllocationUseCase) calculateTotalHours(team domain.Team, issu
 			continue
 		}
 
-		startTime, endTime := p.getIssueTimeRange(issue)
-		if startTime.IsZero() {
-			continue
-		}
-
-		workingHours := p.calculateWorkingHours(issue.Key, manualAdjustments, startTime, endTime)
+		// Use the new time calculation strategy
+		workingHours := p.calculateWorkingHours(issue.Key, manualAdjustments, issue)
 
 		totalHoursByPerson[assignee] += workingHours
 	}
@@ -237,8 +281,8 @@ func (p *SprintTimeAllocationUseCase) getIssueTimeRange(issue domain.JiraIssue) 
 			// If moving out of "In Progress" to a non-Done state, consider this a pause
 			if inProgress && item.FromString == "In Progress" &&
 				item.ToString != statusDone && item.ToString != statusWontDo {
-				// Calculate working hours up to this point and add to total
-				p.calculateWorkingHours(issue.Key, nil, startTime, historyTime)
+				// This was an interruption in progress, but we don't calculate hours here
+				// since we're only determining the overall time range in this method
 				inProgress = false
 			}
 		}
@@ -282,7 +326,7 @@ func (p *SprintTimeAllocationUseCase) calculatePercentageLoad(team domain.Team, 
 			startTime = endTime.Add(-8 * time.Hour)
 		}
 
-		workingHours := p.calculateWorkingHours(issue.Key, manualAdjustments, startTime, endTime)
+		workingHours := p.calculateWorkingHours(issue.Key, manualAdjustments, issue)
 
 		// For percentage calculations, ensure a minimum of 1 hour for completed issues in the same day
 		if workingHours < 1 && startTime.Year() == endTime.Year() && startTime.Month() == endTime.Month() && startTime.Day() == endTime.Day() &&
@@ -315,7 +359,7 @@ func (p *SprintTimeAllocationUseCase) calculatePercentageLoad(team domain.Team, 
 			startTime = endTime.Add(-8 * time.Hour)
 		}
 
-		workingHours := p.calculateWorkingHours(issue.Key, manualAdjustments, startTime, endTime)
+		workingHours := p.calculateWorkingHours(issue.Key, manualAdjustments, issue)
 
 		// For percentage calculations, ensure a minimum of 1 hour for completed issues in the same day
 		if workingHours < 1 && startTime.Year() == endTime.Year() && startTime.Month() == endTime.Month() && startTime.Day() == endTime.Day() &&
@@ -373,12 +417,35 @@ func (p *SprintTimeAllocationUseCase) generateCSV(team domain.Team, results []ma
 }
 
 // calculateWorkingHours calculates the working hours for an issue
-func (p *SprintTimeAllocationUseCase) calculateWorkingHours(issueKey string, manualAdjustments map[string]float64, startTime, endTime time.Time) float64 {
+func (p *SprintTimeAllocationUseCase) calculateWorkingHours(issueKey string, manualAdjustments map[string]float64, issue domain.JiraIssue) float64 {
 	// Check for manual adjustments first
 	if manualAdjustments != nil {
 		if hours, ok := manualAdjustments[issueKey]; ok {
 			return hours
 		}
+	}
+
+	// Use the new time calculation strategy
+	ctx := context.Background()
+
+	if p.sprintBoundary != nil {
+		// Use sprint-bounded calculation
+		hours, err := p.timeCalculator.CalculateWorkingHours(ctx, issue, *p.sprintBoundary)
+		if err != nil {
+			// Fall back to legacy calculation on error
+			return p.calculateWorkingHoursLegacy(issue)
+		}
+		return hours
+	}
+	// Use legacy calculation (sprint boundary not set)
+	return p.calculateWorkingHoursLegacy(issue)
+}
+
+// calculateWorkingHoursLegacy provides the legacy time calculation as fallback
+func (p *SprintTimeAllocationUseCase) calculateWorkingHoursLegacy(issue domain.JiraIssue) float64 {
+	startTime, endTime := p.getIssueTimeRange(issue)
+	if startTime.IsZero() {
+		return 0
 	}
 
 	// Calculate hours between start and end time

--- a/internal/sprint/application/usecase/sprint_time_allocation_test.go
+++ b/internal/sprint/application/usecase/sprint_time_allocation_test.go
@@ -157,7 +157,7 @@ func TestJiraProcessor_CalculateTotalHours(t *testing.T) {
 					DisplayName: "Test User 1",
 				},
 				Status: domain.JiraStatus{
-					Name: "Done",
+					Name: domain.StatusDone,
 				},
 				IssueType: domain.IssueType{
 					Name: "Task",
@@ -181,7 +181,7 @@ func TestJiraProcessor_CalculateTotalHours(t *testing.T) {
 							{
 								Field:      "status",
 								FromString: "In Progress",
-								ToString:   "Done",
+								ToString:   domain.StatusDone,
 							},
 						},
 					},
@@ -196,7 +196,7 @@ func TestJiraProcessor_CalculateTotalHours(t *testing.T) {
 					DisplayName: "Test User 2",
 				},
 				Status: domain.JiraStatus{
-					Name: "Done",
+					Name: domain.StatusDone,
 				},
 				IssueType: domain.IssueType{
 					Name: "Task",
@@ -220,7 +220,7 @@ func TestJiraProcessor_CalculateTotalHours(t *testing.T) {
 							{
 								Field:      "status",
 								FromString: "In Progress",
-								ToString:   "Done",
+								ToString:   domain.StatusDone,
 							},
 						},
 					},
@@ -235,7 +235,7 @@ func TestJiraProcessor_CalculateTotalHours(t *testing.T) {
 					DisplayName: "Test User 2",
 				},
 				Status: domain.JiraStatus{
-					Name: "Done",
+					Name: domain.StatusDone,
 				},
 				IssueType: domain.IssueType{
 					Name: "Sub-task",
@@ -249,7 +249,7 @@ func TestJiraProcessor_CalculateTotalHours(t *testing.T) {
 							{
 								Field:      "status",
 								FromString: "To Do",
-								ToString:   "Done",
+								ToString:   domain.StatusDone,
 							},
 						},
 					},
@@ -313,7 +313,7 @@ func TestJiraProcessor_GetIssueTimeRange(t *testing.T) {
 									{
 										"field":      "status",
 										"fromString": "In Progress",
-										"toString":   "Done",
+										"toString":   domain.StatusDone,
 									},
 								},
 							},
@@ -369,7 +369,7 @@ func TestJiraProcessor_Process(t *testing.T) {
 			Key:      "TEST-123",
 			Summary:  "Test Issue 1",
 			Assignee: "Test User 1",
-			Status:   "Done",
+			Status:   domain.StatusDone,
 			Changelog: ports.JiraChangelog{
 				Histories: []ports.JiraChangeHistory{
 					{
@@ -388,7 +388,7 @@ func TestJiraProcessor_Process(t *testing.T) {
 							{
 								Field:      "status",
 								FromString: "In Progress",
-								ToString:   "Done",
+								ToString:   domain.StatusDone,
 							},
 						},
 					},
@@ -465,6 +465,10 @@ func (m *MockJiraAdapter) GetSprintsForProjectWithBoardInfo(project string, stat
 	return args.Get(0).([]ports.Sprint), args.Get(1).([]ports.BoardInfo), args.Error(2)
 }
 
+func (m *MockJiraAdapter) GetSprintByName(_, _ string) (*ports.Sprint, error) {
+	return nil, nil
+}
+
 func TestGetIssueTimeRange(t *testing.T) {
 	processor := &SprintTimeAllocationUseCase{}
 
@@ -487,7 +491,7 @@ func TestGetIssueTimeRange(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "To Do",
-									ToString:   "Done",
+									ToString:   domain.StatusDone,
 								},
 							},
 						},
@@ -519,7 +523,7 @@ func TestGetIssueTimeRange(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "In Progress",
-									ToString:   "Done",
+									ToString:   domain.StatusDone,
 								},
 							},
 						},
@@ -551,7 +555,7 @@ func TestGetIssueTimeRange(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "In Progress",
-									ToString:   "Blocked",
+									ToString:   domain.StatusBlocked,
 								},
 							},
 						},
@@ -560,7 +564,7 @@ func TestGetIssueTimeRange(t *testing.T) {
 							Items: []domain.JiraChangeItem{
 								{
 									Field:      "status",
-									FromString: "Blocked",
+									FromString: domain.StatusBlocked,
 									ToString:   "In Progress",
 								},
 							},
@@ -571,7 +575,7 @@ func TestGetIssueTimeRange(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "In Progress",
-									ToString:   "Done",
+									ToString:   domain.StatusDone,
 								},
 							},
 						},
@@ -637,7 +641,7 @@ func TestGetIssueTimeRange(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "To Do",
-									ToString:   "Won't Do",
+									ToString:   domain.StatusWontDo,
 								},
 							},
 						},
@@ -669,7 +673,7 @@ func TestGetIssueTimeRange(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "In Progress",
-									ToString:   "Won't Do",
+									ToString:   domain.StatusWontDo,
 								},
 							},
 						},
@@ -691,7 +695,7 @@ func TestGetIssueTimeRange(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "To Do",
-									ToString:   "Blocked",
+									ToString:   domain.StatusBlocked,
 								},
 							},
 						},
@@ -700,7 +704,7 @@ func TestGetIssueTimeRange(t *testing.T) {
 							Items: []domain.JiraChangeItem{
 								{
 									Field:      "status",
-									FromString: "Blocked",
+									FromString: domain.StatusBlocked,
 									ToString:   "To Do",
 								},
 							},
@@ -711,7 +715,7 @@ func TestGetIssueTimeRange(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "To Do",
-									ToString:   "Under Review",
+									ToString:   domain.StatusUnderReview,
 								},
 							},
 						},
@@ -733,7 +737,7 @@ func TestGetIssueTimeRange(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "To Do",
-									ToString:   "Blocked",
+									ToString:   domain.StatusBlocked,
 								},
 							},
 						},
@@ -742,8 +746,8 @@ func TestGetIssueTimeRange(t *testing.T) {
 							Items: []domain.JiraChangeItem{
 								{
 									Field:      "status",
-									FromString: "Blocked",
-									ToString:   "Under Review",
+									FromString: domain.StatusBlocked,
+									ToString:   domain.StatusUnderReview,
 								},
 							},
 						},
@@ -752,8 +756,8 @@ func TestGetIssueTimeRange(t *testing.T) {
 							Items: []domain.JiraChangeItem{
 								{
 									Field:      "status",
-									FromString: "Under Review",
-									ToString:   "Won't Do",
+									FromString: domain.StatusUnderReview,
+									ToString:   domain.StatusWontDo,
 								},
 							},
 						},
@@ -795,7 +799,7 @@ func TestCalculatePercentageLoad(t *testing.T) {
 					Name: "Task",
 				},
 				Status: domain.JiraStatus{
-					Name: "Done",
+					Name: domain.StatusDone,
 				},
 			},
 			Changelog: domain.JiraChangelog{
@@ -806,7 +810,7 @@ func TestCalculatePercentageLoad(t *testing.T) {
 							{
 								Field:      "status",
 								FromString: "To Do",
-								ToString:   "Done",
+								ToString:   domain.StatusDone,
 							},
 						},
 					},
@@ -847,7 +851,7 @@ func TestGenerateCSV(t *testing.T) {
 					"issueTitle":    "Test Task",
 					"workType":      "Development",
 					"assetName":     "cap-asset-booking",
-					"status":        "Done",
+					"status":        domain.StatusDone,
 					"dateStarted":   "2024-03-20",
 					"dateCompleted": "2024-03-21",
 					"engineer1":     "50.00%",
@@ -869,7 +873,7 @@ func TestGenerateCSV(t *testing.T) {
 					"issueTitle":    "Test Task",
 					"workType":      "Development",
 					"assetName":     "cap-asset-booking",
-					"status":        "Done",
+					"status":        domain.StatusDone,
 					"dateStarted":   "2024-03-20",
 					"dateCompleted": "2024-03-21",
 					"engineer1":     "50.00%",
@@ -891,7 +895,7 @@ func TestGenerateCSV(t *testing.T) {
 					"issueTitle":    "Test Task",
 					"workType":      "Development",
 					"assetName":     "cap-asset-booking",
-					"status":        "Done",
+					"status":        domain.StatusDone,
 					"dateStarted":   "2024-03-20",
 					"dateCompleted": "2024-03-21",
 					"engineer1":     "30.00%",
@@ -915,7 +919,7 @@ func TestGenerateCSV(t *testing.T) {
 					"issueTitle":    "Test Task",
 					"workType":      "Development",
 					"assetName":     "cap-asset-booking",
-					"status":        "Done",
+					"status":        domain.StatusDone,
 					"dateStarted":   "2024-03-20",
 					"dateCompleted": "2024-03-21",
 				},
@@ -1005,7 +1009,7 @@ func TestTimeCalculations(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "To Do",
-									ToString:   "Done",
+									ToString:   domain.StatusDone,
 								},
 							},
 						},
@@ -1039,7 +1043,7 @@ func TestTimeCalculations(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "In Progress",
-									ToString:   "Done",
+									ToString:   domain.StatusDone,
 								},
 							},
 						},
@@ -1073,7 +1077,7 @@ func TestTimeCalculations(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "In Progress",
-									ToString:   "Blocked",
+									ToString:   domain.StatusBlocked,
 								},
 							},
 						},
@@ -1082,7 +1086,7 @@ func TestTimeCalculations(t *testing.T) {
 							Items: []domain.JiraChangeItem{
 								{
 									Field:      "status",
-									FromString: "Blocked",
+									FromString: domain.StatusBlocked,
 									ToString:   "In Progress",
 								},
 							},
@@ -1093,7 +1097,7 @@ func TestTimeCalculations(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "In Progress",
-									ToString:   "Done",
+									ToString:   domain.StatusDone,
 								},
 							},
 						},
@@ -1117,7 +1121,7 @@ func TestTimeCalculations(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "To Do",
-									ToString:   "Done",
+									ToString:   domain.StatusDone,
 								},
 							},
 						},
@@ -1161,7 +1165,7 @@ func TestTimeCalculations(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "In Progress",
-									ToString:   "Done",
+									ToString:   domain.StatusDone,
 								},
 							},
 						},
@@ -1181,7 +1185,7 @@ func TestTimeCalculations(t *testing.T) {
 			assert.Equal(t, tt.expectedStart, startTime, "Start time mismatch for %s", tt.description)
 			assert.Equal(t, tt.expectedEnd, endTime, "End time mismatch for %s", tt.description)
 
-			hours := processor.calculateWorkingHours(tt.issue.Key, nil, startTime, endTime)
+			hours := processor.calculateWorkingHours(tt.issue.Key, nil, tt.issue)
 			assert.Equal(t, tt.expectedHours, hours, "Hours mismatch for %s", tt.description)
 		})
 	}
@@ -1216,7 +1220,7 @@ func TestFilterSubtasks(t *testing.T) {
 							{
 								Field:      "status",
 								FromString: "To Do",
-								ToString:   "Done",
+								ToString:   domain.StatusDone,
 							},
 						},
 					},
@@ -1242,7 +1246,7 @@ func TestFilterSubtasks(t *testing.T) {
 							{
 								Field:      "status",
 								FromString: "To Do",
-								ToString:   "Done",
+								ToString:   domain.StatusDone,
 							},
 						},
 					},
@@ -1341,7 +1345,7 @@ func TestMinimumHoursForDirectDone(t *testing.T) {
 					Name: "Task",
 				},
 				Status: domain.JiraStatus{
-					Name: "Done",
+					Name: domain.StatusDone,
 				},
 			},
 			Changelog: domain.JiraChangelog{
@@ -1352,7 +1356,7 @@ func TestMinimumHoursForDirectDone(t *testing.T) {
 							{
 								Field:      "status",
 								FromString: "To Do",
-								ToString:   "Done",
+								ToString:   domain.StatusDone,
 							},
 						},
 					},
@@ -1370,7 +1374,7 @@ func TestMinimumHoursForDirectDone(t *testing.T) {
 					Name: "Task",
 				},
 				Status: domain.JiraStatus{
-					Name: "Done",
+					Name: domain.StatusDone,
 				},
 			},
 			Changelog: domain.JiraChangelog{
@@ -1381,7 +1385,7 @@ func TestMinimumHoursForDirectDone(t *testing.T) {
 							{
 								Field:      "status",
 								FromString: "To Do",
-								ToString:   "Done",
+								ToString:   domain.StatusDone,
 							},
 						},
 					},
@@ -1390,7 +1394,7 @@ func TestMinimumHoursForDirectDone(t *testing.T) {
 						Items: []domain.JiraChangeItem{
 							{
 								Field:      "status",
-								FromString: "Done",
+								FromString: domain.StatusDone,
 								ToString:   "To Do",
 							},
 						},
@@ -1401,7 +1405,7 @@ func TestMinimumHoursForDirectDone(t *testing.T) {
 							{
 								Field:      "status",
 								FromString: "To Do",
-								ToString:   "Done",
+								ToString:   domain.StatusDone,
 							},
 						},
 					},
@@ -1450,7 +1454,7 @@ func TestPercentageLoadWithMinimumHours(t *testing.T) {
 					Name: "Task",
 				},
 				Status: domain.JiraStatus{
-					Name: "Done",
+					Name: domain.StatusDone,
 				},
 			},
 			Changelog: domain.JiraChangelog{
@@ -1461,7 +1465,7 @@ func TestPercentageLoadWithMinimumHours(t *testing.T) {
 							{
 								Field:      "status",
 								FromString: "To Do",
-								ToString:   "Done",
+								ToString:   domain.StatusDone,
 							},
 						},
 					},
@@ -1479,7 +1483,7 @@ func TestPercentageLoadWithMinimumHours(t *testing.T) {
 					Name: "Task",
 				},
 				Status: domain.JiraStatus{
-					Name: "Done",
+					Name: domain.StatusDone,
 				},
 			},
 			Changelog: domain.JiraChangelog{
@@ -1500,7 +1504,7 @@ func TestPercentageLoadWithMinimumHours(t *testing.T) {
 							{
 								Field:      "status",
 								FromString: "In Progress",
-								ToString:   "Done",
+								ToString:   domain.StatusDone,
 							},
 						},
 					},
@@ -1518,7 +1522,7 @@ func TestPercentageLoadWithMinimumHours(t *testing.T) {
 					Name: "Task",
 				},
 				Status: domain.JiraStatus{
-					Name: "Done",
+					Name: domain.StatusDone,
 				},
 			},
 			Changelog: domain.JiraChangelog{
@@ -1529,7 +1533,7 @@ func TestPercentageLoadWithMinimumHours(t *testing.T) {
 							{
 								Field:      "status",
 								FromString: "To Do",
-								ToString:   "Done",
+								ToString:   domain.StatusDone,
 							},
 						},
 					},

--- a/internal/sprint/domain/jira.go
+++ b/internal/sprint/domain/jira.go
@@ -4,6 +4,21 @@ import (
 	"strings"
 )
 
+const (
+	StatusToDo           = "To Do"
+	StatusInProgress     = "In Progress"
+	StatusUnderReview    = "Under Review"
+	StatusCodeReview     = "Code Review"
+	StatusTesting        = "Testing"
+	StatusQA             = "QA"
+	StatusReadyForReview = "Ready for Review"
+	StatusBlocked        = "Blocked"
+	StatusDone           = "Done"
+	StatusWontDo         = "Won't Do"
+	StatusCancelled      = "Cancelled"
+	StatusOnHold         = "On Hold"
+)
+
 // JiraAssignee represents a Jira issue assignee
 type JiraAssignee struct {
 	DisplayName string `json:"displayName"`
@@ -78,7 +93,7 @@ func (i *JiraIssue) IsInProgress() bool {
 	}
 	lastChange := changes[len(changes)-1]
 	for _, item := range lastChange.Items {
-		if item.IsStatusChange() && item.ToString == "In Progress" {
+		if item.IsStatusChange() && item.ToString == StatusInProgress {
 			return true
 		}
 	}
@@ -93,7 +108,7 @@ func (i *JiraIssue) IsDone() bool {
 	}
 	lastChange := changes[len(changes)-1]
 	for _, item := range lastChange.Items {
-		if item.IsStatusChange() && (item.ToString == "Done" || item.ToString == "Won't Do") {
+		if item.IsStatusChange() && (item.ToString == StatusDone || item.ToString == StatusWontDo) {
 			return true
 		}
 	}

--- a/internal/sprint/domain/jira_test.go
+++ b/internal/sprint/domain/jira_test.go
@@ -54,7 +54,7 @@ func TestJiraIssue_GetStatusChanges(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "To Do",
-									ToString:   "In Progress",
+									ToString:   StatusInProgress,
 								},
 							},
 						},
@@ -68,7 +68,7 @@ func TestJiraIssue_GetStatusChanges(t *testing.T) {
 						{
 							Field:      "status",
 							FromString: "To Do",
-							ToString:   "In Progress",
+							ToString:   StatusInProgress,
 						},
 					},
 				},
@@ -85,12 +85,12 @@ func TestJiraIssue_GetStatusChanges(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "To Do",
-									ToString:   "In Progress",
+									ToString:   StatusInProgress,
 								},
 								{
 									Field:      "status",
-									FromString: "In Progress",
-									ToString:   "Done",
+									FromString: StatusInProgress,
+									ToString:   StatusDone,
 								},
 							},
 						},
@@ -104,12 +104,12 @@ func TestJiraIssue_GetStatusChanges(t *testing.T) {
 						{
 							Field:      "status",
 							FromString: "To Do",
-							ToString:   "In Progress",
+							ToString:   StatusInProgress,
 						},
 						{
 							Field:      "status",
-							FromString: "In Progress",
-							ToString:   "Done",
+							FromString: StatusInProgress,
+							ToString:   StatusDone,
 						},
 					},
 				},
@@ -183,7 +183,7 @@ func TestJiraIssue_IsInProgress(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "To Do",
-									ToString:   "In Progress",
+									ToString:   StatusInProgress,
 								},
 							},
 						},
@@ -202,8 +202,8 @@ func TestJiraIssue_IsInProgress(t *testing.T) {
 							Items: []JiraChangeItem{
 								{
 									Field:      "status",
-									FromString: "In Progress",
-									ToString:   "Done",
+									FromString: StatusInProgress,
+									ToString:   StatusDone,
 								},
 							},
 						},
@@ -248,8 +248,8 @@ func TestJiraIssue_IsDone(t *testing.T) {
 							Items: []JiraChangeItem{
 								{
 									Field:      "status",
-									FromString: "In Progress",
-									ToString:   "Done",
+									FromString: StatusInProgress,
+									ToString:   StatusDone,
 								},
 							},
 						},
@@ -268,8 +268,8 @@ func TestJiraIssue_IsDone(t *testing.T) {
 							Items: []JiraChangeItem{
 								{
 									Field:      "status",
-									FromString: "In Progress",
-									ToString:   "Won't Do",
+									FromString: StatusInProgress,
+									ToString:   StatusWontDo,
 								},
 							},
 						},
@@ -289,7 +289,7 @@ func TestJiraIssue_IsDone(t *testing.T) {
 								{
 									Field:      "status",
 									FromString: "To Do",
-									ToString:   "In Progress",
+									ToString:   StatusInProgress,
 								},
 							},
 						},

--- a/internal/sprint/domain/ports/jira_port.go
+++ b/internal/sprint/domain/ports/jira_port.go
@@ -58,6 +58,8 @@ type JiraPort interface {
 	GetSprintIssues(sprint *domain.Sprint) ([]JiraIssue, error)
 	// GetTeamIssues retrieves all issues for a team
 	GetTeamIssues(team *domain.Team) ([]JiraIssue, error)
+	// GetSprintByName retrieves sprint details by project and sprint name
+	GetSprintByName(project, sprintName string) (*Sprint, error)
 }
 
 // BoardInfo represents information about a board

--- a/internal/sprint/domain/sprint_bounded_time_calculation_test.go
+++ b/internal/sprint/domain/sprint_bounded_time_calculation_test.go
@@ -1,0 +1,439 @@
+package domain
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSprintBoundedTimeCalculation tests all scenarios for sprint-bounded time calculation
+func TestSprintBoundedTimeCalculation(t *testing.T) {
+	tests := []struct {
+		name                string
+		issue               JiraIssue
+		sprintBoundary      SprintBoundary
+		expectedHours       float64
+		expectedDescription string
+	}{
+		// === Single Sprint Stories (Current Working Cases) ===
+		{
+			name: "Scenario 1A - Story starts and completes within one sprint",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-05T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+				{timestamp: "2024-03-10T15:00:00.000Z", from: StatusInProgress, to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
+			},
+			expectedHours:       125.0, // 5 days * 25 hours (5 days, 5 hours)
+			expectedDescription: "Full time allocation within sprint boundaries",
+		},
+		{
+			name: "Scenario 1B - Story goes directly from To Do to Done within one sprint",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-10T10:00:00.000Z", from: "To Do", to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
+			},
+			expectedHours:       1.0, // Minimum 1 hour for same-day completion
+			expectedDescription: "Minimum 1 hour allocation for direct completion",
+		},
+
+		// === Cross-Sprint Stories (Problem Cases) ===
+		{
+			name: "Scenario 2A - Story starts in Sprint A, completes in Sprint B (Sprint A perspective)",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-05T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+				{timestamp: "2024-03-25T15:00:00.000Z", from: StatusInProgress, to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
+			},
+			expectedHours:       254.0, // 10 days, 14 hours (Mar 5 10:00 to Mar 15 23:59:59.999)
+			expectedDescription: "Only count time within Sprint A boundaries",
+		},
+		{
+			name: "Scenario 2A - Story starts in Sprint A, completes in Sprint B (Sprint B perspective)",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-05T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+				{timestamp: "2024-03-25T15:00:00.000Z", from: StatusInProgress, to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-16T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-30T23:59:59.999Z"),
+			},
+			expectedHours:       231.0, // 9 days, 15 hours (Mar 16 00:00 to Mar 25 15:00)
+			expectedDescription: "Only count time within Sprint B boundaries",
+		},
+		{
+			name: "Scenario 2B - Story starts before Sprint A, completes in Sprint A",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-05T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+				{timestamp: "2024-03-25T15:00:00.000Z", from: StatusInProgress, to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-16T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-30T23:59:59.999Z"),
+			},
+			expectedHours:       231.0, // 9 days, 15 hours (Mar 16 00:00 to Mar 25 15:00)
+			expectedDescription: "Only count time within sprint boundaries, ignore pre-sprint work",
+		},
+		{
+			name: "Scenario 2C - Story starts in Sprint A, completes after Sprint A",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-05T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+				{timestamp: "2024-03-25T15:00:00.000Z", from: StatusInProgress, to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
+			},
+			expectedHours:       254.0, // 10 days, 14 hours (Mar 5 10:00 to Mar 15 23:59:59.999)
+			expectedDescription: "Only count time within sprint boundaries, ignore post-sprint work",
+		},
+
+		// === Complex Multi-Sprint Stories ===
+		{
+			name: "Scenario 3A - Multiple status transitions across sprints (Sprint A)",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-05T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+				{timestamp: "2024-03-10T15:00:00.000Z", from: StatusInProgress, to: StatusBlocked},
+				{timestamp: "2024-03-20T10:00:00.000Z", from: StatusBlocked, to: StatusInProgress},
+				{timestamp: "2024-03-25T15:00:00.000Z", from: StatusInProgress, to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
+			},
+			expectedHours:       125.0, // 5 days, 5 hours (Mar 5 10:00 to Mar 10 15:00)
+			expectedDescription: "Only count active work time within sprint boundaries",
+		},
+		{
+			name: "Scenario 3A - Multiple status transitions across sprints (Sprint B)",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-05T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+				{timestamp: "2024-03-10T15:00:00.000Z", from: StatusInProgress, to: StatusBlocked},
+				{timestamp: "2024-03-20T10:00:00.000Z", from: StatusBlocked, to: StatusInProgress},
+				{timestamp: "2024-03-25T15:00:00.000Z", from: StatusInProgress, to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-16T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-30T23:59:59.999Z"),
+			},
+			expectedHours:       125.0, // 5 days, 5 hours (Mar 20 10:00 to Mar 25 15:00)
+			expectedDescription: "Only count active work time within sprint boundaries",
+		},
+		{
+			name: "Scenario 3B - Story spans three sprints (Sprint A)",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-05T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+				{timestamp: "2024-03-20T15:00:00.000Z", from: StatusInProgress, to: StatusBlocked},
+				{timestamp: "2024-04-10T10:00:00.000Z", from: StatusBlocked, to: StatusInProgress},
+				{timestamp: "2024-04-12T15:00:00.000Z", from: StatusInProgress, to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
+			},
+			expectedHours:       254.0, // 10 days, 14 hours (Mar 5 10:00 to Mar 15 23:59:59.999)
+			expectedDescription: "Count active work time within Sprint A boundaries",
+		},
+		{
+			name: "Scenario 3B - Story spans three sprints (Sprint B - partially blocked)",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-05T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+				{timestamp: "2024-03-20T15:00:00.000Z", from: StatusInProgress, to: StatusBlocked},
+				{timestamp: "2024-04-10T10:00:00.000Z", from: StatusBlocked, to: StatusInProgress},
+				{timestamp: "2024-04-12T15:00:00.000Z", from: StatusInProgress, to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-16T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-30T23:59:59.999Z"),
+			},
+			expectedHours:       111.0, // 4 days 15 hours (Mar 16 00:00 to Mar 20 15:00, StatusInProgress period only)
+			expectedDescription: "Count only In Progress time, not blocked time",
+		},
+		{
+			name: "Scenario 3B - Story spans three sprints (Sprint C)",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-05T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+				{timestamp: "2024-03-20T15:00:00.000Z", from: StatusInProgress, to: StatusBlocked},
+				{timestamp: "2024-04-10T10:00:00.000Z", from: StatusBlocked, to: StatusInProgress},
+				{timestamp: "2024-04-12T15:00:00.000Z", from: StatusInProgress, to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-04-01T00:00:00.000Z"),
+				EndDate:   parseTime("2024-04-15T23:59:59.999Z"),
+			},
+			expectedHours:       53.0, // 2 days, 5 hours (Apr 10 10:00 to Apr 12 15:00)
+			expectedDescription: "Count active work time within Sprint C boundaries",
+		},
+		{
+			name: "Scenario 3C - Story moves backward in status across sprints (Sprint A)",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-05T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+				{timestamp: "2024-03-10T15:00:00.000Z", from: StatusInProgress, to: StatusUnderReview},
+				{timestamp: "2024-03-20T10:00:00.000Z", from: StatusUnderReview, to: StatusInProgress},
+				{timestamp: "2024-03-25T15:00:00.000Z", from: StatusInProgress, to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
+			},
+			expectedHours:       254.0, // 10 days, 14 hours (Mar 5 10:00 to Mar 15 23:59:59.999, both In Progress and Under Review count as work)
+			expectedDescription: "Count both In Progress and Under Review as work time",
+		},
+
+		// === Edge Cases ===
+		{
+			name: "Scenario 4A - Story completed same day it starts (cross-sprint Sprint A)",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-15T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+				{timestamp: "2024-03-16T14:00:00.000Z", from: StatusInProgress, to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
+			},
+			expectedHours:       14.0, // 14 hours (Mar 15 10:00 to Mar 15 23:59)
+			expectedDescription: "Count time within Sprint A boundaries only",
+		},
+		{
+			name: "Scenario 4A - Story completed same day it starts (cross-sprint Sprint B)",
+			issue: createIssueWithStatusChanges([]statusChange{
+				{timestamp: "2024-03-15T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+				{timestamp: "2024-03-16T14:00:00.000Z", from: StatusInProgress, to: StatusDone},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-16T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-30T23:59:59.999Z"),
+			},
+			expectedHours:       14.0, // 14 hours (Mar 16 00:00 to Mar 16 14:00)
+			expectedDescription: "Count time within Sprint B boundaries only",
+		},
+		{
+			name:  "Scenario 4B - Story with no status changes",
+			issue: createIssueWithStatusChanges([]statusChange{}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
+			},
+			expectedHours:       0.0, // No time allocation
+			expectedDescription: "No allocation for stories with no status changes",
+		},
+		{
+			name: "Story with only non-status changes",
+			issue: createIssueWithNonStatusChanges([]nonStatusChange{
+				{timestamp: "2024-03-05T10:00:00.000Z", field: "description", from: "", to: "Updated description"},
+			}),
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
+			},
+			expectedHours:       0.0, // No time allocation
+			expectedDescription: "No allocation for stories with only non-status changes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create the sprint-bounded time calculator
+			calculator := NewSprintBoundedTimeCalculator()
+
+			// Calculate working hours within sprint boundaries
+			hours, err := calculator.CalculateWorkingHours(context.Background(), tt.issue, tt.sprintBoundary)
+
+			// Verify results
+			require.NoError(t, err, "CalculateWorkingHours should not return an error")
+			assert.Equal(t, tt.expectedHours, hours, "Expected hours should match calculated hours: %s", tt.expectedDescription)
+		})
+	}
+}
+
+// TestSprintBoundaryValidation tests validation of sprint boundaries
+func TestSprintBoundaryValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		sprintBoundary SprintBoundary
+		expectedError  string
+	}{
+		{
+			name: "Valid sprint boundary",
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
+			},
+			expectedError: "",
+		},
+		{
+			name: "Invalid sprint boundary - end before start",
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-15T00:00:00.000Z"),
+				EndDate:   parseTime("2024-03-01T23:59:59.999Z"),
+			},
+			expectedError: "sprint end date must be after start date",
+		},
+		{
+			name: "Invalid sprint boundary - zero start date",
+			sprintBoundary: SprintBoundary{
+				StartDate: time.Time{},
+				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
+			},
+			expectedError: "sprint start date is required",
+		},
+		{
+			name: "Invalid sprint boundary - zero end date",
+			sprintBoundary: SprintBoundary{
+				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
+				EndDate:   time.Time{},
+			},
+			expectedError: "sprint end date is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.sprintBoundary.Validate()
+
+			if tt.expectedError == "" {
+				assert.NoError(t, err, "Valid sprint boundary should not return an error")
+			} else {
+				assert.Error(t, err, "Invalid sprint boundary should return an error")
+				assert.Contains(t, err.Error(), tt.expectedError, "Error message should contain expected text")
+			}
+		})
+	}
+}
+
+// TestTimeCalculationStrategy tests the strategy pattern implementation
+func TestTimeCalculationStrategy(t *testing.T) {
+	t.Run("Legacy strategy maintains backward compatibility", func(t *testing.T) {
+		issue := createIssueWithStatusChanges([]statusChange{
+			{timestamp: "2024-03-05T10:00:00.000Z", from: "To Do", to: StatusInProgress},
+			{timestamp: "2024-03-25T15:00:00.000Z", from: StatusInProgress, to: StatusDone},
+		})
+
+		sprintBoundary := SprintBoundary{
+			StartDate: parseTime("2024-03-01T00:00:00.000Z"),
+			EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
+		}
+
+		// Test legacy strategy (should return full lifecycle time)
+		legacyCalculator := NewLegacyTimeCalculator()
+		legacyHours, err := legacyCalculator.CalculateWorkingHours(context.Background(), issue, sprintBoundary)
+		require.NoError(t, err)
+
+		// Test sprint-bounded strategy
+		sprintCalculator := NewSprintBoundedTimeCalculator()
+		sprintHours, err := sprintCalculator.CalculateWorkingHours(context.Background(), issue, sprintBoundary)
+		require.NoError(t, err)
+
+		// Legacy should return full lifecycle time (20 days, 5 hours)
+		assert.Equal(t, 485.0, legacyHours, "Legacy calculator should return full lifecycle time")
+
+		// Sprint-bounded should return only time within sprint boundaries (10 days, 14 hours)
+		assert.Equal(t, 254.0, sprintHours, "Sprint-bounded calculator should return only time within sprint boundaries")
+
+		// Sprint-bounded should be less than legacy for cross-sprint stories
+		assert.Less(t, sprintHours, legacyHours, "Sprint-bounded time should be less than legacy time for cross-sprint stories")
+	})
+}
+
+// Helper types and functions for creating test data
+type statusChange struct {
+	timestamp string
+	from      string
+	to        string
+}
+
+type nonStatusChange struct {
+	timestamp string
+	field     string
+	from      string
+	to        string
+}
+
+func createIssueWithStatusChanges(changes []statusChange) JiraIssue {
+	histories := make([]JiraChangeHistory, len(changes))
+	for i, change := range changes {
+		histories[i] = JiraChangeHistory{
+			Created: change.timestamp,
+			Items: []JiraChangeItem{
+				{
+					Field:      "status",
+					FromString: change.from,
+					ToString:   change.to,
+				},
+			},
+		}
+	}
+
+	return JiraIssue{
+		Key: "TEST-123",
+		Fields: JiraFields{
+			Summary: "Test Issue",
+			Assignee: JiraAssignee{
+				DisplayName: "Test User",
+			},
+			Status: JiraStatus{
+				Name: StatusDone,
+			},
+			IssueType: IssueType{
+				Name: "Task",
+			},
+		},
+		Changelog: JiraChangelog{
+			Histories: histories,
+		},
+	}
+}
+
+func createIssueWithNonStatusChanges(changes []nonStatusChange) JiraIssue {
+	histories := make([]JiraChangeHistory, len(changes))
+	for i, change := range changes {
+		histories[i] = JiraChangeHistory{
+			Created: change.timestamp,
+			Items: []JiraChangeItem{
+				{
+					Field:      change.field,
+					FromString: change.from,
+					ToString:   change.to,
+				},
+			},
+		}
+	}
+
+	return JiraIssue{
+		Key: "TEST-124",
+		Fields: JiraFields{
+			Summary: "Test Issue",
+			Assignee: JiraAssignee{
+				DisplayName: "Test User",
+			},
+			Status: JiraStatus{
+				Name: "To Do",
+			},
+			IssueType: IssueType{
+				Name: "Task",
+			},
+		},
+		Changelog: JiraChangelog{
+			Histories: histories,
+		},
+	}
+}
+
+func parseTime(timestamp string) time.Time {
+	t, err := time.Parse("2006-01-02T15:04:05.000Z", timestamp)
+	if err != nil {
+		panic(err)
+	}
+	return t.UTC()
+}

--- a/internal/sprint/domain/time_calculation.go
+++ b/internal/sprint/domain/time_calculation.go
@@ -1,0 +1,386 @@
+package domain
+
+import (
+	"context"
+	"errors"
+	"math"
+	"time"
+)
+
+// TimeCalculationStrategy defines the interface for different time calculation strategies
+// This follows the Strategy pattern to allow different calculation approaches
+type TimeCalculationStrategy interface {
+	CalculateWorkingHours(ctx context.Context, issue JiraIssue, sprintBoundary SprintBoundary) (float64, error)
+}
+
+// SprintBoundary represents the time boundaries of a sprint
+// This is a value object that encapsulates sprint date range logic
+type SprintBoundary struct {
+	StartDate time.Time
+	EndDate   time.Time
+}
+
+// NewSprintBoundary creates a new sprint boundary with validation
+func NewSprintBoundary(startDate, endDate time.Time) (SprintBoundary, error) {
+	boundary := SprintBoundary{
+		StartDate: startDate,
+		EndDate:   endDate,
+	}
+
+	if err := boundary.Validate(); err != nil {
+		return SprintBoundary{}, err
+	}
+
+	return boundary, nil
+}
+
+// Validate ensures the sprint boundary is valid
+func (sb SprintBoundary) Validate() error {
+	if sb.StartDate.IsZero() {
+		return errors.New("sprint start date is required")
+	}
+
+	if sb.EndDate.IsZero() {
+		return errors.New("sprint end date is required")
+	}
+
+	if sb.EndDate.Before(sb.StartDate) {
+		return errors.New("sprint end date must be after start date")
+	}
+
+	return nil
+}
+
+// Contains checks if a given time falls within the sprint boundary
+func (sb SprintBoundary) Contains(t time.Time) bool {
+	return !t.Before(sb.StartDate) && !t.After(sb.EndDate)
+}
+
+// ClampTime constrains a time to fall within the sprint boundary
+func (sb SprintBoundary) ClampTime(t time.Time) time.Time {
+	if t.Before(sb.StartDate) {
+		return sb.StartDate
+	}
+	if t.After(sb.EndDate) {
+		return sb.EndDate
+	}
+	return t
+}
+
+// StatusChangePeriod represents a period of time with a specific status
+// This helps in calculating work time for different status transitions
+type StatusChangePeriod struct {
+	StartTime time.Time
+	EndTime   time.Time
+	Status    string
+}
+
+// Duration returns the duration of the status change period
+func (scp StatusChangePeriod) Duration() time.Duration {
+	if scp.EndTime.IsZero() {
+		return 0
+	}
+	return scp.EndTime.Sub(scp.StartTime)
+}
+
+// IsWorkTime determines if a status represents active work time
+func (scp StatusChangePeriod) IsWorkTime() bool {
+	workStatuses := []string{
+		StatusInProgress,
+		"Under Review",
+		"Code Review",
+		"Testing",
+		"QA",
+		"Ready for Review",
+	}
+
+	// Explicitly exclude non-work statuses
+	nonWorkStatuses := []string{
+		"To Do",
+		"Blocked",
+		"Done",
+		StatusWontDo,
+		"Cancelled",
+		"On Hold",
+	}
+
+	// Check if it's explicitly a non-work status
+	for _, status := range nonWorkStatuses {
+		if scp.Status == status {
+			return false
+		}
+	}
+
+	// Check if it's explicitly a work status
+	for _, status := range workStatuses {
+		if scp.Status == status {
+			return true
+		}
+	}
+
+	// Default to false for unknown statuses
+	return false
+}
+
+// SprintBoundedTimeCalculator implements TimeCalculationStrategy
+// This is the main implementation that respects sprint boundaries
+type SprintBoundedTimeCalculator struct {
+	// Could add configuration options here if needed
+}
+
+// NewSprintBoundedTimeCalculator creates a new sprint-bounded time calculator
+func NewSprintBoundedTimeCalculator() *SprintBoundedTimeCalculator {
+	return &SprintBoundedTimeCalculator{}
+}
+
+// CalculateWorkingHours calculates working hours within sprint boundaries
+func (calc *SprintBoundedTimeCalculator) CalculateWorkingHours(_ context.Context, issue JiraIssue, sprintBoundary SprintBoundary) (float64, error) {
+	// Validate sprint boundary
+	if err := sprintBoundary.Validate(); err != nil {
+		return 0, err
+	}
+
+	// Get status change periods
+	periods := calc.extractStatusChangePeriods(issue)
+
+	// Calculate work time within sprint boundaries
+	var totalHours float64
+	for _, period := range periods {
+		if period.IsWorkTime() {
+			hours := calc.calculatePeriodHours(period, sprintBoundary)
+			totalHours += hours
+		}
+	}
+
+	// Apply minimum hour rule for same-day completion within sprint
+	if totalHours == 0 && calc.hasCompletionInSprint(issue, sprintBoundary) {
+		totalHours = 1.0
+	}
+
+	// Round to avoid floating-point precision issues
+	return roundHours(totalHours), nil
+}
+
+// extractStatusChangePeriods extracts all status change periods from the issue
+func (calc *SprintBoundedTimeCalculator) extractStatusChangePeriods(issue JiraIssue) []StatusChangePeriod {
+	var periods []StatusChangePeriod
+
+	// Sort status changes chronologically
+	statusChanges := issue.GetStatusChanges()
+	if len(statusChanges) == 0 {
+		return periods
+	}
+
+	// Create periods between status changes
+	for i := 0; i < len(statusChanges); i++ {
+		// Parse timestamp
+		startTime, err := time.Parse("2006-01-02T15:04:05.000Z", statusChanges[i].Created)
+		if err != nil {
+			// Try RFC3339 format
+			startTime, err = time.Parse(time.RFC3339, statusChanges[i].Created)
+			if err != nil {
+				continue
+			}
+		}
+		startTime = startTime.UTC()
+
+		// Get the status that this change transitions TO
+		var status string
+		for _, item := range statusChanges[i].Items {
+			if item.IsStatusChange() {
+				status = item.ToString
+				break
+			}
+		}
+
+		// Determine end time (next status change or zero if it's the last one)
+		var endTime time.Time
+		if i+1 < len(statusChanges) {
+			endTime, err = time.Parse("2006-01-02T15:04:05.000Z", statusChanges[i+1].Created)
+			if err != nil {
+				endTime, err = time.Parse(time.RFC3339, statusChanges[i+1].Created)
+				if err != nil {
+					continue
+				}
+			}
+			endTime = endTime.UTC()
+		}
+
+		periods = append(periods, StatusChangePeriod{
+			StartTime: startTime,
+			EndTime:   endTime,
+			Status:    status,
+		})
+	}
+
+	return periods
+}
+
+// calculatePeriodHours calculates hours for a specific period within sprint boundaries
+func (calc *SprintBoundedTimeCalculator) calculatePeriodHours(period StatusChangePeriod, sprintBoundary SprintBoundary) float64 {
+	// Clamp period to sprint boundaries
+	startTime := sprintBoundary.ClampTime(period.StartTime)
+	endTime := period.EndTime
+
+	// If end time is zero (ongoing), use sprint end time
+	if endTime.IsZero() {
+		endTime = sprintBoundary.EndDate
+	} else {
+		endTime = sprintBoundary.ClampTime(endTime)
+	}
+
+	// If start time is after end time, no overlap with sprint
+	if startTime.After(endTime) {
+		return 0
+	}
+
+	// Calculate duration in hours
+	duration := endTime.Sub(startTime)
+	hours := duration.Hours()
+
+	// Ensure non-negative hours
+	if hours < 0 {
+		hours = 0
+	}
+
+	return hours
+}
+
+// hasCompletionInSprint checks if the issue was completed within the sprint
+func (calc *SprintBoundedTimeCalculator) hasCompletionInSprint(issue JiraIssue, sprintBoundary SprintBoundary) bool {
+	statusChanges := issue.GetStatusChanges()
+
+	for _, change := range statusChanges {
+		timestamp, err := time.Parse("2006-01-02T15:04:05.000Z", change.Created)
+		if err != nil {
+			timestamp, err = time.Parse(time.RFC3339, change.Created)
+			if err != nil {
+				continue
+			}
+		}
+		timestamp = timestamp.UTC()
+
+		if sprintBoundary.Contains(timestamp) {
+			for _, item := range change.Items {
+				if item.IsStatusChange() && (item.ToString == StatusDone || item.ToString == StatusWontDo) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// LegacyTimeCalculator implements the original time calculation logic
+// This maintains backward compatibility
+type LegacyTimeCalculator struct{}
+
+// NewLegacyTimeCalculator creates a new legacy time calculator
+func NewLegacyTimeCalculator() *LegacyTimeCalculator {
+	return &LegacyTimeCalculator{}
+}
+
+// CalculateWorkingHours calculates working hours using the legacy algorithm
+func (calc *LegacyTimeCalculator) CalculateWorkingHours(_ context.Context, issue JiraIssue, _ SprintBoundary) (float64, error) {
+	// This replicates the original logic from sprint_time_allocation.go
+	startTime, endTime := calc.getIssueTimeRange(issue)
+
+	if startTime.IsZero() {
+		return 0, nil
+	}
+
+	// Calculate hours between start and end time (ignoring sprint boundaries)
+	duration := endTime.Sub(startTime)
+	hours := duration.Hours()
+
+	// Ensure hours is not negative
+	if hours < 0 {
+		hours = 0
+	}
+
+	return roundHours(hours), nil
+}
+
+// getIssueTimeRange replicates the original logic from the use case
+func (calc *LegacyTimeCalculator) getIssueTimeRange(issue JiraIssue) (time.Time, time.Time) {
+	var startTime, endTime time.Time
+	var inProgress bool
+	var firstInProgressTime time.Time
+
+	// Process histories in chronological order
+	for i := 0; i < len(issue.Changelog.Histories); i++ {
+		history := issue.Changelog.Histories[i]
+
+		for _, item := range history.Items {
+			if !item.IsStatusChange() {
+				continue
+			}
+
+			// Parse the history timestamp and ensure UTC timezone
+			historyTime, err := time.Parse("2006-01-02T15:04:05.000-0700", history.Created)
+			if err != nil {
+				// If parsing fails, try RFC3339 format
+				historyTime, err = time.Parse(time.RFC3339, history.Created)
+				if err != nil {
+					continue
+				}
+			}
+			historyTime = historyTime.UTC()
+
+			// Look for transition into StatusInProgress state
+			if item.ToString == StatusInProgress {
+				if firstInProgressTime.IsZero() {
+					firstInProgressTime = historyTime
+				}
+				startTime = firstInProgressTime // Always use the first In Progress time
+				inProgress = true
+			}
+
+			// Look for transition to "Done" or "Won't Do" state
+			if item.ToString == StatusDone || item.ToString == StatusWontDo {
+				endTime = historyTime
+				// If we weren't in progress, use the completion time as start time
+				if !inProgress && startTime.IsZero() {
+					startTime = historyTime
+				}
+			}
+		}
+	}
+
+	// Ensure endTime is not before startTime
+	if !endTime.IsZero() && !startTime.IsZero() && endTime.Before(startTime) {
+		// If endTime is before startTime, swap them
+		startTime, endTime = endTime, startTime
+	}
+
+	return startTime, endTime
+}
+
+// WorkTimeCalculator is the main calculator that uses a strategy
+// This follows the Strategy pattern and Dependency Injection principles
+type WorkTimeCalculator struct {
+	strategy TimeCalculationStrategy
+}
+
+// NewWorkTimeCalculator creates a new work time calculator with the specified strategy
+func NewWorkTimeCalculator(strategy TimeCalculationStrategy) *WorkTimeCalculator {
+	return &WorkTimeCalculator{
+		strategy: strategy,
+	}
+}
+
+// CalculateWorkingHours delegates to the configured strategy
+func (calc *WorkTimeCalculator) CalculateWorkingHours(ctx context.Context, issue JiraIssue, sprintBoundary SprintBoundary) (float64, error) {
+	return calc.strategy.CalculateWorkingHours(ctx, issue, sprintBoundary)
+}
+
+// SetStrategy allows changing the calculation strategy at runtime
+func (calc *WorkTimeCalculator) SetStrategy(strategy TimeCalculationStrategy) {
+	calc.strategy = strategy
+}
+
+// roundHours rounds hours to 2 decimal places to avoid floating-point precision issues
+func roundHours(hours float64) float64 {
+	return math.Round(hours*100) / 100
+}

--- a/internal/sprint/domain/time_calculation_scenarios.md
+++ b/internal/sprint/domain/time_calculation_scenarios.md
@@ -1,0 +1,243 @@
+# Multi-Sprint Story Time Allocation Scenarios
+
+## Overview
+
+This document outlines all possible scenarios for stories that span multiple sprints and how time allocation should be calculated within sprint boundaries.
+
+## Core Principles
+
+1. **Sprint Boundary Respect**: Only count time within the target sprint's date range
+2. **Status Transition Accuracy**: Handle status changes that cross sprint boundaries
+3. **Work Time Attribution**: Attribute actual work time to the correct sprint
+4. **Proportional Allocation**: Distribute time fairly across sprints based on actual work periods
+
+## Scenario Categories
+
+### 1. Single Sprint Stories (Current Working Cases)
+
+- **Scenario 1A**: Story starts and completes within one sprint
+
+  - Expected: Full time allocation to the sprint
+  - Current: ✅ Works correctly
+
+- **Scenario 1B**: Story goes directly from "To Do" to "Done" within one sprint
+  - Expected: Minimum 1 hour allocation
+  - Current: ✅ Works correctly
+
+### 2. Cross-Sprint Stories (Problem Cases)
+
+#### **Scenario 2A**: Story starts in Sprint A, completes in Sprint B
+
+```
+Sprint A: 2024-03-01 to 2024-03-15
+Sprint B: 2024-03-16 to 2024-03-30
+
+Story Timeline:
+- 2024-03-05: To Do → In Progress (within Sprint A)
+- 2024-03-25: In Progress → Done (within Sprint B)
+
+Current Problem:
+- Sprint A allocation: 0 hours (story not completed)
+- Sprint B allocation: 20 days (full lifecycle)
+
+Expected Solution:
+- Sprint A allocation: 10 days (Mar 5-15)
+- Sprint B allocation: 10 days (Mar 16-25)
+```
+
+#### **Scenario 2B**: Story starts before Sprint A, completes in Sprint A
+
+```
+Sprint A: 2024-03-16 to 2024-03-30
+
+Story Timeline:
+- 2024-03-05: To Do → In Progress (before Sprint A)
+- 2024-03-25: In Progress → Done (within Sprint A)
+
+Current Problem:
+- Sprint A allocation: 20 days (full lifecycle)
+
+Expected Solution:
+- Sprint A allocation: 10 days (Mar 16-25 only)
+```
+
+#### **Scenario 2C**: Story starts in Sprint A, completes after Sprint A
+
+```
+Sprint A: 2024-03-01 to 2024-03-15
+
+Story Timeline:
+- 2024-03-05: To Do → In Progress (within Sprint A)
+- 2024-03-25: In Progress → Done (after Sprint A)
+
+Current Problem:
+- Sprint A allocation: 0 hours (story not completed)
+
+Expected Solution:
+- Sprint A allocation: 10 days (Mar 5-15 only)
+```
+
+### 3. Complex Multi-Sprint Stories
+
+#### **Scenario 3A**: Story with multiple status transitions across sprints
+
+```
+Sprint A: 2024-03-01 to 2024-03-15
+Sprint B: 2024-03-16 to 2024-03-30
+
+Story Timeline:
+- 2024-03-05: To Do → In Progress (Sprint A)
+- 2024-03-10: In Progress → Blocked (Sprint A)
+- 2024-03-20: Blocked → In Progress (Sprint B)
+- 2024-03-25: In Progress → Done (Sprint B)
+
+Expected Solution:
+- Sprint A allocation: 5 days (Mar 5-10 only)
+- Sprint B allocation: 5 days (Mar 20-25 only)
+```
+
+#### **Scenario 3B**: Story spans three sprints
+
+```
+Sprint A: 2024-03-01 to 2024-03-15
+Sprint B: 2024-03-16 to 2024-03-30
+Sprint C: 2024-04-01 to 2024-04-15
+
+Story Timeline:
+- 2024-03-05: To Do → In Progress (Sprint A)
+- 2024-03-20: In Progress → Blocked (Sprint B)
+- 2024-04-10: Blocked → In Progress (Sprint C)
+- 2024-04-12: In Progress → Done (Sprint C)
+
+Expected Solution:
+- Sprint A allocation: 10 days (Mar 5-15)
+- Sprint B allocation: 0 days (blocked entire period)
+- Sprint C allocation: 2 days (Apr 10-12)
+```
+
+#### **Scenario 3C**: Story moves backward in status across sprints
+
+```
+Sprint A: 2024-03-01 to 2024-03-15
+Sprint B: 2024-03-16 to 2024-03-30
+
+Story Timeline:
+- 2024-03-05: To Do → In Progress (Sprint A)
+- 2024-03-10: In Progress → Under Review (Sprint A)
+- 2024-03-20: Under Review → In Progress (Sprint B)
+- 2024-03-25: In Progress → Done (Sprint B)
+
+Expected Solution:
+- Sprint A allocation: 10 days (Mar 5-15, both In Progress and Under Review count as work)
+- Sprint B allocation: 10 days (Mar 16-25, both In Progress and Under Review count as work)
+```
+
+### 4. Edge Cases
+
+#### **Scenario 4A**: Story completed same day it starts (cross-sprint)
+
+```
+Sprint A: 2024-03-01 to 2024-03-15
+Sprint B: 2024-03-16 to 2024-03-30
+
+Story Timeline:
+- 2024-03-15 10:00: To Do → In Progress (Sprint A)
+- 2024-03-16 14:00: In Progress → Done (Sprint B)
+
+Expected Solution:
+- Sprint A allocation: 14 hours (10:00-24:00 on Mar 15)
+- Sprint B allocation: 14 hours (00:00-14:00 on Mar 16)
+```
+
+#### **Scenario 4B**: Story with no status changes but exists in sprint
+
+```
+Sprint A: 2024-03-01 to 2024-03-15
+
+Story Timeline:
+- Story exists in sprint but no status changes in changelog
+
+Expected Solution:
+- Sprint A allocation: 0 hours (no evidence of work)
+```
+
+## Technical Implementation Strategy
+
+### 1. Time Calculation Abstraction
+
+```go
+type TimeCalculationStrategy interface {
+    CalculateWorkingHours(ctx context.Context, issue JiraIssue, sprintBoundary SprintBoundary) (float64, error)
+}
+```
+
+### 2. Sprint Boundary Value Object
+
+```go
+type SprintBoundary struct {
+    StartDate time.Time
+    EndDate   time.Time
+}
+```
+
+### 3. Status Change Period
+
+```go
+type StatusChangePeriod struct {
+    StartTime   time.Time
+    EndTime     time.Time
+    Status      string
+    IsWorkTime  bool
+}
+```
+
+### 4. Work Time Calculator
+
+```go
+type WorkTimeCalculator struct {
+    strategy TimeCalculationStrategy
+}
+```
+
+## Test Strategy
+
+### Unit Tests
+
+1. Test each scenario in isolation
+2. Test boundary conditions (start/end of sprints)
+3. Test edge cases (same day completion, no status changes)
+4. Test time zone handling
+
+### Integration Tests
+
+1. Test with real sprint data
+2. Test backward compatibility
+3. Test performance with large datasets
+
+## Implementation Phases
+
+### Phase 1: Core Domain Logic
+
+- Implement SprintBoundary value object
+- Implement TimeCalculationStrategy interface
+- Implement SprintBoundedTimeCalculator
+
+### Phase 2: Integration
+
+- Update SprintTimeAllocationUseCase
+- Maintain backward compatibility
+- Add configuration for strategy selection
+
+### Phase 3: Testing & Validation
+
+- Comprehensive test coverage
+- Performance testing
+- Real-world validation
+
+## Success Criteria
+
+1. **Accuracy**: Time allocation matches actual work periods within sprint boundaries
+2. **Consistency**: Same story shows consistent time allocation across different sprint views
+3. **Performance**: No significant performance degradation
+4. **Maintainability**: Clean, testable code following SOLID principles
+5. **Backward Compatibility**: Existing functionality remains unchanged when new feature is disabled

--- a/internal/sprint/domain/time_calculation_test.go
+++ b/internal/sprint/domain/time_calculation_test.go
@@ -1,0 +1,110 @@
+package domain
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSprintBoundary(t *testing.T) {
+	start := time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 29, 18, 0, 0, 0, time.UTC)
+
+	boundary, err := NewSprintBoundary(start, end)
+
+	require.NoError(t, err)
+	assert.Equal(t, start, boundary.StartDate)
+	assert.Equal(t, end, boundary.EndDate)
+}
+
+func TestNewSprintBoundary_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		startDate time.Time
+		endDate   time.Time
+		expectErr bool
+	}{
+		{
+			name:      "end before start",
+			startDate: time.Date(2024, 1, 29, 18, 0, 0, 0, time.UTC),
+			endDate:   time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC),
+			expectErr: true,
+		},
+		{
+			name:      "zero start date",
+			startDate: time.Time{},
+			endDate:   time.Date(2024, 1, 29, 18, 0, 0, 0, time.UTC),
+			expectErr: true,
+		},
+		{
+			name:      "zero end date",
+			startDate: time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC),
+			endDate:   time.Time{},
+			expectErr: true,
+		},
+		{
+			name:      "valid dates",
+			startDate: time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC),
+			endDate:   time.Date(2024, 1, 29, 18, 0, 0, 0, time.UTC),
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			boundary, err := NewSprintBoundary(tt.startDate, tt.endDate)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Equal(t, SprintBoundary{}, boundary)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.startDate, boundary.StartDate)
+				assert.Equal(t, tt.endDate, boundary.EndDate)
+			}
+		})
+	}
+}
+
+func TestNewWorkTimeCalculator(t *testing.T) {
+	strategy := NewSprintBoundedTimeCalculator()
+	calculator := NewWorkTimeCalculator(strategy)
+
+	assert.NotNil(t, calculator)
+}
+
+func TestWorkTimeCalculator_SetStrategy(t *testing.T) {
+	strategy1 := NewSprintBoundedTimeCalculator()
+	strategy2 := NewLegacyTimeCalculator()
+
+	calculator := NewWorkTimeCalculator(strategy1)
+	calculator.SetStrategy(strategy2)
+
+	// We can't directly test the internal strategy field, but we can verify the method doesn't panic
+	assert.NotNil(t, calculator)
+}
+
+func TestWorkTimeCalculator_CalculateWorkingHours(t *testing.T) {
+	// Create a mock issue
+	issue := JiraIssue{
+		Key: "TEST-1",
+	}
+
+	// Create sprint boundary
+	boundary, err := NewSprintBoundary(
+		time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC),
+		time.Date(2024, 1, 29, 18, 0, 0, 0, time.UTC),
+	)
+	require.NoError(t, err)
+
+	// Test with sprint-bounded strategy
+	strategy := NewSprintBoundedTimeCalculator()
+	calculator := NewWorkTimeCalculator(strategy)
+
+	hours, err := calculator.CalculateWorkingHours(context.Background(), issue, boundary)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, hours, 0.0)
+}

--- a/internal/sprint/infrastructure/jira_adapter.go
+++ b/internal/sprint/infrastructure/jira_adapter.go
@@ -308,5 +308,23 @@ func (a *JiraAdapter) getSprintsForBoard(boardID int, states []string) ([]ports.
 	return portSprints, nil
 }
 
+// GetSprintByName retrieves sprint details by project and sprint name
+func (a *JiraAdapter) GetSprintByName(project, sprintName string) (*ports.Sprint, error) {
+	// Get all sprints for the project
+	sprints, err := a.GetSprintsForProject(project, []string{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sprints for project %s: %w", project, err)
+	}
+
+	// Find sprint by name
+	for _, sprint := range sprints {
+		if sprint.Name == sprintName {
+			return &sprint, nil
+		}
+	}
+
+	return nil, fmt.Errorf("sprint '%s' not found in project %s", sprintName, project)
+}
+
 // Ensure JiraAdapter implements JiraPort
 var _ ports.JiraPort = (*JiraAdapter)(nil)

--- a/internal/tasks/application/service_test.go
+++ b/internal/tasks/application/service_test.go
@@ -45,7 +45,7 @@ func TestTasksService_FetchTasks(t *testing.T) {
 							Key:     "PROJ-1",
 							Type:    "Story",
 							Summary: "Test Task",
-							Status:  "In Progress",
+							Status:  domain.TaskStatusInProgress,
 							Sprint:  "Sprint 1",
 						},
 					}, nil
@@ -100,7 +100,7 @@ func TestTasksService_FetchTasks(t *testing.T) {
 							Key:     "PROJ-1",
 							Type:    "Story",
 							Summary: "Test Task",
-							Status:  "In Progress",
+							Status:  domain.TaskStatusInProgress,
 							Sprint:  "Sprint 1",
 						},
 					}, nil
@@ -160,7 +160,7 @@ func TestTasksService_ClassifyTasks(t *testing.T) {
 							Key:     "PROJ-1",
 							Type:    "Story",
 							Summary: "Test Task",
-							Status:  "In Progress",
+							Status:  domain.TaskStatusInProgress,
 							Sprint:  "Sprint 1",
 						},
 					}, nil
@@ -212,7 +212,7 @@ func TestTasksService_ClassifyTasks(t *testing.T) {
 							Key:     "PROJ-1",
 							Type:    "Story",
 							Summary: "Test Task",
-							Status:  "In Progress",
+							Status:  domain.TaskStatusInProgress,
 							Sprint:  "Sprint 1",
 						},
 					}, nil
@@ -278,7 +278,7 @@ func TestTasksService_ClassifyTasks(t *testing.T) {
 							Key:     "PROJ-1",
 							Type:    "Story",
 							Summary: "Test Task",
-							Status:  "In Progress",
+							Status:  domain.TaskStatusInProgress,
 							Sprint:  "Sprint 1",
 						},
 					}, nil
@@ -339,21 +339,21 @@ func TestTaskService_GetTasksByAsset(t *testing.T) {
 			Key:     "TEST-1",
 			Type:    "Story",
 			Summary: "Test Task 1",
-			Status:  "In Progress",
+			Status:  domain.TaskStatusInProgress,
 			Labels:  []string{"cap-asset-insurance", "cap-development"},
 		},
 		{
 			Key:     "TEST-2",
 			Type:    "Story",
 			Summary: "Test Task 2",
-			Status:  "In Progress",
+			Status:  domain.TaskStatusInProgress,
 			Labels:  []string{"cap-asset-insurance", "cap-development"},
 		},
 		{
 			Key:     "TEST-3",
 			Type:    "Story",
 			Summary: "Test Task 3",
-			Status:  "In Progress",
+			Status:  domain.TaskStatusInProgress,
 			Labels:  []string{"cap-asset-other", "cap-development"},
 		},
 	}
@@ -744,7 +744,7 @@ func TestTaskService_GetTaskByKey(t *testing.T) {
 			Summary: "Enable rounding with new Journey Details Service",
 			Project: "FN",
 			Sprint:  "The Hulk",
-			Status:  "Done",
+			Status:  domain.TaskStatusInProgress,
 			Type:    "Task",
 		}
 

--- a/internal/tasks/domain/task.go
+++ b/internal/tasks/domain/task.go
@@ -1,7 +1,9 @@
 package domain
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -64,7 +66,8 @@ type Task struct {
 	Summary     string       `json:"summary"`
 	Description string       `json:"description"`
 	Project     string       `json:"project"`
-	Sprint      string       `json:"sprint"`
+	Sprint      string       `json:"sprint"`            // Legacy field for backward compatibility
+	Sprints     []string     `json:"sprints,omitempty"` // New array field for multi-sprint support
 	Platform    string       `json:"platform"`
 	Status      TaskStatus   `json:"status"`
 	Type        TaskType     `json:"type"`
@@ -96,7 +99,7 @@ func NewTask(key, summary, project, sprint, platform string) (*Task, error) {
 	}
 
 	now := time.Now()
-	return &Task{
+	task := &Task{
 		Key:       key,
 		Summary:   summary,
 		Project:   project,
@@ -108,7 +111,214 @@ func NewTask(key, summary, project, sprint, platform string) (*Task, error) {
 		CreatedAt: now,
 		UpdatedAt: now,
 		Version:   1,
-	}, nil
+	}
+
+	// Set sprints array based on sprint string
+	task.setSprintsFromString(sprint)
+
+	return task, nil
+}
+
+// NewTaskWithSprints creates a new task with multiple sprints
+func NewTaskWithSprints(key, summary, project string, sprints []string, platform string) (*Task, error) {
+	if key == "" {
+		return nil, ErrEmptyKey
+	}
+	if summary == "" {
+		return nil, ErrEmptySummary
+	}
+	if project == "" {
+		return nil, ErrEmptyProject
+	}
+	if len(sprints) == 0 {
+		return nil, ErrEmptySprint
+	}
+	if platform == "" {
+		return nil, ErrEmptyPlatform
+	}
+
+	now := time.Now()
+	task := &Task{
+		Key:       key,
+		Summary:   summary,
+		Project:   project,
+		Sprints:   sprints,
+		Platform:  platform,
+		Status:    TaskStatusTodo,
+		Type:      TaskTypeTask,
+		Priority:  TaskPriorityMedium,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	// Set legacy sprint field for backward compatibility
+	task.Sprint = strings.Join(sprints, ", ")
+
+	return task, nil
+}
+
+// NewTaskWithoutSprint creates a new task without sprint assignment
+func NewTaskWithoutSprint(key, summary, project, platform string) (*Task, error) {
+	if key == "" {
+		return nil, ErrEmptyKey
+	}
+	if summary == "" {
+		return nil, ErrEmptySummary
+	}
+	if project == "" {
+		return nil, ErrEmptyProject
+	}
+	if platform == "" {
+		return nil, ErrEmptyPlatform
+	}
+
+	now := time.Now()
+	task := &Task{
+		Key:       key,
+		Summary:   summary,
+		Project:   project,
+		Sprint:    "",         // Empty sprint
+		Sprints:   []string{}, // Empty sprints array
+		Platform:  platform,
+		Status:    TaskStatusTodo,
+		Type:      TaskTypeTask,
+		Priority:  TaskPriorityMedium,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	return task, nil
+}
+
+// GetSprints returns the sprint names as an array
+func (t *Task) GetSprints() []string {
+	// If we have the new sprints array, use it
+	if len(t.Sprints) > 0 {
+		return t.Sprints
+	}
+
+	// Fall back to parsing the legacy sprint string
+	if t.Sprint != "" {
+		return t.parseSprintString(t.Sprint)
+	}
+
+	return []string{}
+}
+
+// GetPrimarySprint returns the first/primary sprint
+func (t *Task) GetPrimarySprint() string {
+	sprints := t.GetSprints()
+	if len(sprints) > 0 {
+		return sprints[0]
+	}
+	return ""
+}
+
+// HasSprint checks if the task belongs to a specific sprint
+func (t *Task) HasSprint(sprintName string) bool {
+	sprints := t.GetSprints()
+	for _, sprint := range sprints {
+		if sprint == sprintName {
+			return true
+		}
+	}
+	return false
+}
+
+// SetSprints updates the task sprints
+func (t *Task) SetSprints(sprints []string) {
+	t.Sprints = sprints
+	t.Sprint = strings.Join(sprints, ", ") // Maintain backward compatibility
+	t.UpdatedAt = time.Now()
+	t.Version++
+}
+
+// AddSprint adds a sprint to the task if it doesn't already exist
+func (t *Task) AddSprint(sprintName string) {
+	if !t.HasSprint(sprintName) {
+		sprints := t.GetSprints()
+		sprints = append(sprints, sprintName)
+		t.SetSprints(sprints)
+	}
+}
+
+// RemoveSprint removes a sprint from the task
+func (t *Task) RemoveSprint(sprintName string) {
+	sprints := t.GetSprints()
+	var newSprints []string
+	for _, sprint := range sprints {
+		if sprint != sprintName {
+			newSprints = append(newSprints, sprint)
+		}
+	}
+	if len(newSprints) != len(sprints) {
+		t.SetSprints(newSprints)
+	}
+}
+
+// setSprintsFromString parses sprint string and sets the sprints array
+func (t *Task) setSprintsFromString(sprintStr string) {
+	if sprintStr != "" {
+		t.Sprints = t.parseSprintString(sprintStr)
+	}
+}
+
+// parseSprintString parses a comma-separated sprint string into an array
+func (t *Task) parseSprintString(sprintStr string) []string {
+	if sprintStr == "" {
+		return []string{}
+	}
+
+	// Split by comma and trim whitespace
+	parts := strings.Split(sprintStr, ",")
+	var sprints []string
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			sprints = append(sprints, trimmed)
+		}
+	}
+	return sprints
+}
+
+// MarshalJSON handles custom JSON marshaling to ensure data consistency
+func (t *Task) MarshalJSON() ([]byte, error) {
+	// Ensure consistency between Sprint and Sprints fields
+	if len(t.Sprints) > 0 && t.Sprint == "" {
+		t.Sprint = strings.Join(t.Sprints, ", ")
+	} else if t.Sprint != "" && len(t.Sprints) == 0 {
+		t.Sprints = t.parseSprintString(t.Sprint)
+	}
+
+	// Create a copy of the struct for marshaling
+	type TaskAlias Task
+	return json.Marshal((*TaskAlias)(t))
+}
+
+// UnmarshalJSON handles custom JSON unmarshaling to ensure data consistency
+func (t *Task) UnmarshalJSON(data []byte) error {
+	// Use alias to avoid infinite recursion
+	type TaskAlias Task
+	aux := &TaskAlias{}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	*t = Task(*aux)
+
+	// Ensure consistency between Sprint and Sprints fields
+	if len(t.Sprints) > 0 {
+		// If we have sprints array, ensure Sprint field is consistent
+		t.Sprint = strings.Join(t.Sprints, ", ")
+	} else if t.Sprint != "" {
+		// If we only have Sprint field, populate Sprints array
+		t.Sprints = t.parseSprintString(t.Sprint)
+	}
+
+	return nil
 }
 
 // UpdateStatus updates the task status

--- a/internal/tasks/domain/task_test.go
+++ b/internal/tasks/domain/task_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,6 +25,15 @@ func TestNewTask(t *testing.T) {
 			summary:  "Test task",
 			project:  "TEST",
 			sprint:   "Sprint 1",
+			platform: "jira",
+			wantErr:  false,
+		},
+		{
+			name:     "valid task with comma-separated sprints",
+			key:      "TEST-2",
+			summary:  "Multi-sprint task",
+			project:  "TEST",
+			sprint:   "Sprint 1, Sprint 2",
 			platform: "jira",
 			wantErr:  false,
 		},
@@ -101,8 +111,444 @@ func TestNewTask(t *testing.T) {
 			assert.Equal(t, 1, task.Version)
 			assert.False(t, task.CreatedAt.IsZero())
 			assert.False(t, task.UpdatedAt.IsZero())
+
+			// Test that sprints array is populated from sprint string
+			if tt.sprint != "" {
+				sprints := task.GetSprints()
+				assert.NotEmpty(t, sprints)
+				if tt.sprint == "Sprint 1, Sprint 2" {
+					assert.Equal(t, []string{"Sprint 1", "Sprint 2"}, sprints)
+				} else {
+					assert.Equal(t, []string{tt.sprint}, sprints)
+				}
+			}
 		})
 	}
+}
+
+func TestNewTaskWithSprints(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		summary  string
+		project  string
+		sprints  []string
+		platform string
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name:     "valid task with single sprint",
+			key:      "TEST-1",
+			summary:  "Test task",
+			project:  "TEST",
+			sprints:  []string{"Sprint 1"},
+			platform: "jira",
+			wantErr:  false,
+		},
+		{
+			name:     "valid task with multiple sprints",
+			key:      "TEST-2",
+			summary:  "Multi-sprint task",
+			project:  "TEST",
+			sprints:  []string{"Sprint 1", "Sprint 2", "Sprint 3"},
+			platform: "jira",
+			wantErr:  false,
+		},
+		{
+			name:     "empty key",
+			key:      "",
+			summary:  "Test task",
+			project:  "TEST",
+			sprints:  []string{"Sprint 1"},
+			platform: "jira",
+			wantErr:  true,
+			errMsg:   ErrEmptyKey.Error(),
+		},
+		{
+			name:     "empty summary",
+			key:      "TEST-1",
+			summary:  "",
+			project:  "TEST",
+			sprints:  []string{"Sprint 1"},
+			platform: "jira",
+			wantErr:  true,
+			errMsg:   ErrEmptySummary.Error(),
+		},
+		{
+			name:     "empty project",
+			key:      "TEST-1",
+			summary:  "Test task",
+			project:  "",
+			sprints:  []string{"Sprint 1"},
+			platform: "jira",
+			wantErr:  true,
+			errMsg:   ErrEmptyProject.Error(),
+		},
+		{
+			name:     "empty sprints",
+			key:      "TEST-1",
+			summary:  "Test task",
+			project:  "TEST",
+			sprints:  []string{},
+			platform: "jira",
+			wantErr:  true,
+			errMsg:   ErrEmptySprint.Error(),
+		},
+		{
+			name:     "empty platform",
+			key:      "TEST-1",
+			summary:  "Test task",
+			project:  "TEST",
+			sprints:  []string{"Sprint 1"},
+			platform: "",
+			wantErr:  true,
+			errMsg:   ErrEmptyPlatform.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task, err := NewTaskWithSprints(tt.key, tt.summary, tt.project, tt.sprints, tt.platform)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, tt.errMsg, err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.key, task.Key)
+			assert.Equal(t, tt.summary, task.Summary)
+			assert.Equal(t, tt.project, task.Project)
+			assert.Equal(t, tt.sprints, task.Sprints)
+			assert.Equal(t, tt.platform, task.Platform)
+			assert.Equal(t, TaskStatusTodo, task.Status)
+			assert.Equal(t, TaskTypeTask, task.Type)
+			assert.Equal(t, TaskPriorityMedium, task.Priority)
+			assert.Equal(t, 1, task.Version)
+			assert.False(t, task.CreatedAt.IsZero())
+			assert.False(t, task.UpdatedAt.IsZero())
+
+			// Test that Sprint field is set correctly for backward compatibility
+			expectedSprintStr := ""
+			if len(tt.sprints) > 0 {
+				if len(tt.sprints) == 1 {
+					expectedSprintStr = tt.sprints[0]
+				} else {
+					expectedSprintStr = "Sprint 1, Sprint 2, Sprint 3"
+				}
+			}
+			assert.Equal(t, expectedSprintStr, task.Sprint)
+		})
+	}
+}
+
+func TestGetSprints(t *testing.T) {
+	tests := []struct {
+		name            string
+		task            *Task
+		expectedSprints []string
+	}{
+		{
+			name: "task with sprints array",
+			task: &Task{
+				Sprints: []string{"Sprint 1", "Sprint 2"},
+				Sprint:  "Sprint 1, Sprint 2",
+			},
+			expectedSprints: []string{"Sprint 1", "Sprint 2"},
+		},
+		{
+			name: "task with only sprint string",
+			task: &Task{
+				Sprint: "Sprint 1, Sprint 2",
+			},
+			expectedSprints: []string{"Sprint 1", "Sprint 2"},
+		},
+		{
+			name: "task with single sprint string",
+			task: &Task{
+				Sprint: "Sprint 1",
+			},
+			expectedSprints: []string{"Sprint 1"},
+		},
+		{
+			name:            "task with empty sprint data",
+			task:            &Task{},
+			expectedSprints: []string{},
+		},
+		{
+			name: "task with whitespace in sprint string",
+			task: &Task{
+				Sprint: " Sprint 1 , Sprint 2 , Sprint 3 ",
+			},
+			expectedSprints: []string{"Sprint 1", "Sprint 2", "Sprint 3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sprints := tt.task.GetSprints()
+			assert.Equal(t, tt.expectedSprints, sprints)
+		})
+	}
+}
+
+func TestGetPrimarySprint(t *testing.T) {
+	tests := []struct {
+		name            string
+		task            *Task
+		expectedPrimary string
+	}{
+		{
+			name: "task with multiple sprints",
+			task: &Task{
+				Sprints: []string{"Sprint 1", "Sprint 2", "Sprint 3"},
+			},
+			expectedPrimary: "Sprint 1",
+		},
+		{
+			name: "task with single sprint",
+			task: &Task{
+				Sprints: []string{"Sprint 1"},
+			},
+			expectedPrimary: "Sprint 1",
+		},
+		{
+			name: "task with sprint string only",
+			task: &Task{
+				Sprint: "Sprint 1, Sprint 2",
+			},
+			expectedPrimary: "Sprint 1",
+		},
+		{
+			name:            "task with no sprints",
+			task:            &Task{},
+			expectedPrimary: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			primary := tt.task.GetPrimarySprint()
+			assert.Equal(t, tt.expectedPrimary, primary)
+		})
+	}
+}
+
+func TestHasSprint(t *testing.T) {
+	task := &Task{
+		Sprints: []string{"Sprint 1", "Sprint 2", "Sprint 3"},
+		Sprint:  "Sprint 1, Sprint 2, Sprint 3",
+	}
+
+	tests := []struct {
+		name       string
+		sprintName string
+		expectHas  bool
+	}{
+		{
+			name:       "has first sprint",
+			sprintName: "Sprint 1",
+			expectHas:  true,
+		},
+		{
+			name:       "has middle sprint",
+			sprintName: "Sprint 2",
+			expectHas:  true,
+		},
+		{
+			name:       "has last sprint",
+			sprintName: "Sprint 3",
+			expectHas:  true,
+		},
+		{
+			name:       "does not have sprint",
+			sprintName: "Sprint 4",
+			expectHas:  false,
+		},
+		{
+			name:       "empty sprint name",
+			sprintName: "",
+			expectHas:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := task.HasSprint(tt.sprintName)
+			assert.Equal(t, tt.expectHas, result)
+		})
+	}
+}
+
+func TestSetSprints(t *testing.T) {
+	task := &Task{
+		Key:     "TEST-1",
+		Version: 1,
+	}
+
+	newSprints := []string{"New Sprint 1", "New Sprint 2"}
+	task.SetSprints(newSprints)
+
+	assert.Equal(t, newSprints, task.Sprints)
+	assert.Equal(t, "New Sprint 1, New Sprint 2", task.Sprint)
+	assert.Equal(t, 2, task.Version)
+	assert.False(t, task.UpdatedAt.IsZero())
+}
+
+func TestAddSprint(t *testing.T) {
+	task := &Task{
+		Key:     "TEST-1",
+		Sprints: []string{"Sprint 1"},
+		Sprint:  "Sprint 1",
+		Version: 1,
+	}
+
+	// Add new sprint
+	task.AddSprint("Sprint 2")
+	assert.Equal(t, []string{"Sprint 1", "Sprint 2"}, task.Sprints)
+	assert.Equal(t, "Sprint 1, Sprint 2", task.Sprint)
+	assert.Equal(t, 2, task.Version)
+
+	// Add existing sprint (should not change anything)
+	oldVersion := task.Version
+	task.AddSprint("Sprint 1")
+	assert.Equal(t, []string{"Sprint 1", "Sprint 2"}, task.Sprints)
+	assert.Equal(t, oldVersion, task.Version)
+}
+
+func TestRemoveSprint(t *testing.T) {
+	task := &Task{
+		Key:     "TEST-1",
+		Sprints: []string{"Sprint 1", "Sprint 2", "Sprint 3"},
+		Sprint:  "Sprint 1, Sprint 2, Sprint 3",
+		Version: 1,
+	}
+
+	// Remove middle sprint
+	task.RemoveSprint("Sprint 2")
+	assert.Equal(t, []string{"Sprint 1", "Sprint 3"}, task.Sprints)
+	assert.Equal(t, "Sprint 1, Sprint 3", task.Sprint)
+	assert.Equal(t, 2, task.Version)
+
+	// Remove non-existing sprint (should not change anything)
+	oldVersion := task.Version
+	task.RemoveSprint("Sprint 4")
+	assert.Equal(t, []string{"Sprint 1", "Sprint 3"}, task.Sprints)
+	assert.Equal(t, oldVersion, task.Version)
+}
+
+func TestJSONMarshalUnmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		task *Task
+	}{
+		{
+			name: "task with sprints array",
+			task: &Task{
+				Key:     "TEST-1",
+				Summary: "Test task",
+				Project: "TEST",
+				Sprints: []string{"Sprint 1", "Sprint 2"},
+				Sprint:  "Sprint 1, Sprint 2",
+			},
+		},
+		{
+			name: "task with only sprint string (legacy format)",
+			task: &Task{
+				Key:     "TEST-2",
+				Summary: "Legacy task",
+				Project: "TEST",
+				Sprint:  "Sprint 1, Sprint 2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Marshal to JSON
+			data, err := json.Marshal(tt.task)
+			require.NoError(t, err)
+
+			// Unmarshal from JSON
+			var unmarshaled Task
+			err = json.Unmarshal(data, &unmarshaled)
+			require.NoError(t, err)
+
+			// Verify data integrity
+			assert.Equal(t, tt.task.Key, unmarshaled.Key)
+			assert.Equal(t, tt.task.Summary, unmarshaled.Summary)
+			assert.Equal(t, tt.task.Project, unmarshaled.Project)
+
+			// Verify sprint consistency
+			expectedSprints := tt.task.GetSprints()
+			actualSprints := unmarshaled.GetSprints()
+			assert.Equal(t, expectedSprints, actualSprints)
+
+			// Verify both Sprint and Sprints fields are populated
+			assert.NotEmpty(t, unmarshaled.Sprint)
+			assert.NotEmpty(t, unmarshaled.Sprints)
+		})
+	}
+}
+
+func TestJSONBackwardCompatibility(t *testing.T) {
+	// Test unmarshaling legacy JSON format (only sprint field)
+	legacyJSON := `{
+		"key": "TEST-1",
+		"summary": "Legacy task",
+		"project": "TEST",
+		"sprint": "Sprint 1, Sprint 2",
+		"platform": "jira",
+		"status": "TODO",
+		"type": "TASK",
+		"priority": "MEDIUM",
+		"work_type": "",
+		"labels": [],
+		"epic": "",
+		"created_at": "2024-01-01T00:00:00Z",
+		"updated_at": "2024-01-01T00:00:00Z",
+		"version": 1
+	}`
+
+	var task Task
+	err := json.Unmarshal([]byte(legacyJSON), &task)
+	require.NoError(t, err)
+
+	// Verify that Sprints array is populated from Sprint string
+	assert.Equal(t, "Sprint 1, Sprint 2", task.Sprint)
+	assert.Equal(t, []string{"Sprint 1", "Sprint 2"}, task.Sprints)
+	assert.True(t, task.HasSprint("Sprint 1"))
+	assert.True(t, task.HasSprint("Sprint 2"))
+	assert.Equal(t, "Sprint 1", task.GetPrimarySprint())
+}
+
+func TestJSONForwardCompatibility(t *testing.T) {
+	// Test marshaling new format and ensuring Sprint field is populated
+	task := &Task{
+		Key:     "TEST-1",
+		Summary: "New task",
+		Project: "TEST",
+		Sprints: []string{"Sprint 1", "Sprint 2", "Sprint 3"},
+	}
+
+	data, err := json.Marshal(task)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	require.NoError(t, err)
+
+	// Verify both fields are present in JSON
+	assert.Equal(t, "Sprint 1, Sprint 2, Sprint 3", result["sprint"])
+
+	sprintsField, ok := result["sprints"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, sprintsField, 3)
+	assert.Equal(t, "Sprint 1", sprintsField[0])
+	assert.Equal(t, "Sprint 2", sprintsField[1])
+	assert.Equal(t, "Sprint 3", sprintsField[2])
 }
 
 func TestUpdateStatus(t *testing.T) {
@@ -435,4 +881,85 @@ func TestTask_UpdateWorkType(t *testing.T) {
 		assert.Equal(t, currentWorkType, task.WorkType, "Work type should remain unchanged")
 		assert.Equal(t, currentVersion, task.Version, "Version should remain unchanged")
 	})
+}
+
+func TestNewTaskWithoutSprint(t *testing.T) {
+	tests := []struct {
+		name        string
+		key         string
+		summary     string
+		project     string
+		platform    string
+		expectError bool
+		errorType   error
+	}{
+		{
+			name:        "valid task without sprint",
+			key:         "TEST-1",
+			summary:     "Test task",
+			project:     "TEST",
+			platform:    "JIRA",
+			expectError: false,
+		},
+		{
+			name:        "empty key",
+			key:         "",
+			summary:     "Test task",
+			project:     "TEST",
+			platform:    "JIRA",
+			expectError: true,
+			errorType:   ErrEmptyKey,
+		},
+		{
+			name:        "empty summary",
+			key:         "TEST-1",
+			summary:     "",
+			project:     "TEST",
+			platform:    "JIRA",
+			expectError: true,
+			errorType:   ErrEmptySummary,
+		},
+		{
+			name:        "empty project",
+			key:         "TEST-1",
+			summary:     "Test task",
+			project:     "",
+			platform:    "JIRA",
+			expectError: true,
+			errorType:   ErrEmptyProject,
+		},
+		{
+			name:        "empty platform",
+			key:         "TEST-1",
+			summary:     "Test task",
+			project:     "TEST",
+			platform:    "",
+			expectError: true,
+			errorType:   ErrEmptyPlatform,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task, err := NewTaskWithoutSprint(tt.key, tt.summary, tt.project, tt.platform)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, tt.errorType, err)
+				assert.Nil(t, task)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, task)
+				assert.Equal(t, tt.key, task.Key)
+				assert.Equal(t, tt.summary, task.Summary)
+				assert.Equal(t, tt.project, task.Project)
+				assert.Equal(t, tt.platform, task.Platform)
+				assert.Equal(t, "", task.Sprint)
+				assert.Empty(t, task.Sprints)
+				assert.Equal(t, TaskStatusTodo, task.Status)
+				assert.Equal(t, TaskTypeTask, task.Type)
+				assert.Equal(t, TaskPriorityMedium, task.Priority)
+			}
+		})
+	}
 }

--- a/internal/tasks/infrastructure/jira/client.go
+++ b/internal/tasks/infrastructure/jira/client.go
@@ -142,39 +142,9 @@ func wasWorkedOnDuringSprint(issue api.Issue, sprintStart, sprintEnd time.Time) 
 func (c *client) convertToDomainTasks(searchResp api.SearchResult, sprint string) ([]*domain.Task, error) {
 	tasks := make([]*domain.Task, 0, len(searchResp.Issues))
 	for _, issue := range searchResp.Issues {
-		// Get sprint dates if available
-		var sprintStart, sprintEnd time.Time
-		if len(issue.Fields.Sprint) > 0 {
-			for _, s := range issue.Fields.Sprint {
-				if s.Name == sprint {
-					var err error
-					if s.StartDate != "" {
-						sprintStart, err = parseTime(s.StartDate)
-						if err != nil {
-							continue
-						}
-					}
-					if s.EndDate != "" {
-						sprintEnd, err = parseTime(s.EndDate)
-						if err != nil {
-							continue
-						}
-					}
-					break
-				}
-			}
-		}
-
-		// Skip if we couldn't get valid sprint dates
-		if sprintStart.IsZero() || sprintEnd.IsZero() {
+		// Check if this issue is relevant to the requested sprint
+		if !c.isRelevantToSprint(issue, sprint) {
 			continue
-		}
-
-		// For issues with multiple sprints, check if there was any work done during this sprint
-		if len(issue.Fields.Sprint) > 1 {
-			if !wasWorkedOnDuringSprint(issue, sprintStart, sprintEnd) {
-				continue
-			}
 		}
 
 		// Handle empty timestamps
@@ -266,26 +236,240 @@ func (c *client) convertToDomainTasks(searchResp api.SearchResult, sprint string
 	return tasks, nil
 }
 
+// isRelevantToSprint determines if an issue is relevant to the requested sprint
+// This handles both single-sprint and multi-sprint scenarios
+func (c *client) isRelevantToSprint(issue api.Issue, sprint string) bool {
+	if sprint == "" {
+		return true // No sprint filter, include all issues
+	}
+
+	// Check if the issue has any sprints assigned
+	if len(issue.Fields.Sprint) == 0 {
+		return false // No sprints assigned, not relevant
+	}
+
+	// Look for the specific sprint in the issue's sprint list
+	var targetSprint api.Sprint
+	var sprintFound bool
+	for _, s := range issue.Fields.Sprint {
+		if s.Name == sprint {
+			targetSprint = s
+			sprintFound = true
+			break
+		}
+	}
+
+	if !sprintFound {
+		return false // Sprint not found in issue's sprint list
+	}
+
+	// For single-sprint issues, always include them
+	if len(issue.Fields.Sprint) == 1 {
+		return true
+	}
+
+	// For multi-sprint issues, apply more sophisticated logic
+	return c.isMultiSprintTaskRelevant(issue, targetSprint, sprint)
+}
+
+// isMultiSprintTaskRelevant determines if a multi-sprint task is relevant to the requested sprint
+func (c *client) isMultiSprintTaskRelevant(issue api.Issue, targetSprint api.Sprint, sprintName string) bool {
+	// Get sprint dates for the target sprint
+	var sprintStart, sprintEnd time.Time
+	if targetSprint.StartDate != "" {
+		var err error
+		sprintStart, err = parseTime(targetSprint.StartDate)
+		if err != nil {
+			return true // If we can't parse dates, include the issue to be safe
+		}
+	}
+	if targetSprint.EndDate != "" {
+		var err error
+		sprintEnd, err = parseTime(targetSprint.EndDate)
+		if err != nil {
+			return true // If we can't parse dates, include the issue to be safe
+		}
+	}
+
+	// If we don't have valid sprint dates, include the issue
+	if sprintStart.IsZero() || sprintEnd.IsZero() {
+		return true
+	}
+
+	// Check if there was meaningful work done during the sprint period
+	if wasWorkedOnDuringSprint(issue, sprintStart, sprintEnd) {
+		return true
+	}
+
+	// For multi-sprint tasks, also check if this is the most recent sprint
+	// This handles cases where tasks are moved to new sprints without changelog entries
+	mostRecentSprint := c.findMostRecentSprint(issue.Fields.Sprint)
+	if mostRecentSprint != nil && mostRecentSprint.Name == sprintName {
+		return true
+	}
+
+	// Fallback: if we can't determine the most recent sprint due to missing dates,
+	// be permissive and include the task to avoid missing relevant work
+	if mostRecentSprint == nil {
+		return true
+	}
+
+	return false
+}
+
+// findMostRecentSprint finds the most recent sprint among the issue's sprints
+func (c *client) findMostRecentSprint(sprints []api.Sprint) *api.Sprint {
+	if len(sprints) == 0 {
+		return nil
+	}
+
+	var mostRecent *api.Sprint
+	var mostRecentTime time.Time
+
+	for i := range sprints {
+		sprint := &sprints[i]
+		var sprintTime time.Time
+
+		// Use end date if available, otherwise start date
+		if sprint.EndDate != "" {
+			if t, err := parseTime(sprint.EndDate); err == nil {
+				sprintTime = t
+			}
+		} else if sprint.StartDate != "" {
+			if t, err := parseTime(sprint.StartDate); err == nil {
+				sprintTime = t
+			}
+		}
+
+		if !sprintTime.IsZero() && (mostRecent == nil || sprintTime.After(mostRecentTime)) {
+			mostRecent = sprint
+			mostRecentTime = sprintTime
+		}
+	}
+
+	return mostRecent
+}
+
 // FetchTasks retrieves tasks from Jira for a given project and sprint
 func (c *client) FetchTasks(ctx context.Context, project, sprint string) ([]*domain.Task, error) {
 	if project == "" {
 		return nil, fmt.Errorf("project is required")
 	}
 
-	// Build JQL query - include issues in the sprint
-	jql := fmt.Sprintf("project = %s", project)
+	// For sprint-specific queries, use a dual strategy to ensure we don't miss multi-sprint tasks
 	if sprint != "" {
-		jql += fmt.Sprintf(" AND sprint in (\"%s\")", sprint)
+		return c.fetchTasksWithDualStrategy(ctx, project, sprint)
 	}
-	jql += " ORDER BY key ASC"
 
+	// For non-sprint queries, use the standard approach
+	return c.fetchTasksWithQuery(ctx, project, sprint, false)
+}
+
+// fetchTasksWithDualStrategy combines results from both specific and broader queries
+func (c *client) fetchTasksWithDualStrategy(ctx context.Context, project, sprint string) ([]*domain.Task, error) {
+	// Run both queries in parallel to maximize coverage
+	var specificTasks, broadTasks []*domain.Task
+	var specificErr, broadErr error
+
+	// Channel to collect results
+	type result struct {
+		tasks []*domain.Task
+		err   error
+		query string
+	}
+
+	results := make(chan result, 2)
+
+	// Start specific query
+	go func() {
+		tasks, err := c.fetchTasksWithQuery(ctx, project, sprint, false)
+		results <- result{tasks: tasks, err: err, query: "specific"}
+	}()
+
+	// Start broader query
+	go func() {
+		tasks, err := c.fetchTasksWithQuery(ctx, project, sprint, true)
+		results <- result{tasks: tasks, err: err, query: "broad"}
+	}()
+
+	// Collect results
+	for i := 0; i < 2; i++ {
+		res := <-results
+		if res.err != nil {
+			if res.query == "specific" {
+				specificErr = res.err
+			} else {
+				broadErr = res.err
+			}
+		} else {
+			if res.query == "specific" {
+				specificTasks = res.tasks
+			} else {
+				broadTasks = res.tasks
+			}
+		}
+	}
+
+	// If both queries failed, return the specific query error
+	if specificErr != nil && broadErr != nil {
+		return nil, specificErr
+	}
+
+	// Merge and deduplicate results
+	return c.mergeAndDeduplicateTasks(specificTasks, broadTasks), nil
+}
+
+// mergeAndDeduplicateTasks combines task lists and removes duplicates based on task key
+func (c *client) mergeAndDeduplicateTasks(specificTasks, broadTasks []*domain.Task) []*domain.Task {
+	if len(specificTasks) == 0 {
+		return broadTasks
+	}
+	if len(broadTasks) == 0 {
+		return specificTasks
+	}
+
+	// Create a map to track unique tasks by key
+	taskMap := make(map[string]*domain.Task)
+
+	// Add specific tasks first (they have priority)
+	for _, task := range specificTasks {
+		taskMap[task.Key] = task
+	}
+
+	// Add broad tasks only if not already present
+	for _, task := range broadTasks {
+		if _, exists := taskMap[task.Key]; !exists {
+			taskMap[task.Key] = task
+		}
+	}
+
+	// Convert back to slice
+	mergedTasks := make([]*domain.Task, 0, len(taskMap))
+	for _, task := range taskMap {
+		mergedTasks = append(mergedTasks, task)
+	}
+
+	// Sort by key for consistent output
+	for i := 0; i < len(mergedTasks)-1; i++ {
+		for j := i + 1; j < len(mergedTasks); j++ {
+			if mergedTasks[i].Key > mergedTasks[j].Key {
+				mergedTasks[i], mergedTasks[j] = mergedTasks[j], mergedTasks[i]
+			}
+		}
+	}
+
+	return mergedTasks
+}
+
+// search executes a JQL query and returns the raw search results
+func (c *client) search(ctx context.Context, jql string) (*api.SearchResult, error) {
 	// Build request URL with fields and expand parameters
-	url := fmt.Sprintf("%s/rest/api/3/search?jql=%s&fields=*all&expand=changelog",
+	requestURL := fmt.Sprintf("%s/rest/api/3/search?jql=%s&fields=*all&expand=changelog",
 		c.config.GetBaseURL(),
 		url.QueryEscape(jql))
 
 	// Create request
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -302,7 +486,11 @@ func (c *client) FetchTasks(ctx context.Context, project, sprint string) ([]*dom
 	defer resp.Body.Close()
 
 	// Check response status and body
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
 	}
@@ -313,7 +501,35 @@ func (c *client) FetchTasks(ctx context.Context, project, sprint string) ([]*dom
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	return c.convertToDomainTasks(searchResp, sprint)
+	return &searchResp, nil
+}
+
+// fetchTasksWithQuery executes a JIRA query and returns tasks
+func (c *client) fetchTasksWithQuery(ctx context.Context, project, sprint string, isBroaderQuery bool) ([]*domain.Task, error) {
+	jql := fmt.Sprintf("project = %s", project)
+	if sprint != "" {
+		if isBroaderQuery {
+			// Enhanced broader query: look for tasks that were updated recently and might be multi-sprint
+			// This catches tasks that might have been moved between sprints or worked on across sprints
+			jql += fmt.Sprintf(" AND (sprint in (\"%s\") OR (updated >= -30d AND sprint is not EMPTY))", sprint)
+		} else {
+			// Standard query - specific sprint only
+			jql += fmt.Sprintf(" AND sprint in (\"%s\")", sprint)
+		}
+	}
+	jql += " ORDER BY key ASC"
+
+	searchResp, err := c.search(ctx, jql)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search tasks: %w", err)
+	}
+
+	tasks, err := c.convertToDomainTasks(*searchResp, sprint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert tasks: %w", err)
+	}
+
+	return tasks, nil
 }
 
 // FetchTaskByKey retrieves a single task from Jira by its key

--- a/internal/tasks/infrastructure/jira/client.go
+++ b/internal/tasks/infrastructure/jira/client.go
@@ -197,17 +197,13 @@ func (c *client) convertToDomainTasks(searchResp api.SearchResult, sprint string
 			}
 		}
 
-		// Handle empty sprint
-		sprintName := ""
+		// Handle sprint names
+		var sprintNames []string
 		if len(issue.Fields.Sprint) > 0 {
-			var sprintNames []string
 			for _, s := range issue.Fields.Sprint {
 				if s.Name != "" {
 					sprintNames = append(sprintNames, s.Name)
 				}
-			}
-			if len(sprintNames) > 0 {
-				sprintName = strings.Join(sprintNames, ", ")
 			}
 		}
 
@@ -226,7 +222,15 @@ func (c *client) convertToDomainTasks(searchResp api.SearchResult, sprint string
 			epicKey = issue.Fields.Parent.Key
 		}
 
-		task, err := domain.NewTask(issue.Key, issue.Fields.Summary, projectKey, sprintName, "JIRA")
+		// Create task with multi-sprint support
+		var task *domain.Task
+		var err error
+		if len(sprintNames) > 0 {
+			task, err = domain.NewTaskWithSprints(issue.Key, issue.Fields.Summary, projectKey, sprintNames, "JIRA")
+		} else {
+			// Use NewTaskWithoutSprint for issues with no sprints
+			task, err = domain.NewTaskWithoutSprint(issue.Key, issue.Fields.Summary, projectKey, "JIRA")
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to create task: %w", err)
 		}
@@ -390,20 +394,16 @@ func (c *client) convertSingleIssueToDomainTask(issue api.Issue) (*domain.Task, 
 	}
 
 	// Handle sprint names
-	sprintName := ""
+	var sprintNames []string
 	if len(issue.Fields.Sprint) > 0 {
-		var sprintNames []string
 		for _, s := range issue.Fields.Sprint {
 			if s.Name != "" {
 				sprintNames = append(sprintNames, s.Name)
 			}
 		}
-		if len(sprintNames) > 0 {
-			sprintName = strings.Join(sprintNames, ", ")
-		}
 	}
 
-	// Extract project key from issue key (e.g., "FN-1015" -> "FN")
+	// Use the project key from the issue key if not available in fields
 	projectKey := ""
 	if parts := strings.Split(issue.Key, "-"); len(parts) >= 2 {
 		projectKey = parts[0]
@@ -431,23 +431,29 @@ func (c *client) convertSingleIssueToDomainTask(issue api.Issue) (*domain.Task, 
 		}
 	}
 
-	task := &domain.Task{
-		Key:         issue.Key,
-		Summary:     issue.Fields.Summary,
-		Description: issue.Fields.Description.ExtractAllText(),
-		Status:      mapJiraStatus(issue.Fields.Status.Name),
-		Type:        mapJiraType(issue.Fields.IssueType.Name),
-		Priority:    domain.TaskPriorityMedium, // Default priority
-		Project:     projectKey,
-		Sprint:      sprintName,
-		Epic:        epicKey,
-		Platform:    "JIRA",
-		Labels:      issue.Fields.Labels,
-		WorkType:    workType,
-		CreatedAt:   created,
-		UpdatedAt:   updated,
-		Version:     1,
+	// Create task with multi-sprint support
+	var task *domain.Task
+	var err error
+	if len(sprintNames) > 0 {
+		task, err = domain.NewTaskWithSprints(issue.Key, issue.Fields.Summary, projectKey, sprintNames, "JIRA")
+	} else {
+		// Use NewTaskWithoutSprint for issues with no sprints
+		task, err = domain.NewTaskWithoutSprint(issue.Key, issue.Fields.Summary, projectKey, "JIRA")
 	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to create task: %w", err)
+	}
+
+	// Set additional fields
+	task.Description = issue.Fields.Description.ExtractAllText()
+	task.Status = mapJiraStatus(issue.Fields.Status.Name)
+	task.Type = mapJiraType(issue.Fields.IssueType.Name)
+	task.Priority = domain.TaskPriorityMedium // Default priority
+	task.Labels = issue.Fields.Labels
+	task.Epic = epicKey
+	task.CreatedAt = created
+	task.UpdatedAt = updated
+	task.WorkType = workType
 
 	return task, nil
 }

--- a/internal/tasks/infrastructure/jira/client_test.go
+++ b/internal/tasks/infrastructure/jira/client_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -1023,4 +1024,110 @@ func TestClient_FetchTaskByKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClient_UpdateLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		taskKey        string
+		labels         []string
+		serverResponse string
+		statusCode     int
+		expectError    bool
+	}{
+		{
+			name:           "successful update",
+			taskKey:        "TEST-1",
+			labels:         []string{"label1", "label2"},
+			serverResponse: `{"key": "TEST-1"}`,
+			statusCode:     200,
+			expectError:    false,
+		},
+		{
+			name:           "empty task key",
+			taskKey:        "",
+			labels:         []string{"label1"},
+			serverResponse: "",
+			statusCode:     400,
+			expectError:    true,
+		},
+		{
+			name:           "server error",
+			taskKey:        "TEST-1",
+			labels:         []string{"label1"},
+			serverResponse: `{"error": "Internal server error"}`,
+			statusCode:     500,
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.serverResponse))
+			}))
+			defer server.Close()
+
+			config := &Config{
+				BaseURL: server.URL,
+				Email:   "test@example.com",
+				Token:   "test-token",
+			}
+
+			client, err := NewClient(config)
+			require.NoError(t, err)
+
+			err = client.UpdateLabels(context.Background(), tt.taskKey, tt.labels)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewRepositoryLegacy_ErrorHandling(t *testing.T) {
+	// Clear environment variables to force error
+	origBaseURL := os.Getenv("JIRA_BASE_URL")
+	origEmail := os.Getenv("JIRA_EMAIL")
+	origToken := os.Getenv("JIRA_TOKEN")
+
+	os.Unsetenv("JIRA_BASE_URL")
+	os.Unsetenv("JIRA_EMAIL")
+	os.Unsetenv("JIRA_TOKEN")
+
+	defer func() {
+		if origBaseURL != "" {
+			os.Setenv("JIRA_BASE_URL", origBaseURL)
+		}
+		if origEmail != "" {
+			os.Setenv("JIRA_EMAIL", origEmail)
+		}
+		if origToken != "" {
+			os.Setenv("JIRA_TOKEN", origToken)
+		}
+	}()
+
+	_, err := NewRepositoryLegacy()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create Jira configuration")
+}
+
+func TestNewRepositoryLegacy_Success(t *testing.T) {
+	// Set up environment variables for valid config
+	os.Setenv("JIRA_BASE_URL", "https://test.atlassian.net")
+	os.Setenv("JIRA_EMAIL", "test@example.com")
+	os.Setenv("JIRA_TOKEN", "test-token")
+	defer func() {
+		os.Unsetenv("JIRA_BASE_URL")
+		os.Unsetenv("JIRA_EMAIL")
+		os.Unsetenv("JIRA_TOKEN")
+	}()
+
+	repo, err := NewRepositoryLegacy()
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
 }

--- a/internal/tasks/infrastructure/jira/client_test.go
+++ b/internal/tasks/infrastructure/jira/client_test.go
@@ -70,7 +70,11 @@ func TestClient_FetchTasks(t *testing.T) {
 			// Verify request
 			assert.Equal(t, http.MethodGet, r.Method, "Method should be GET")
 			assert.Equal(t, "/rest/api/3/search", r.URL.Path, "Path should match")
-			assert.Equal(t, "project = TEST AND sprint in (\"Sprint 1\") ORDER BY key ASC", r.URL.Query().Get("jql"), "JQL should match")
+			// With dual strategy, we expect either the specific query or the broader query
+			jql := r.URL.Query().Get("jql")
+			expectedSpecific := "project = TEST AND sprint in (\"Sprint 1\") ORDER BY key ASC"
+			expectedBroad := "project = TEST AND (sprint in (\"Sprint 1\") OR (updated >= -30d AND sprint is not EMPTY)) ORDER BY key ASC"
+			assert.True(t, jql == expectedSpecific || jql == expectedBroad, "JQL should match either specific or broad query, got: %s", jql)
 			assert.Equal(t, "*all", r.URL.Query().Get("fields"), "Fields should match")
 			assert.Equal(t, "changelog", r.URL.Query().Get("expand"), "Expand should match")
 
@@ -1130,4 +1134,464 @@ func TestNewRepositoryLegacy_Success(t *testing.T) {
 	repo, err := NewRepositoryLegacy()
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
+}
+
+func TestIsRelevantToSprint(t *testing.T) {
+	client := &client{
+		httpClient: nil,
+		config:     nil,
+	}
+
+	// Base time for testing
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	sprintStart := baseTime.Format(time.RFC3339)
+	sprintEnd := baseTime.Add(14 * 24 * time.Hour).Format(time.RFC3339)
+
+	tests := []struct {
+		name     string
+		issue    api.Issue
+		sprint   string
+		expected bool
+	}{
+		{
+			name: "no sprint filter",
+			issue: api.Issue{
+				Fields: api.Fields{
+					Sprint: []api.Sprint{{Name: "Sprint 1"}},
+				},
+			},
+			sprint:   "",
+			expected: true,
+		},
+		{
+			name: "no sprints assigned",
+			issue: api.Issue{
+				Fields: api.Fields{
+					Sprint: []api.Sprint{},
+				},
+			},
+			sprint:   "Sprint 1",
+			expected: false,
+		},
+		{
+			name: "single sprint match",
+			issue: api.Issue{
+				Fields: api.Fields{
+					Sprint: []api.Sprint{{Name: "Sprint 1", StartDate: sprintStart, EndDate: sprintEnd}},
+				},
+			},
+			sprint:   "Sprint 1",
+			expected: true,
+		},
+		{
+			name: "single sprint no match",
+			issue: api.Issue{
+				Fields: api.Fields{
+					Sprint: []api.Sprint{{Name: "Sprint 2", StartDate: sprintStart, EndDate: sprintEnd}},
+				},
+			},
+			sprint:   "Sprint 1",
+			expected: false,
+		},
+		{
+			name: "multi-sprint with target sprint",
+			issue: api.Issue{
+				Fields: api.Fields{
+					Sprint: []api.Sprint{
+						{Name: "Sprint 1", StartDate: sprintStart, EndDate: sprintEnd},
+						{Name: "Sprint 2", StartDate: baseTime.Add(15 * 24 * time.Hour).Format(time.RFC3339), EndDate: baseTime.Add(29 * 24 * time.Hour).Format(time.RFC3339)},
+					},
+					Changelog: api.Changelog{
+						Histories: []api.ChangelogHistory{
+							{
+								Created: baseTime.Add(5 * 24 * time.Hour).Format(time.RFC3339),
+								Items: []api.ChangelogItem{
+									{Field: "status", FromString: "To Do", ToString: "In Progress"},
+								},
+							},
+						},
+					},
+				},
+			},
+			sprint:   "Sprint 1",
+			expected: true,
+		},
+		{
+			name: "multi-sprint without target sprint",
+			issue: api.Issue{
+				Fields: api.Fields{
+					Sprint: []api.Sprint{
+						{Name: "Sprint 2", StartDate: sprintStart, EndDate: sprintEnd},
+						{Name: "Sprint 3", StartDate: baseTime.Add(15 * 24 * time.Hour).Format(time.RFC3339), EndDate: baseTime.Add(29 * 24 * time.Hour).Format(time.RFC3339)},
+					},
+				},
+			},
+			sprint:   "Sprint 1",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := client.isRelevantToSprint(tt.issue, tt.sprint)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsMultiSprintTaskRelevant(t *testing.T) {
+	client := &client{
+		httpClient: nil,
+		config:     nil,
+	}
+
+	// Base time for testing
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	sprintStart := baseTime.Format(time.RFC3339)
+	sprintEnd := baseTime.Add(14 * 24 * time.Hour).Format(time.RFC3339)
+
+	targetSprint := api.Sprint{
+		Name:      "Sprint 1",
+		StartDate: sprintStart,
+		EndDate:   sprintEnd,
+	}
+
+	tests := []struct {
+		name     string
+		issue    api.Issue
+		expected bool
+	}{
+		{
+			name: "work done during sprint",
+			issue: api.Issue{
+				Fields: api.Fields{
+					Sprint: []api.Sprint{
+						targetSprint,
+						{Name: "Sprint 2", StartDate: baseTime.Add(15 * 24 * time.Hour).Format(time.RFC3339), EndDate: baseTime.Add(29 * 24 * time.Hour).Format(time.RFC3339)},
+					},
+					Changelog: api.Changelog{
+						Histories: []api.ChangelogHistory{
+							{
+								Created: baseTime.Add(5 * 24 * time.Hour).Format(time.RFC3339),
+								Items: []api.ChangelogItem{
+									{Field: "status", FromString: "To Do", ToString: "In Progress"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "no work during sprint but most recent",
+			issue: api.Issue{
+				Fields: api.Fields{
+					Sprint: []api.Sprint{
+						{Name: "Sprint 0", StartDate: baseTime.Add(-15 * 24 * time.Hour).Format(time.RFC3339), EndDate: baseTime.Add(-1 * 24 * time.Hour).Format(time.RFC3339)},
+						targetSprint,
+					},
+					Changelog: api.Changelog{
+						Histories: []api.ChangelogHistory{
+							{
+								Created: baseTime.Add(-5 * 24 * time.Hour).Format(time.RFC3339),
+								Items: []api.ChangelogItem{
+									{Field: "status", FromString: "To Do", ToString: "In Progress"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "no work during sprint and not most recent",
+			issue: api.Issue{
+				Fields: api.Fields{
+					Sprint: []api.Sprint{
+						targetSprint,
+						{Name: "Sprint 2", StartDate: baseTime.Add(15 * 24 * time.Hour).Format(time.RFC3339), EndDate: baseTime.Add(29 * 24 * time.Hour).Format(time.RFC3339)},
+					},
+					Changelog: api.Changelog{
+						Histories: []api.ChangelogHistory{
+							{
+								Created: baseTime.Add(20 * 24 * time.Hour).Format(time.RFC3339),
+								Items: []api.ChangelogItem{
+									{Field: "status", FromString: "To Do", ToString: "In Progress"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "no sprint dates - include to be safe",
+			issue: api.Issue{
+				Fields: api.Fields{
+					Sprint: []api.Sprint{
+						{Name: "Sprint 1"}, // No dates
+						{Name: "Sprint 2"}, // Second sprint to make it multi-sprint
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := client.isMultiSprintTaskRelevant(tt.issue, targetSprint, "Sprint 1")
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFindMostRecentSprint(t *testing.T) {
+	client := &client{
+		httpClient: nil,
+		config:     nil,
+	}
+
+	// Base time for testing
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		sprints  []api.Sprint
+		expected *api.Sprint
+	}{
+		{
+			name:     "empty sprints",
+			sprints:  []api.Sprint{},
+			expected: nil,
+		},
+		{
+			name: "single sprint",
+			sprints: []api.Sprint{
+				{Name: "Sprint 1", StartDate: baseTime.Format(time.RFC3339), EndDate: baseTime.Add(14 * 24 * time.Hour).Format(time.RFC3339)},
+			},
+			expected: &api.Sprint{Name: "Sprint 1", StartDate: baseTime.Format(time.RFC3339), EndDate: baseTime.Add(14 * 24 * time.Hour).Format(time.RFC3339)},
+		},
+		{
+			name: "multiple sprints - most recent by end date",
+			sprints: []api.Sprint{
+				{Name: "Sprint 1", StartDate: baseTime.Format(time.RFC3339), EndDate: baseTime.Add(14 * 24 * time.Hour).Format(time.RFC3339)},
+				{Name: "Sprint 2", StartDate: baseTime.Add(15 * 24 * time.Hour).Format(time.RFC3339), EndDate: baseTime.Add(29 * 24 * time.Hour).Format(time.RFC3339)},
+			},
+			expected: &api.Sprint{Name: "Sprint 2", StartDate: baseTime.Add(15 * 24 * time.Hour).Format(time.RFC3339), EndDate: baseTime.Add(29 * 24 * time.Hour).Format(time.RFC3339)},
+		},
+		{
+			name: "multiple sprints - fallback to start date",
+			sprints: []api.Sprint{
+				{Name: "Sprint 1", StartDate: baseTime.Format(time.RFC3339)},
+				{Name: "Sprint 2", StartDate: baseTime.Add(15 * 24 * time.Hour).Format(time.RFC3339)},
+			},
+			expected: &api.Sprint{Name: "Sprint 2", StartDate: baseTime.Add(15 * 24 * time.Hour).Format(time.RFC3339)},
+		},
+		{
+			name: "sprints with invalid dates",
+			sprints: []api.Sprint{
+				{Name: "Sprint 1", StartDate: "invalid-date"},
+				{Name: "Sprint 2", StartDate: baseTime.Add(15 * 24 * time.Hour).Format(time.RFC3339)},
+			},
+			expected: &api.Sprint{Name: "Sprint 2", StartDate: baseTime.Add(15 * 24 * time.Hour).Format(time.RFC3339)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := client.findMostRecentSprint(tt.sprints)
+			if tt.expected == nil {
+				assert.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+				assert.Equal(t, tt.expected.Name, result.Name)
+				assert.Equal(t, tt.expected.StartDate, result.StartDate)
+				assert.Equal(t, tt.expected.EndDate, result.EndDate)
+			}
+		})
+	}
+}
+
+func TestFetchTasksWithFallback(t *testing.T) {
+	tests := []struct {
+		name               string
+		specificQueryTasks []api.Issue
+		broadQueryTasks    []api.Issue
+		sprint             string
+		expectedQueryCount int
+		expectedTaskCount  int
+		expectedTaskKey    string
+	}{
+		{
+			name: "specific query returns tasks",
+			specificQueryTasks: []api.Issue{
+				{
+					Key: "TEST-1",
+					Fields: api.Fields{
+						Summary:   "Test Task 1",
+						Project:   api.Project{Key: "TEST"},
+						Sprint:    []api.Sprint{{Name: "Sprint 1", StartDate: "2025-01-01T00:00:00.000Z", EndDate: "2025-01-14T00:00:00.000Z"}},
+						Created:   "2025-01-01T00:00:00.000Z",
+						Updated:   "2025-01-01T00:00:00.000Z",
+						Status:    api.Status{Name: "In Progress"},
+						IssueType: api.IssueType{Name: "Story"},
+					},
+				},
+			},
+			broadQueryTasks:    []api.Issue{},
+			sprint:             "Sprint 1",
+			expectedQueryCount: 2, // Dual strategy makes both queries
+			expectedTaskCount:  1,
+			expectedTaskKey:    "TEST-1",
+		},
+		{
+			name:               "specific query returns no tasks, fallback to broad",
+			specificQueryTasks: []api.Issue{},
+			broadQueryTasks: []api.Issue{
+				{
+					Key: "TEST-2",
+					Fields: api.Fields{
+						Summary:   "Test Task 2",
+						Project:   api.Project{Key: "TEST"},
+						Sprint:    []api.Sprint{{Name: "Sprint 1", StartDate: "2025-01-01T00:00:00.000Z", EndDate: "2025-01-14T00:00:00.000Z"}},
+						Created:   "2025-01-01T00:00:00.000Z",
+						Updated:   "2025-01-01T00:00:00.000Z",
+						Status:    api.Status{Name: "Done"},
+						IssueType: api.IssueType{Name: "Story"},
+					},
+				},
+			},
+			sprint:             "Sprint 1",
+			expectedQueryCount: 2, // Both queries called
+			expectedTaskCount:  1,
+			expectedTaskKey:    "TEST-2",
+		},
+		{
+			name: "no sprint filter - only specific query",
+			specificQueryTasks: []api.Issue{
+				{
+					Key: "TEST-3",
+					Fields: api.Fields{
+						Summary:   "Test Task 3",
+						Project:   api.Project{Key: "TEST"},
+						Sprint:    []api.Sprint{{Name: "Sprint 1", StartDate: "2025-01-01T00:00:00.000Z", EndDate: "2025-01-14T00:00:00.000Z"}},
+						Created:   "2025-01-01T00:00:00.000Z",
+						Updated:   "2025-01-01T00:00:00.000Z",
+						Status:    api.Status{Name: "To Do"},
+						IssueType: api.IssueType{Name: "Story"},
+					},
+				},
+			},
+			broadQueryTasks:    []api.Issue{},
+			sprint:             "",
+			expectedQueryCount: 1, // Only specific query called
+			expectedTaskCount:  1,
+			expectedTaskKey:    "TEST-3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queryCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				queryCount++
+				w.Header().Set("Content-Type", "application/json")
+
+				var responseData map[string]interface{}
+
+				// Determine which query this is based on the URL
+				if strings.Contains(r.URL.RawQuery, "sprint+is+not+EMPTY") {
+					// This is the broad query
+					responseData = map[string]interface{}{
+						"issues": convertIssuesToResponse(tt.broadQueryTasks),
+					}
+				} else {
+					// This is the specific query
+					responseData = map[string]interface{}{
+						"issues": convertIssuesToResponse(tt.specificQueryTasks),
+					}
+				}
+
+				json.NewEncoder(w).Encode(responseData)
+			}))
+			defer server.Close()
+
+			config := &Config{
+				BaseURL: server.URL,
+				Email:   "test@example.com",
+				Token:   "test-token",
+			}
+			client, err := NewClient(config)
+			require.NoError(t, err)
+
+			tasks, err := client.FetchTasks(context.Background(), "TEST", tt.sprint)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedQueryCount, queryCount, "Expected number of queries")
+			assert.Equal(t, tt.expectedTaskCount, len(tasks), "Expected number of tasks")
+
+			if tt.expectedTaskCount > 0 {
+				assert.Equal(t, tt.expectedTaskKey, tasks[0].Key, "Expected task key")
+			}
+		})
+	}
+}
+
+// Helper function to convert test issues to response format
+func convertIssuesToResponse(issues []api.Issue) []map[string]interface{} {
+	response := make([]map[string]interface{}, 0, len(issues))
+	for _, issue := range issues {
+		issueData := map[string]interface{}{
+			"key": issue.Key,
+			"fields": map[string]interface{}{
+				"summary":   issue.Fields.Summary,
+				"project":   map[string]interface{}{"key": issue.Fields.Project.Key},
+				"created":   issue.Fields.Created,
+				"updated":   issue.Fields.Updated,
+				"status":    map[string]interface{}{"name": issue.Fields.Status.Name},
+				"issuetype": map[string]interface{}{"name": issue.Fields.IssueType.Name},
+				"description": map[string]interface{}{
+					"type":    "doc",
+					"version": 1,
+					"content": []map[string]interface{}{
+						{
+							"type": "paragraph",
+							"content": []map[string]interface{}{
+								{
+									"type": "text",
+									"text": "Test Description",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// Add sprint information if available
+		if len(issue.Fields.Sprint) > 0 {
+			var sprints []map[string]interface{}
+			for _, sprint := range issue.Fields.Sprint {
+				sprintData := map[string]interface{}{
+					"name":  sprint.Name,
+					"state": "active",
+				}
+				if sprint.StartDate != "" {
+					sprintData["startDate"] = sprint.StartDate
+				}
+				if sprint.EndDate != "" {
+					sprintData["endDate"] = sprint.EndDate
+				}
+				sprints = append(sprints, sprintData)
+			}
+			issueData["fields"].(map[string]interface{})["customfield_10100"] = sprints
+		}
+
+		response = append(response, issueData)
+	}
+	return response
 }

--- a/internal/tasks/infrastructure/migration/sprint_migration.go
+++ b/internal/tasks/infrastructure/migration/sprint_migration.go
@@ -1,0 +1,305 @@
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain"
+	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain/ports"
+)
+
+// Result represents the result of a migration operation
+type Result struct {
+	TasksProcessed int                    `json:"tasks_processed"`
+	TasksMigrated  int                    `json:"tasks_migrated"`
+	TasksSkipped   int                    `json:"tasks_skipped"`
+	BackupCreated  bool                   `json:"backup_created"`
+	BackupPath     string                 `json:"backup_path"`
+	MigratedTasks  []string               `json:"migrated_tasks"`
+	SkippedTasks   []string               `json:"skipped_tasks"`
+	Errors         []string               `json:"errors"`
+	Duration       time.Duration          `json:"duration"`
+	Statistics     map[string]interface{} `json:"statistics"`
+}
+
+// SprintMigration handles the migration of sprint data from string to array format
+type SprintMigration struct {
+	repository ports.TaskRepository
+	backupDir  string
+}
+
+// NewSprintMigration creates a new SprintMigration instance
+func NewSprintMigration(repository ports.TaskRepository, backupDir string) *SprintMigration {
+	return &SprintMigration{
+		repository: repository,
+		backupDir:  backupDir,
+	}
+}
+
+// MigrateToArrayFormat migrates tasks from comma-separated sprint strings to array format
+func (m *SprintMigration) MigrateToArrayFormat(_ context.Context, dryRun bool) (*Result, error) {
+	start := time.Now()
+
+	result := &Result{
+		Statistics: make(map[string]interface{}),
+	}
+
+	// Get all tasks
+	tasks, err := m.repository.FindAll(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch tasks: %w", err)
+	}
+
+	result.TasksProcessed = len(tasks)
+
+	// Create backup if not dry run
+	if !dryRun {
+		backupPath, err := m.createBackup(tasks)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create backup: %w", err)
+		}
+		result.BackupCreated = true
+		result.BackupPath = backupPath
+	}
+
+	// Process each task
+	for _, task := range tasks {
+		migrated, err := m.migrateTask(task)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("Task %s: %s", task.Key, err.Error()))
+			continue
+		}
+
+		if migrated {
+			result.TasksMigrated++
+			result.MigratedTasks = append(result.MigratedTasks, task.Key)
+
+			// Save the migrated task if not dry run
+			if !dryRun {
+				if err := m.repository.Save(context.Background(), task); err != nil {
+					result.Errors = append(result.Errors, fmt.Sprintf("Failed to save task %s: %s", task.Key, err.Error()))
+					continue
+				}
+			}
+		} else {
+			result.TasksSkipped++
+			result.SkippedTasks = append(result.SkippedTasks, task.Key)
+		}
+	}
+
+	result.Duration = time.Since(start)
+
+	// Add statistics
+	result.Statistics["success_rate"] = float64(result.TasksMigrated) / float64(result.TasksProcessed) * 100
+	result.Statistics["migration_time"] = result.Duration.String()
+
+	return result, nil
+}
+
+// migrateTask migrates a single task from string to array format
+func (m *SprintMigration) migrateTask(task *domain.Task) (bool, error) {
+	// Check if task has no sprint data at all
+	if task.Sprint == "" {
+		return false, nil // No sprint data to migrate
+	}
+
+	// Check if task has been explicitly migrated by checking if the Sprint field
+	// exactly matches the joined Sprints array (indicating explicit migration)
+	if len(task.Sprints) > 0 {
+		expectedSprintString := strings.Join(task.Sprints, ", ")
+		if task.Sprint == expectedSprintString {
+			// This indicates the task was explicitly migrated (Sprint field was set by SetSprints)
+			return false, nil // No migration needed
+		}
+	}
+
+	// At this point, we have a task with Sprint data that needs migration
+	// Parse sprint string and populate sprints array
+	sprints := task.GetSprints() // This will parse the Sprint string
+	if len(sprints) == 0 {
+		return false, fmt.Errorf("failed to parse sprint string: %s", task.Sprint)
+	}
+
+	// Set the sprints array (this will also update the Sprint field for consistency)
+	task.SetSprints(sprints)
+
+	return true, nil
+}
+
+// createBackup creates a backup of all tasks before migration
+func (m *SprintMigration) createBackup(tasks []*domain.Task) (string, error) {
+	// Create backup directory if it doesn't exist
+	if err := os.MkdirAll(m.backupDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create backup directory: %w", err)
+	}
+
+	// Create backup file with timestamp
+	timestamp := time.Now().Format("20060102_150405")
+	backupPath := fmt.Sprintf("%s/tasks_backup_%s.json", m.backupDir, timestamp)
+
+	// Convert tasks to map for JSON serialization
+	taskMap := make(map[string]*domain.Task)
+	for _, task := range tasks {
+		taskMap[task.Key] = task
+	}
+
+	// Marshal to JSON
+	data, err := json.MarshalIndent(taskMap, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal tasks: %w", err)
+	}
+
+	// Write backup file
+	if err := os.WriteFile(backupPath, data, 0644); err != nil {
+		return "", fmt.Errorf("failed to write backup file: %w", err)
+	}
+
+	return backupPath, nil
+}
+
+// ValidateCompatibility checks if the current tasks are compatible with the new format
+func (m *SprintMigration) ValidateCompatibility(_ context.Context) error {
+	tasks, err := m.repository.FindAll(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to fetch tasks: %w", err)
+	}
+
+	var errors []string
+
+	for _, task := range tasks {
+		// Check if task has valid sprint data
+		if task.Sprint == "" && len(task.Sprints) == 0 {
+			errors = append(errors, fmt.Sprintf("Task %s has no sprint data", task.Key))
+			continue
+		}
+
+		// Check if sprint string can be parsed
+		if task.Sprint != "" {
+			sprints := task.GetSprints()
+			if len(sprints) == 0 {
+				errors = append(errors, fmt.Sprintf("Task %s has unparseable sprint string: %s", task.Key, task.Sprint))
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("validation failed: %v", errors)
+	}
+
+	return nil
+}
+
+// GetMigrationStats returns statistics about the current migration state
+func (m *SprintMigration) GetMigrationStats(_ context.Context) (*Result, error) {
+	tasks, err := m.repository.FindAll(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch tasks: %w", err)
+	}
+
+	result := &Result{
+		TasksProcessed: len(tasks),
+		Statistics:     make(map[string]interface{}),
+	}
+
+	var alreadyMigrated int
+	var needsMigration int
+
+	for _, task := range tasks {
+		// Check if task has no sprint data at all
+		if task.Sprint == "" {
+			continue // Skip tasks with no sprint data
+		}
+
+		// Check if task has been explicitly migrated by checking if the Sprint field
+		// exactly matches the joined Sprints array (indicating explicit migration)
+		if len(task.Sprints) > 0 {
+			expectedSprintString := strings.Join(task.Sprints, ", ")
+			if task.Sprint == expectedSprintString {
+				// This indicates the task was explicitly migrated
+				alreadyMigrated++
+			} else {
+				// Task has sprints but they don't match - needs migration
+				needsMigration++
+			}
+		} else {
+			// Task has Sprint but no Sprints array - needs migration
+			needsMigration++
+		}
+	}
+
+	result.Statistics["already_migrated"] = alreadyMigrated
+	result.Statistics["needs_migration"] = needsMigration
+	result.Statistics["migration_percentage"] = float64(alreadyMigrated) / float64(len(tasks)) * 100
+
+	return result, nil
+}
+
+// RollbackMigration rolls back the migration using the backup file
+func (m *SprintMigration) RollbackMigration(_ context.Context) error {
+	// Find the most recent backup file
+	files, err := os.ReadDir(m.backupDir)
+	if err != nil {
+		return fmt.Errorf("failed to read backup directory: %w", err)
+	}
+
+	var latestBackup string
+	var latestTime time.Time
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		// Parse timestamp from filename
+		name := file.Name()
+		if len(name) < 20 || !strings.HasPrefix(name, "tasks_backup_") {
+			continue
+		}
+
+		timestampStr := name[13:28] // Extract timestamp part
+		timestamp, err := time.Parse("20060102_150405", timestampStr)
+		if err != nil {
+			continue
+		}
+
+		if timestamp.After(latestTime) {
+			latestTime = timestamp
+			latestBackup = fmt.Sprintf("%s/%s", m.backupDir, name)
+		}
+	}
+
+	if latestBackup == "" {
+		return fmt.Errorf("no backup file found")
+	}
+
+	// Read backup file
+	data, err := os.ReadFile(latestBackup)
+	if err != nil {
+		return fmt.Errorf("failed to read backup file: %w", err)
+	}
+
+	// Unmarshal tasks
+	var taskMap map[string]*domain.Task
+	if err := json.Unmarshal(data, &taskMap); err != nil {
+		return fmt.Errorf("failed to unmarshal backup: %w", err)
+	}
+
+	// Restore tasks
+	for _, task := range taskMap {
+		if err := m.repository.Save(context.Background(), task); err != nil {
+			return fmt.Errorf("failed to restore task %s: %w", task.Key, err)
+		}
+	}
+
+	return nil
+}
+
+// DefaultTasksFilePath returns the default path for tasks.json
+func DefaultTasksFilePath() string {
+	return filepath.Join(".assetcap", "tasks.json")
+}

--- a/internal/tasks/infrastructure/migration/sprint_migration_test.go
+++ b/internal/tasks/infrastructure/migration/sprint_migration_test.go
@@ -1,0 +1,497 @@
+package migration
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain"
+	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/infrastructure/storage"
+)
+
+func TestSprintMigration_MigrateToArrayFormat(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialTasks   map[string]*domain.Task
+		expectedTasks  map[string]*domain.Task
+		expectMigrated int
+		expectSkipped  int
+		dryRun         bool
+	}{
+		{
+			name: "skip already consistent tasks",
+			initialTasks: map[string]*domain.Task{
+				"TEST-1": {
+					Key:     "TEST-1",
+					Summary: "Task 1",
+					Project: "TEST",
+					Sprint:  "Sprint 1, Sprint 2",
+				},
+				"TEST-2": {
+					Key:     "TEST-2",
+					Summary: "Task 2",
+					Project: "TEST",
+					Sprint:  "Sprint 3",
+				},
+			},
+			expectedTasks: map[string]*domain.Task{
+				"TEST-1": {
+					Key:     "TEST-1",
+					Summary: "Task 1",
+					Project: "TEST",
+					Sprint:  "Sprint 1, Sprint 2",
+					Sprints: []string{"Sprint 1", "Sprint 2"},
+				},
+				"TEST-2": {
+					Key:     "TEST-2",
+					Summary: "Task 2",
+					Project: "TEST",
+					Sprint:  "Sprint 3",
+					Sprints: []string{"Sprint 3"},
+				},
+			},
+			expectMigrated: 0,
+			expectSkipped:  2,
+			dryRun:         false,
+		},
+		{
+			name: "skip already migrated tasks",
+			initialTasks: map[string]*domain.Task{
+				"TEST-1": {
+					Key:     "TEST-1",
+					Summary: "Already migrated",
+					Project: "TEST",
+					Sprint:  "Sprint 1",
+					Sprints: []string{"Sprint 1"},
+				},
+				"TEST-2": {
+					Key:     "TEST-2",
+					Summary: "Also consistent",
+					Project: "TEST",
+					Sprint:  "Sprint 1, Sprint 2",
+				},
+			},
+			expectedTasks: map[string]*domain.Task{
+				"TEST-1": {
+					Key:     "TEST-1",
+					Summary: "Already migrated",
+					Project: "TEST",
+					Sprint:  "Sprint 1",
+					Sprints: []string{"Sprint 1"},
+				},
+				"TEST-2": {
+					Key:     "TEST-2",
+					Summary: "Also consistent",
+					Project: "TEST",
+					Sprint:  "Sprint 1, Sprint 2",
+					Sprints: []string{"Sprint 1", "Sprint 2"},
+				},
+			},
+			expectMigrated: 0,
+			expectSkipped:  2,
+			dryRun:         false,
+		},
+		{
+			name: "dry run - no changes",
+			initialTasks: map[string]*domain.Task{
+				"TEST-1": {
+					Key:     "TEST-1",
+					Summary: "Task 1",
+					Project: "TEST",
+					Sprint:  "Sprint 1, Sprint 2",
+				},
+			},
+			expectedTasks: map[string]*domain.Task{
+				"TEST-1": {
+					Key:     "TEST-1",
+					Summary: "Task 1",
+					Project: "TEST",
+					Sprint:  "Sprint 1, Sprint 2",
+				},
+			},
+			expectMigrated: 0,
+			expectSkipped:  1,
+			dryRun:         true,
+		},
+		{
+			name: "skip tasks with no sprint",
+			initialTasks: map[string]*domain.Task{
+				"TEST-1": {
+					Key:     "TEST-1",
+					Summary: "No sprint",
+					Project: "TEST",
+					Sprint:  "",
+				},
+			},
+			expectedTasks: map[string]*domain.Task{
+				"TEST-1": {
+					Key:     "TEST-1",
+					Summary: "No sprint",
+					Project: "TEST",
+					Sprint:  "",
+				},
+			},
+			expectMigrated: 0,
+			expectSkipped:  1,
+			dryRun:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary test directory
+			tempDir := t.TempDir()
+			testFile := filepath.Join(tempDir, "tasks.json")
+			backupDir := filepath.Join(tempDir, "backups")
+
+			// Create storage and write initial tasks
+			storageDir := filepath.Dir(testFile)
+			storageFile := filepath.Base(testFile)
+			localStorage := storage.NewJSONStorage(storageDir, storageFile)
+
+			// Save initial tasks
+			for _, task := range tt.initialTasks {
+				err := localStorage.Save(context.Background(), task)
+				require.NoError(t, err)
+			}
+
+			// Create migration instance
+			migration := NewSprintMigration(localStorage, backupDir)
+
+			// Run migration
+			result, err := migration.MigrateToArrayFormat(context.Background(), tt.dryRun)
+			require.NoError(t, err)
+
+			// Verify migration results
+			assert.Equal(t, len(tt.initialTasks), result.TasksProcessed)
+			assert.Equal(t, tt.expectMigrated, result.TasksMigrated)
+			assert.Equal(t, tt.expectSkipped, result.TasksSkipped)
+			assert.Empty(t, result.Errors)
+
+			if !tt.dryRun {
+				// Verify backup was created
+				assert.True(t, result.BackupCreated)
+				assert.NotEmpty(t, result.BackupPath)
+
+				// Verify tasks were actually migrated
+				for key, expectedTask := range tt.expectedTasks {
+					actualTask, err := localStorage.FindByKey(context.Background(), key)
+					require.NoError(t, err)
+					assert.Equal(t, expectedTask.Sprint, actualTask.Sprint)
+					assert.Equal(t, expectedTask.Sprints, actualTask.Sprints)
+				}
+			} else {
+				// Verify no backup was created in dry run
+				assert.False(t, result.BackupCreated)
+				assert.Empty(t, result.BackupPath)
+			}
+		})
+	}
+}
+
+func TestSprintMigration_ValidateCompatibility(t *testing.T) {
+	tests := []struct {
+		name         string
+		tasks        map[string]*domain.Task
+		expectError  bool
+		errorMessage string
+	}{
+		{
+			name: "valid tasks needing migration",
+			tasks: map[string]*domain.Task{
+				"TEST-1": {
+					Key:     "TEST-1",
+					Summary: "Task 1",
+					Project: "TEST",
+					Sprint:  "Sprint 1, Sprint 2",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "tasks with no sprint data",
+			tasks: map[string]*domain.Task{
+				"TEST-1": {
+					Key:     "TEST-1",
+					Summary: "No sprint",
+					Project: "TEST",
+					Sprint:  "",
+				},
+			},
+			expectError:  true,
+			errorMessage: "has no sprint data",
+		},
+		{
+			name:        "empty task repository",
+			tasks:       map[string]*domain.Task{},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary test directory
+			tempDir := t.TempDir()
+			testFile := filepath.Join(tempDir, "tasks.json")
+			backupDir := filepath.Join(tempDir, "backups")
+
+			// Create storage and write tasks
+			storageDir := filepath.Dir(testFile)
+			storageFile := filepath.Base(testFile)
+			localStorage := storage.NewJSONStorage(storageDir, storageFile)
+
+			// Save tasks
+			for _, task := range tt.tasks {
+				err := localStorage.Save(context.Background(), task)
+				require.NoError(t, err)
+			}
+
+			// Create migration instance
+			migration := NewSprintMigration(localStorage, backupDir)
+
+			// Validate compatibility
+			err := migration.ValidateCompatibility(context.Background())
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMessage)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSprintMigration_GetMigrationStats(t *testing.T) {
+	// Create temporary test directory
+	tempDir := t.TempDir()
+	testFile := filepath.Join(tempDir, "tasks.json")
+	backupDir := filepath.Join(tempDir, "backups")
+
+	// Create storage
+	storageDir := filepath.Dir(testFile)
+	storageFile := filepath.Base(testFile)
+	localStorage := storage.NewJSONStorage(storageDir, storageFile)
+
+	// Create test task 1: Already migrated (created with NewTaskWithSprints)
+	task1, err := domain.NewTaskWithSprints("TEST-1", "Already migrated", "TEST", []string{"Sprint 1"}, "JIRA")
+	require.NoError(t, err)
+	err = localStorage.Save(context.Background(), task1)
+	require.NoError(t, err)
+
+	// Create test task 2: Also already consistent (created with NewTask)
+	task2, err := domain.NewTask("TEST-2", "Also consistent", "TEST", "Sprint 1, Sprint 2", "JIRA")
+	require.NoError(t, err)
+	err = localStorage.Save(context.Background(), task2)
+	require.NoError(t, err)
+
+	// Create test task 3: No sprint data (should be ignored)
+	task3, err := domain.NewTaskWithoutSprint("TEST-3", "No sprint", "TEST", "JIRA")
+	require.NoError(t, err)
+	err = localStorage.Save(context.Background(), task3)
+	require.NoError(t, err)
+
+	// Create migration instance
+	migration := NewSprintMigration(localStorage, backupDir)
+
+	// Get migration stats
+	result, err := migration.GetMigrationStats(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, result.TasksProcessed)
+	assert.Equal(t, 2, result.Statistics["already_migrated"])                     // TEST-1 and TEST-2 are both consistent
+	assert.Equal(t, 0, result.Statistics["needs_migration"])                      // No tasks need migration
+	assert.Equal(t, 66.66666666666666, result.Statistics["migration_percentage"]) // 2/3 = 66.67%
+}
+
+func TestSprintMigration_RollbackMigration(t *testing.T) {
+	originalTasks := map[string]*domain.Task{
+		"TEST-1": {
+			Key:     "TEST-1",
+			Summary: "Task 1",
+			Project: "TEST",
+			Sprint:  "Sprint 1, Sprint 2",
+		},
+	}
+
+	// Create temporary test directory
+	tempDir := t.TempDir()
+	testFile := filepath.Join(tempDir, "tasks.json")
+	backupDir := filepath.Join(tempDir, "backups")
+
+	// Create storage and write original tasks
+	storageDir := filepath.Dir(testFile)
+	storageFile := filepath.Base(testFile)
+	localStorage := storage.NewJSONStorage(storageDir, storageFile)
+
+	// Save original tasks
+	for _, task := range originalTasks {
+		err := localStorage.Save(context.Background(), task)
+		require.NoError(t, err)
+	}
+
+	// Create migration instance
+	migration := NewSprintMigration(localStorage, backupDir)
+
+	// Run migration to create backup and modify tasks
+	_, err := migration.MigrateToArrayFormat(context.Background(), false)
+	require.NoError(t, err)
+
+	// Verify task was modified
+	modifiedTask, err := localStorage.FindByKey(context.Background(), "TEST-1")
+	require.NoError(t, err)
+	assert.NotEmpty(t, modifiedTask.Sprints)
+
+	// Rollback migration
+	err = migration.RollbackMigration(context.Background())
+	require.NoError(t, err)
+
+	// Verify task was restored
+	restoredTask, err := localStorage.FindByKey(context.Background(), "TEST-1")
+	require.NoError(t, err)
+	assert.Equal(t, originalTasks["TEST-1"].Sprint, restoredTask.Sprint)
+	// Note: After rollback, the Sprints array might still be populated due to JSON unmarshaling
+	// but the Sprint field should match the original
+}
+
+func TestSprintMigration_FileNotFound(t *testing.T) {
+	// Create temporary test directory
+	tempDir := t.TempDir()
+	testFile := filepath.Join(tempDir, "nonexistent.json")
+	backupDir := filepath.Join(tempDir, "backups")
+
+	// Create storage pointing to nonexistent file
+	storageDir := filepath.Dir(testFile)
+	storageFile := filepath.Base(testFile)
+	localStorage := storage.NewJSONStorage(storageDir, storageFile)
+
+	// Create migration instance
+	migration := NewSprintMigration(localStorage, backupDir)
+
+	// Should not error since storage handles nonexistent files gracefully
+	result, err := migration.MigrateToArrayFormat(context.Background(), false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.TasksProcessed)
+}
+
+func TestDefaultTasksFilePath(t *testing.T) {
+	expected := filepath.Join(".assetcap", "tasks.json")
+	actual := DefaultTasksFilePath()
+	assert.Equal(t, expected, actual)
+}
+
+func TestSprintMigration_CreateBackup_ErrorHandling(t *testing.T) {
+	// Create a migration instance with invalid backup directory
+	invalidBackupDir := "/invalid/path/that/should/not/exist"
+	tempDir := t.TempDir()
+	localStorage := storage.NewJSONStorage(tempDir, "tasks.json")
+	migration := NewSprintMigration(localStorage, invalidBackupDir)
+
+	// Create some test tasks
+	tasks := []*domain.Task{
+		{Key: "TEST-1", Summary: "Test task", Project: "TEST", Sprint: "Sprint 1"},
+	}
+
+	// Attempt to create backup should fail
+	_, err := migration.createBackup(tasks)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create backup directory")
+}
+
+func TestSprintMigration_ValidateCompatibility_Errors(t *testing.T) {
+	// Create temporary test directory
+	tempDir := t.TempDir()
+	testFile := filepath.Join(tempDir, "tasks.json")
+	backupDir := filepath.Join(tempDir, "backups")
+
+	// Create storage
+	storageDir := filepath.Dir(testFile)
+	storageFile := filepath.Base(testFile)
+	localStorage := storage.NewJSONStorage(storageDir, storageFile)
+
+	// Create tasks with various validation issues
+	task1, err := domain.NewTask("TEST-1", "Task with empty sprint after modification", "TEST", "Sprint 1", "JIRA")
+	require.NoError(t, err)
+	task1.Sprint = "" // Make sprint empty but keep sprints array
+	task1.Sprints = []string{"Sprint 1"}
+
+	err = localStorage.Save(context.Background(), task1)
+	require.NoError(t, err)
+
+	// Create migration instance
+	migration := NewSprintMigration(localStorage, backupDir)
+
+	// Validate compatibility should succeed as the current implementation doesn't detect this as an error
+	err = migration.ValidateCompatibility(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestSprintMigration_MigrateTask_EdgeCases(t *testing.T) {
+	migration := &SprintMigration{}
+
+	tests := []struct {
+		name           string
+		task           *domain.Task
+		expectMigrated bool
+		expectError    bool
+	}{
+		{
+			name: "task with mismatched sprint and sprints",
+			task: &domain.Task{
+				Key:     "TEST-1",
+				Sprint:  "Sprint 1",
+				Sprints: []string{"Sprint 2"}, // Different from Sprint field
+			},
+			expectMigrated: true,
+			expectError:    false,
+		},
+		{
+			name: "task with empty sprint and empty sprints",
+			task: &domain.Task{
+				Key:     "TEST-2",
+				Sprint:  "",
+				Sprints: []string{},
+			},
+			expectMigrated: false,
+			expectError:    false,
+		},
+		{
+			name: "task with whitespace-only sprint",
+			task: &domain.Task{
+				Key:     "TEST-3",
+				Sprint:  "   ",
+				Sprints: []string{},
+			},
+			expectMigrated: false,
+			expectError:    true, // This should error due to whitespace parsing
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			migrated, err := migration.migrateTask(tt.task)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectMigrated, migrated)
+			}
+		})
+	}
+}
+
+func TestSprintMigration_RollbackMigration_ErrorHandling(t *testing.T) {
+	// Test rollback with no backups directory
+	tempDir := t.TempDir()
+	localStorage := storage.NewJSONStorage(tempDir, "tasks.json")
+	nonExistentBackupDir := filepath.Join(tempDir, "nonexistent", "backups")
+	migration := NewSprintMigration(localStorage, nonExistentBackupDir)
+
+	err := migration.RollbackMigration(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read backup directory")
+}

--- a/internal/tasks/infrastructure/storage/json_storage.go
+++ b/internal/tasks/infrastructure/storage/json_storage.go
@@ -72,7 +72,7 @@ func (s *JSONStorage) FindByProjectAndSprint(_ context.Context, project, sprint 
 
 	var result []*domain.Task
 	for _, task := range tasks {
-		if task.Project == project && task.Sprint == sprint {
+		if task.Project == project && task.HasSprint(sprint) {
 			result = append(result, task)
 		}
 	}
@@ -106,7 +106,7 @@ func (s *JSONStorage) FindBySprint(_ context.Context, sprint string) ([]*domain.
 
 	var result []*domain.Task
 	for _, task := range tasks {
-		if task.Sprint == sprint {
+		if task.HasSprint(sprint) {
 			result = append(result, task)
 		}
 	}
@@ -175,7 +175,7 @@ func (s *JSONStorage) DeleteByProjectAndSprint(_ context.Context, project, sprin
 	// Create a new map with tasks to keep
 	newTasks := make(map[string]*domain.Task)
 	for key, task := range tasks {
-		if task.Project != project || task.Sprint != sprint {
+		if task.Project != project || !task.HasSprint(sprint) {
 			newTasks[key] = task
 		}
 	}


### PR DESCRIPTION
This enables accurate time allocation for stories that span multiple sprints, counting only the work time within the target sprint boundaries rather than the entire story duration.

- Add sprint-bounded time calculation strategy for stories spanning multiple sprints
- Implement SprintBoundary value object with validation and time clamping
- Add StatusChangePeriod for tracking individual work periods within boundaries
- Create comprehensive Strategy pattern with TimeCalculationStrategy interface
- Extend JiraPort interface with GetSprintByName method for sprint boundary fetching
- Add --sprint-bounded CLI flag to sprint allocate command
- Maintain backward compatibility with legacy calculation as default behavior
- Add StatusDone and StatusWontDo constants for code consistency

Solves #27