### PR TITLE
fix: sort engineer names alphabetically in sprint allocation CSV output

### DIFF
--- a/internal/sprint/application/usecase/sprint_time_allocation.go
+++ b/internal/sprint/application/usecase/sprint_time_allocation.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -406,7 +407,13 @@ func (p *SprintTimeAllocationUseCase) calculatePercentageLoad(team domain.Team, 
 
 func (p *SprintTimeAllocationUseCase) generateCSV(team domain.Team, results []map[string]interface{}) (string, error) {
 	headers := []string{"sprint", "issueKey", "issueType", "issueTitle", "workType", "assetName", "status", "dateStarted", "dateCompleted"}
-	headers = append(headers, team.Team...)
+
+	// Sort engineer names alphabetically before adding to headers
+	sortedTeamMembers := make([]string, len(team.Team))
+	copy(sortedTeamMembers, team.Team)
+	sort.Strings(sortedTeamMembers)
+
+	headers = append(headers, sortedTeamMembers...)
 
 	csvData, err := p.structArrayToCSVOrdered(results, headers)
 	if err != nil {


### PR DESCRIPTION
The sprint allocation CSV was displaying engineer names in the order they appeared in teams.json configuration file instead of alphabetical order.

Changes:
- Added sort import to sprint_time_allocation.go
- Modified generateCSV function to sort team member names before adding to CSV headers
- Created sorted copy of team.Team slice to preserve original data structure
- Fixed formatting issues with linter

This improves readability and consistency of sprint allocation reports by displaying engineer names in a predictable alphabetical order.