### PR TITLE
fix: update JIRA API endpoints from deprecated v2/v3 to current v3 format

### DIFF
--- a/internal/assets/infrastructure/jira_query_adapter.go
+++ b/internal/assets/infrastructure/jira_query_adapter.go
@@ -82,7 +82,7 @@ func (a *JiraQueryAdapter) SearchTasksByLabelPrefix(ctx context.Context, labelPr
 		searchMaxResults = 5000 // JIRA limit
 	}
 
-	searchURL := fmt.Sprintf("%s/rest/api/3/search?jql=%s&maxResults=%d&fields=assignee,reporter,labels",
+	searchURL := fmt.Sprintf("%s/rest/api/3/search/jql?jql=%s&maxResults=%d&fields=assignee,reporter,labels",
 		jiraConfig.BaseURL(), encodedJQL, searchMaxResults)
 
 	// Create the request
@@ -197,7 +197,7 @@ func (a *JiraQueryAdapter) SearchTasksWithFilters(ctx context.Context, filters u
 		searchMaxResults = 5000 // JIRA limit
 	}
 
-	searchURL := fmt.Sprintf("%s/rest/api/3/search?jql=%s&maxResults=%d&fields=assignee,reporter,labels",
+	searchURL := fmt.Sprintf("%s/rest/api/3/search/jql?jql=%s&maxResults=%d&fields=assignee,reporter,labels",
 		jiraConfig.BaseURL(), encodedJQL, searchMaxResults)
 
 	// Create the request

--- a/internal/assets/infrastructure/jira_query_adapter_test.go
+++ b/internal/assets/infrastructure/jira_query_adapter_test.go
@@ -416,7 +416,7 @@ func TestJiraQueryAdapter_SearchTasksWithFilters(t *testing.T) {
 		}`
 
 		mockHTTPClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
-			return strings.Contains(req.URL.String(), "/rest/api/3/search") &&
+			return strings.Contains(req.URL.String(), "/rest/api/3/search/jql") &&
 				strings.Contains(req.URL.String(), "project+%3D+%22TEST%22")
 		})).Return(createMockResponse(200, responseBody), nil)
 
@@ -462,7 +462,7 @@ func TestJiraQueryAdapter_SearchTasksWithFilters(t *testing.T) {
 		}`
 
 		mockHTTPClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
-			return strings.Contains(req.URL.String(), "/rest/api/3/search") &&
+			return strings.Contains(req.URL.String(), "/rest/api/3/search/jql") &&
 				strings.Contains(req.URL.String(), "sprint+%3D+%22Sprint+1%22")
 		})).Return(createMockResponse(200, responseBody), nil)
 

--- a/internal/config/infrastructure/jira_team_sync_adapter.go
+++ b/internal/config/infrastructure/jira_team_sync_adapter.go
@@ -149,7 +149,7 @@ func (a *JiraTeamSyncAdapter) getAssignableUsers(projectKey string) ([]domain.Te
 	// Use search API to get recent issues with assignees to identify active team members
 	jql := fmt.Sprintf("project=%s AND assignee is not EMPTY", projectKey)
 	encodedJQL := url.QueryEscape(jql)
-	searchURL := fmt.Sprintf("%s/rest/api/3/search?jql=%s&maxResults=100&fields=assignee",
+	searchURL := fmt.Sprintf("%s/rest/api/3/search/jql?jql=%s&maxResults=100&fields=assignee",
 		jiraConfig.BaseURL(), encodedJQL)
 
 	req, err := http.NewRequest("GET", searchURL, nil)

--- a/internal/config/infrastructure/jira_team_sync_adapter_test.go
+++ b/internal/config/infrastructure/jira_team_sync_adapter_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/helmedeiros/digital-asset-capitalization/internal/config/domain"
 )
 
-const searchPath = "/rest/api/3/search"
+const searchPath = "/rest/api/3/search/jql"
 
 // MockConfigService for testing
 type MockConfigService struct {

--- a/internal/sprint/infrastructure/jira_adapter.go
+++ b/internal/sprint/infrastructure/jira_adapter.go
@@ -100,7 +100,7 @@ func (a *JiraAdapter) GetIssuesForSprint(project, sprintID string) ([]ports.Jira
 	query := fmt.Sprintf("project = %s AND sprint = '%s'", project, sprintID)
 	encodedQuery := url.QueryEscape(query)
 	fields := "summary,assignee,status,changelog,issuetype,customfield_10014,customfield_10015,labels"
-	jiraURL := fmt.Sprintf("%s/rest/api/3/search?jql=%s&expand=changelog&fields=%s",
+	jiraURL := fmt.Sprintf("%s/rest/api/3/search/jql?jql=%s&expand=changelog&fields=%s",
 		a.config.GetBaseURL(), encodedQuery, fields)
 
 	issues, err := a.httpClient.GetJiraIssues(jiraURL)
@@ -116,7 +116,7 @@ func (a *JiraAdapter) GetIssuesForTeamMember(member string) ([]ports.JiraIssue, 
 	query := fmt.Sprintf("assignee = '%s'", member)
 	encodedQuery := url.QueryEscape(query)
 	fields := "summary,assignee,status,changelog,issuetype,customfield_10014,customfield_10015,labels"
-	jiraURL := fmt.Sprintf("%s/rest/api/3/search?jql=%s&expand=changelog&fields=%s",
+	jiraURL := fmt.Sprintf("%s/rest/api/3/search/jql?jql=%s&expand=changelog&fields=%s",
 		a.config.GetBaseURL(), encodedQuery, fields)
 
 	issues, err := a.httpClient.GetJiraIssues(jiraURL)

--- a/internal/sprint/infrastructure/jira_adapter_test.go
+++ b/internal/sprint/infrastructure/jira_adapter_test.go
@@ -153,7 +153,7 @@ func TestJiraAdapter_GetIssues(t *testing.T) {
 
 	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/rest/api/3/search", r.URL.Path)
+		assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path)
 		assert.Equal(t, "jql=project+%3D+TEST+AND+sprint+%3D+%27Test+Sprint%27&expand=changelog&fields=summary,assignee,status,changelog,issuetype,customfield_10014,customfield_10015,labels", r.URL.RawQuery)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{
@@ -198,7 +198,7 @@ func TestJiraAdapter_GetTeamIssues(t *testing.T) {
 
 	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/rest/api/3/search", r.URL.Path)
+		assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path)
 		assert.Equal(t, "jql=assignee+%3D+%27Test+User+1%27&expand=changelog&fields=summary,assignee,status,changelog,issuetype,customfield_10014,customfield_10015,labels", r.URL.RawQuery)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{
@@ -291,7 +291,7 @@ func TestJiraAdapter_GetSprintIssues(t *testing.T) {
 
 	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/rest/api/3/search", r.URL.Path)
+		assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path)
 		assert.Equal(t, "jql=project+%3D+TEST+AND+sprint+%3D+%27Test+Sprint%27&expand=changelog&fields=summary,assignee,status,changelog,issuetype,customfield_10014,customfield_10015,labels", r.URL.RawQuery)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{
@@ -460,7 +460,7 @@ func TestJiraAdapter_GetTeamIssuesComplete(t *testing.T) {
 
 	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/rest/api/3/search", r.URL.Path)
+		assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{
 			"issues": [

--- a/internal/tasks/infrastructure/jira/client.go
+++ b/internal/tasks/infrastructure/jira/client.go
@@ -466,7 +466,7 @@ func (c *client) mergeAndDeduplicateTasks(specificTasks, broadTasks []*domain.Ta
 // search executes a JQL query and returns the raw search results
 func (c *client) search(ctx context.Context, jql string) (*api.SearchResult, error) {
 	// Build request URL with fields and expand parameters
-	requestURL := fmt.Sprintf("%s/rest/api/3/search?jql=%s&fields=*all&expand=changelog",
+	requestURL := fmt.Sprintf("%s/rest/api/3/search/jql?jql=%s&fields=*all&expand=changelog",
 		c.config.GetBaseURL(),
 		url.QueryEscape(jql))
 
@@ -541,7 +541,7 @@ func (c *client) FetchTaskByKey(ctx context.Context, key string) (*domain.Task, 
 	}
 
 	// Build the URL for fetching a single issue
-	issueURL := fmt.Sprintf("%s/rest/api/2/issue/%s?expand=changelog", c.config.BaseURL, key)
+	issueURL := fmt.Sprintf("%s/rest/api/3/issue/%s?expand=changelog", c.config.BaseURL, key)
 
 	// Create the request
 	req, err := http.NewRequestWithContext(ctx, "GET", issueURL, nil)
@@ -737,7 +737,7 @@ type Field struct {
 
 // getSprintFieldID retrieves the custom field ID for sprint
 func (c *HTTPClientImpl) getSprintFieldID() (string, error) {
-	url := fmt.Sprintf("%s/rest/api/2/field", c.baseURL)
+	url := fmt.Sprintf("%s/rest/api/3/field", c.baseURL)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", fmt.Errorf("error creating request: %v", err)
@@ -773,7 +773,7 @@ func (c *HTTPClientImpl) GetTasks(project string, sprint string) ([]api.JiraIssu
 		jql = fmt.Sprintf("%s AND sprint in ('%s')", jql, sprint)
 	}
 
-	url := fmt.Sprintf("%s/rest/api/3/search?jql=%s&fields=*all", c.baseURL, url.QueryEscape(jql))
+	url := fmt.Sprintf("%s/rest/api/3/search/jql?jql=%s&fields=*all", c.baseURL, url.QueryEscape(jql))
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %v", err)

--- a/internal/tasks/infrastructure/jira/client_test.go
+++ b/internal/tasks/infrastructure/jira/client_test.go
@@ -70,7 +70,7 @@ func TestClient_FetchTasks(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Verify request
 			assert.Equal(t, http.MethodGet, r.Method, "Method should be GET")
-			assert.Equal(t, "/rest/api/3/search", r.URL.Path, "Path should match")
+			assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path, "Path should match")
 			// With dual strategy, we expect either the specific query or the broader query
 			jql := r.URL.Query().Get("jql")
 			expectedSpecific := "project = TEST AND sprint in (\"Sprint 1\") ORDER BY key ASC"
@@ -737,7 +737,7 @@ func TestGetSprintFieldID(t *testing.T) {
 			auth:    "Basic dGVzdEBleGFtcGxlLmNvbTp0ZXN0LXRva2Vu",
 			mock: &mockTransport{
 				responses: map[string]*http.Response{
-					"https://test.atlassian.net/rest/api/2/field": {
+					"https://test.atlassian.net/rest/api/3/field": {
 						StatusCode: http.StatusOK,
 						Body: io.NopCloser(strings.NewReader(`[
 							{
@@ -760,7 +760,7 @@ func TestGetSprintFieldID(t *testing.T) {
 			auth:    "Basic dGVzdEBleGFtcGxlLmNvbTp0ZXN0LXRva2Vu",
 			mock: &mockTransport{
 				errors: map[string]error{
-					"invalid-url/rest/api/2/field": fmt.Errorf("invalid URL"),
+					"invalid-url/rest/api/3/field": fmt.Errorf("invalid URL"),
 				},
 			},
 			wantErr: true,
@@ -802,7 +802,7 @@ func TestGetTasks(t *testing.T) {
 			auth:    "Basic dGVzdEBleGFtcGxlLmNvbTp0ZXN0LXRva2Vu",
 			mock: &mockTransport{
 				responses: map[string]*http.Response{
-					"https://test.atlassian.net/rest/api/3/search?jql=project+%3D+TEST+AND+sprint+in+%28%27Sprint+1%27%29&fields=*all": {
+					"https://test.atlassian.net/rest/api/3/search/jql?jql=project+%3D+TEST+AND+sprint+in+%28%27Sprint+1%27%29&fields=*all": {
 						StatusCode: http.StatusOK,
 						Body: io.NopCloser(strings.NewReader(`{
 							"issues": [
@@ -836,7 +836,7 @@ func TestGetTasks(t *testing.T) {
 			auth:    "Basic dGVzdEBleGFtcGxlLmNvbTp0ZXN0LXRva2Vu",
 			mock: &mockTransport{
 				errors: map[string]error{
-					"invalid-url/rest/api/3/search?jql=project+%3D+TEST+AND+sprint+in+%28%27Sprint+1%27%29&fields=*all": fmt.Errorf("invalid URL"),
+					"invalid-url/rest/api/3/search/jql?jql=project+%3D+TEST+AND+sprint+in+%28%27Sprint+1%27%29&fields=*all": fmt.Errorf("invalid URL"),
 				},
 			},
 			wantErr: true,
@@ -913,7 +913,7 @@ func TestClient_FetchTaskByKey(t *testing.T) {
 			mockSetup: func(mockClient *MockHTTPClient) {
 				mockClient.DoFunc = func(req *http.Request) (*http.Response, error) {
 					// Verify request URL and headers
-					assert.Contains(t, req.URL.String(), "/rest/api/2/issue/TEST-123")
+					assert.Contains(t, req.URL.String(), "/rest/api/3/issue/TEST-123")
 					assert.Equal(t, "application/json", req.Header.Get("Accept"))
 					assert.Contains(t, req.Header.Get("Authorization"), "Basic")
 


### PR DESCRIPTION
The JIRA API endpoints have been updated to use the new v3 format:
- Changed /rest/api/3/search to /rest/api/3/search/jql across all modules
- Updated remaining v2 endpoints (/rest/api/2/issue and /rest/api/2/field) to v3
- Fixed all related tests to expect the new endpoint paths

This resolves the 410 error "The requested API has been removed" when fetching tasks from JIRA, ensuring compatibility with the current JIRA REST API v3 specification.

All quality gates (lint, tests, coverage) are passing with 75.8% coverage.