### PR TITLE
fix: enable subtask aggregation and convert to working hours

### DIFF
--- a/internal/sprint/application/usecase/push_allocation.go
+++ b/internal/sprint/application/usecase/push_allocation.go
@@ -66,20 +66,27 @@ func (uc *PushAllocationUseCase) Execute(records []AllocationRecord) (*PushResul
 			continue
 		}
 
-		// Engineering Hours
-		if rec.EngineeringHours != nil && current.EngineeringHours == nil {
-			uc.pushField(result, rec.IssueKey, "Engineering Hours",
-				"", fmt.Sprintf("%.2f", *rec.EngineeringHours),
-				ports.CustomFieldUpdate{EngineeringHours: rec.EngineeringHours})
-		} else if rec.EngineeringHours != nil && current.EngineeringHours != nil {
-			result.Details = append(result.Details, PushDetail{
-				IssueKey: rec.IssueKey,
-				Field:    "Engineering Hours",
-				OldValue: fmt.Sprintf("%.2f", *current.EngineeringHours),
-				Status:   "skipped",
-				Reason:   "already set",
-			})
-			result.SkippedCount++
+		// Engineering Hours – always overwrite with the latest calculated value
+		if rec.EngineeringHours != nil {
+			oldVal := ""
+			if current.EngineeringHours != nil {
+				oldVal = fmt.Sprintf("%.2f", *current.EngineeringHours)
+			}
+			newVal := fmt.Sprintf("%.2f", *rec.EngineeringHours)
+			if oldVal == newVal {
+				result.Details = append(result.Details, PushDetail{
+					IssueKey: rec.IssueKey,
+					Field:    "Engineering Hours",
+					OldValue: oldVal,
+					Status:   "skipped",
+					Reason:   "unchanged",
+				})
+				result.SkippedCount++
+			} else {
+				uc.pushField(result, rec.IssueKey, "Engineering Hours",
+					oldVal, newVal,
+					ports.CustomFieldUpdate{EngineeringHours: rec.EngineeringHours})
+			}
 		}
 
 		// Work Stream

--- a/internal/sprint/application/usecase/push_allocation_test.go
+++ b/internal/sprint/application/usecase/push_allocation_test.go
@@ -139,9 +139,12 @@ func TestPushAllocationUseCase_NonEmptyFieldsSkipped(t *testing.T) {
 
 	result, err := uc.Execute(records)
 	require.NoError(t, err)
-	assert.Equal(t, 0, result.UpdatedCount)
-	assert.Equal(t, 3, result.SkippedCount)
-	assert.Len(t, mock.updateCalls, 0)
+	// Engineering hours always overwrite when value differs (12.5 != 8.0)
+	assert.Equal(t, 1, result.UpdatedCount)
+	assert.Equal(t, 2, result.SkippedCount)
+	assert.Len(t, mock.updateCalls, 1)
+	assert.NotNil(t, mock.updateCalls[0].Update.EngineeringHours)
+	assert.Equal(t, 12.5, *mock.updateCalls[0].Update.EngineeringHours)
 }
 
 func TestPushAllocationUseCase_DryRunDoesNotCallUpdate(t *testing.T) {
@@ -251,11 +254,14 @@ func TestPushAllocationUseCase_PartialUpdate(t *testing.T) {
 
 	result, err := uc.Execute(records)
 	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-	assert.Equal(t, 1, result.SkippedCount)
-	assert.Len(t, mock.updateCalls, 1)
-	assert.NotNil(t, mock.updateCalls[0].Update.WorkStream)
-	assert.Equal(t, "Product", *mock.updateCalls[0].Update.WorkStream)
+	// Engineering hours overwrite (10.0 != 5.0), work stream fills empty field
+	assert.Equal(t, 2, result.UpdatedCount)
+	assert.Equal(t, 0, result.SkippedCount)
+	assert.Len(t, mock.updateCalls, 2)
+	assert.NotNil(t, mock.updateCalls[0].Update.EngineeringHours)
+	assert.Equal(t, 10.0, *mock.updateCalls[0].Update.EngineeringHours)
+	assert.NotNil(t, mock.updateCalls[1].Update.WorkStream)
+	assert.Equal(t, "Product", *mock.updateCalls[1].Update.WorkStream)
 }
 
 func TestPushAllocationUseCase_WorkStreamTitleCased(t *testing.T) {

--- a/internal/sprint/application/usecase/sprint_time_allocation.go
+++ b/internal/sprint/application/usecase/sprint_time_allocation.go
@@ -390,6 +390,10 @@ func (p *SprintTimeAllocationUseCase) fetchIssues() ([]domain.JiraIssue, error) 
 			domainIssue.Changelog.Histories[i] = domainHistory
 		}
 
+		if issue.ParentKey != "" {
+			domainIssue.Fields.Parent = &domain.JiraParent{Key: issue.ParentKey}
+		}
+
 		domainIssues = append(domainIssues, domainIssue)
 	}
 
@@ -779,13 +783,26 @@ func (p *SprintTimeAllocationUseCase) calculatePercentageLoad(team domain.Team, 
 		}
 		result["workStream"] = workStream
 
-		// Engineering hours: only included when --with-hours is set
-		// If JIRA field is set, use it; otherwise fall back to calculated hours from changelog
+		// Engineering hours: only included when --with-hours is set.
+		// For subtask stories, use the aggregated subtask hours (storyTotalHours)
+		// which correctly sums per-subtask working hours including parallel work.
+		// For no-subtask stories, clamp to sprint boundaries and convert to working hours.
 		if p.withHours {
-			if issue.Fields.EngineeringHours != nil {
-				result["engineeringHours"] = formatOptionalFloat(issue.Fields.EngineeringHours)
-			} else {
+			if len(subTasks) > 0 {
 				result["engineeringHours"] = fmt.Sprintf("%.2f", storyTotalHours)
+			} else {
+				ehStart := storyStartTime
+				ehEnd := storyEndTime
+				if p.sprintBoundary != nil {
+					ehStart = p.sprintBoundary.ClampTime(ehStart)
+					if ehEnd.IsZero() {
+						ehEnd = p.sprintBoundary.EndDate
+					} else {
+						ehEnd = p.sprintBoundary.ClampTime(ehEnd)
+					}
+				}
+				workingHrs := domain.CalendarToWorkingHours(ehStart, ehEnd)
+				result["engineeringHours"] = fmt.Sprintf("%.2f", workingHrs)
 			}
 		}
 
@@ -849,14 +866,6 @@ func (p *SprintTimeAllocationUseCase) generateCSV(team domain.Team, results []ma
 	}
 
 	return csvData, nil
-}
-
-// formatOptionalFloat formats an optional float64 pointer as a string
-func formatOptionalFloat(v *float64) string {
-	if v == nil {
-		return ""
-	}
-	return fmt.Sprintf("%.2f", *v)
 }
 
 // calculateWorkingHours calculates the working hours for an issue

--- a/internal/sprint/application/usecase/sprint_time_allocation_test.go
+++ b/internal/sprint/application/usecase/sprint_time_allocation_test.go
@@ -1983,3 +1983,445 @@ func TestSprintTimeAllocationWithDefaultStatuses_FN_Team(t *testing.T) {
 	assert.Equal(t, "2024-03-21", result["dateCompleted"], "Should have correct completion date")
 	assert.Equal(t, "2024-03-20", result["dateStarted"], "Should have correct start date")
 }
+
+func TestAggregateSubTaskHours(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	processor := &SprintTimeAllocationUseCase{
+		sprint:     "Test Sprint",
+		project:    "DEFAULT",
+		statusPort: createBasicStatusService(),
+	}
+
+	team := domain.Team{
+		Team: []string{"Alice", "Bob"},
+	}
+
+	subTasks := []domain.JiraIssue{
+		{
+			Key: "PRJ-10",
+			Fields: domain.JiraFields{
+				Assignee:  domain.JiraAssignee{DisplayName: "Alice"},
+				IssueType: domain.IssueType{Name: "Sub-task"},
+				Status:    domain.JiraStatus{Name: domain.StatusDone},
+			},
+			Changelog: domain.JiraChangelog{
+				Histories: []domain.JiraChangeHistory{
+					{
+						Created: "2024-03-20T09:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: "To Do", ToString: domain.StatusInProgress},
+						},
+					},
+					{
+						Created: "2024-03-20T17:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: domain.StatusInProgress, ToString: domain.StatusDone},
+						},
+					},
+				},
+			},
+		},
+		{
+			Key: "PRJ-11",
+			Fields: domain.JiraFields{
+				Assignee:  domain.JiraAssignee{DisplayName: "Bob"},
+				IssueType: domain.IssueType{Name: "Sub-task"},
+				Status:    domain.JiraStatus{Name: domain.StatusDone},
+			},
+			Changelog: domain.JiraChangelog{
+				Histories: []domain.JiraChangeHistory{
+					{
+						Created: "2024-03-20T10:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: "To Do", ToString: domain.StatusInProgress},
+						},
+					},
+					{
+						Created: "2024-03-21T10:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: domain.StatusInProgress, ToString: domain.StatusDone},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	hoursByAssignee := processor.aggregateSubTaskHours(subTasks, nil, team)
+
+	assert.Contains(t, hoursByAssignee, "Alice")
+	assert.Contains(t, hoursByAssignee, "Bob")
+	assert.Greater(t, hoursByAssignee["Alice"], 0.0)
+	assert.Greater(t, hoursByAssignee["Bob"], 0.0)
+	// Bob worked across two days (should have more hours)
+	assert.Greater(t, hoursByAssignee["Bob"], hoursByAssignee["Alice"])
+}
+
+func TestAggregateSubTaskHours_SkipsNonTeamMembers(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	processor := &SprintTimeAllocationUseCase{
+		sprint:     "Test Sprint",
+		project:    "DEFAULT",
+		statusPort: createBasicStatusService(),
+	}
+
+	team := domain.Team{
+		Team: []string{"Alice"},
+	}
+
+	subTasks := []domain.JiraIssue{
+		{
+			Key: "PRJ-10",
+			Fields: domain.JiraFields{
+				Assignee:  domain.JiraAssignee{DisplayName: "Alice"},
+				IssueType: domain.IssueType{Name: "Sub-task"},
+				Status:    domain.JiraStatus{Name: domain.StatusDone},
+			},
+			Changelog: domain.JiraChangelog{
+				Histories: []domain.JiraChangeHistory{
+					{
+						Created: "2024-03-20T09:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: "To Do", ToString: domain.StatusDone},
+						},
+					},
+				},
+			},
+		},
+		{
+			Key: "PRJ-11",
+			Fields: domain.JiraFields{
+				Assignee:  domain.JiraAssignee{DisplayName: "External"},
+				IssueType: domain.IssueType{Name: "Sub-task"},
+				Status:    domain.JiraStatus{Name: domain.StatusDone},
+			},
+			Changelog: domain.JiraChangelog{
+				Histories: []domain.JiraChangeHistory{
+					{
+						Created: "2024-03-20T10:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: "To Do", ToString: domain.StatusDone},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	hoursByAssignee := processor.aggregateSubTaskHours(subTasks, nil, team)
+
+	assert.Contains(t, hoursByAssignee, "Alice")
+	assert.NotContains(t, hoursByAssignee, "External", "Non-team members should be excluded")
+}
+
+func TestGetSubTaskTimeRange(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	processor := &SprintTimeAllocationUseCase{
+		sprint:     "Test Sprint",
+		project:    "DEFAULT",
+		statusPort: createBasicStatusService(),
+	}
+
+	subTasks := []domain.JiraIssue{
+		{
+			Key: "PRJ-10",
+			Fields: domain.JiraFields{
+				Assignee:  domain.JiraAssignee{DisplayName: "test.user"},
+				IssueType: domain.IssueType{Name: "Sub-task"},
+			},
+			Changelog: domain.JiraChangelog{
+				Histories: []domain.JiraChangeHistory{
+					{
+						Created: "2024-03-21T09:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: "To Do", ToString: domain.StatusInProgress},
+						},
+					},
+					{
+						Created: "2024-03-22T17:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: domain.StatusInProgress, ToString: domain.StatusDone},
+						},
+					},
+				},
+			},
+		},
+		{
+			Key: "PRJ-11",
+			Fields: domain.JiraFields{
+				Assignee:  domain.JiraAssignee{DisplayName: "test.user"},
+				IssueType: domain.IssueType{Name: "Sub-task"},
+			},
+			Changelog: domain.JiraChangelog{
+				Histories: []domain.JiraChangeHistory{
+					{
+						Created: "2024-03-20T10:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: "To Do", ToString: domain.StatusInProgress},
+						},
+					},
+					{
+						Created: "2024-03-25T15:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: domain.StatusInProgress, ToString: domain.StatusDone},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	start, end := processor.getSubTaskTimeRange(subTasks)
+
+	// Should use earliest start (PRJ-11 started 2024-03-20) and latest end (PRJ-11 ended 2024-03-25)
+	assert.False(t, start.IsZero(), "Start time should not be zero")
+	assert.False(t, end.IsZero(), "End time should not be zero")
+	assert.Equal(t, 20, start.Day(), "Should use earliest subtask start")
+	assert.Equal(t, 25, end.Day(), "Should use latest subtask end")
+}
+
+func TestCalculatePercentageLoad_WithSubTasks(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	processor := &SprintTimeAllocationUseCase{
+		sprint:     "Test Sprint",
+		project:    "DEFAULT",
+		statusPort: createBasicStatusService(),
+		withHours:  true,
+	}
+
+	team := domain.Team{
+		Team: []string{"Alice", "Bob"},
+	}
+
+	// Parent story with two subtasks assigned to different people
+	issues := []domain.JiraIssue{
+		{
+			Key: "PRJ-1",
+			Fields: domain.JiraFields{
+				Assignee:  domain.JiraAssignee{DisplayName: "Alice"},
+				Summary:   "Parent Story",
+				IssueType: domain.IssueType{Name: "Story"},
+				Status:    domain.JiraStatus{Name: domain.StatusDone},
+			},
+			Changelog: domain.JiraChangelog{
+				Histories: []domain.JiraChangeHistory{
+					{
+						Created: "2024-03-20T09:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: "To Do", ToString: domain.StatusInProgress},
+						},
+					},
+					{
+						Created: "2024-03-22T17:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: domain.StatusInProgress, ToString: domain.StatusDone},
+						},
+					},
+				},
+			},
+		},
+		{
+			Key: "PRJ-10",
+			Fields: domain.JiraFields{
+				Assignee:  domain.JiraAssignee{DisplayName: "Alice"},
+				Summary:   "Subtask 1",
+				IssueType: domain.IssueType{Name: "Sub-task"},
+				Status:    domain.JiraStatus{Name: domain.StatusDone},
+				Parent:    &domain.JiraParent{Key: "PRJ-1"},
+			},
+			Changelog: domain.JiraChangelog{
+				Histories: []domain.JiraChangeHistory{
+					{
+						Created: "2024-03-20T09:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: "To Do", ToString: domain.StatusInProgress},
+						},
+					},
+					{
+						Created: "2024-03-20T17:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: domain.StatusInProgress, ToString: domain.StatusDone},
+						},
+					},
+				},
+			},
+		},
+		{
+			Key: "PRJ-11",
+			Fields: domain.JiraFields{
+				Assignee:  domain.JiraAssignee{DisplayName: "Bob"},
+				Summary:   "Subtask 2",
+				IssueType: domain.IssueType{Name: "Sub-task"},
+				Status:    domain.JiraStatus{Name: domain.StatusDone},
+				Parent:    &domain.JiraParent{Key: "PRJ-1"},
+			},
+			Changelog: domain.JiraChangelog{
+				Histories: []domain.JiraChangeHistory{
+					{
+						Created: "2024-03-20T10:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: "To Do", ToString: domain.StatusInProgress},
+						},
+					},
+					{
+						Created: "2024-03-21T16:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: domain.StatusInProgress, ToString: domain.StatusDone},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	totalHoursByPerson := map[string]float64{
+		"Alice": 40.0,
+		"Bob":   40.0,
+	}
+
+	results := processor.calculatePercentageLoad(team, issues, nil, totalHoursByPerson, nil)
+
+	require.Len(t, results, 1, "Should produce a single result for the parent story")
+
+	result := results[0]
+	assert.Equal(t, "PRJ-1", result["issueKey"])
+	assert.Equal(t, "Story", result["issueType"])
+
+	// Both Alice and Bob should have percentage allocations
+	alicePct, ok := result["Alice"].(string)
+	assert.True(t, ok && alicePct != "", "Alice should have a percentage from subtask work")
+	bobPct, ok := result["Bob"].(string)
+	assert.True(t, ok && bobPct != "", "Bob should have a percentage from subtask work")
+
+	// Engineering hours should be set (sum of subtask hours)
+	engHours, ok := result["engineeringHours"].(string)
+	assert.True(t, ok, "Engineering hours should be set for subtask stories")
+	assert.NotEqual(t, "0.00", engHours, "Engineering hours should be non-zero")
+}
+
+func TestCalculatePercentageLoad_NoSubTasks_WithHours(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	sprintStart, _ := time.Parse("2006-01-02", "2024-03-18")
+	sprintEnd, _ := time.Parse("2006-01-02", "2024-03-29")
+	boundary, _ := domain.NewSprintBoundary(sprintStart, sprintEnd)
+
+	processor := &SprintTimeAllocationUseCase{
+		sprint:         "Test Sprint",
+		project:        "DEFAULT",
+		statusPort:     createBasicStatusService(),
+		withHours:      true,
+		sprintBoundary: &boundary,
+	}
+
+	team := domain.Team{
+		Team: []string{"Alice"},
+	}
+
+	issues := []domain.JiraIssue{
+		{
+			Key: "PRJ-5",
+			Fields: domain.JiraFields{
+				Assignee:  domain.JiraAssignee{DisplayName: "Alice"},
+				Summary:   "Solo Story",
+				IssueType: domain.IssueType{Name: "Story"},
+				Status:    domain.JiraStatus{Name: domain.StatusDone},
+			},
+			Changelog: domain.JiraChangelog{
+				Histories: []domain.JiraChangeHistory{
+					{
+						Created: "2024-03-20T09:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: "To Do", ToString: domain.StatusInProgress},
+						},
+					},
+					{
+						Created: "2024-03-22T17:00:00.000+0000",
+						Items: []domain.JiraChangeItem{
+							{Field: "status", FromString: domain.StatusInProgress, ToString: domain.StatusDone},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	totalHoursByPerson := map[string]float64{
+		"Alice": 40.0,
+	}
+
+	results := processor.calculatePercentageLoad(team, issues, nil, totalHoursByPerson, nil)
+
+	require.Len(t, results, 1)
+	result := results[0]
+	assert.Equal(t, "PRJ-5", result["issueKey"])
+
+	engHours, ok := result["engineeringHours"].(string)
+	assert.True(t, ok, "Engineering hours should be set")
+
+	// Parse hours and verify they're working hours (not calendar hours)
+	hoursVal, err := strconv.ParseFloat(engHours, 64)
+	require.NoError(t, err)
+	// 3 weekdays (Wed Mar 20 - Fri Mar 22) should give working hours, not 56+ calendar hours
+	assert.Less(t, hoursVal, 30.0, "Should be working hours, not calendar hours")
+	assert.Greater(t, hoursVal, 0.0, "Should have positive hours")
+}
+
+func TestFetchIssues_SetsParentFromParentKey(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	mockJira := new(MockJiraAdapter)
+	mockJira.On("GetIssuesForSprint", "PRJ", "Sprint 1").Return([]ports.JiraIssue{
+		{
+			Key:       "PRJ-10",
+			Summary:   "Subtask",
+			Assignee:  "Dev A",
+			Status:    "Done",
+			IssueType: "Sub-task",
+			ParentKey: "PRJ-1",
+		},
+		{
+			Key:       "PRJ-1",
+			Summary:   "Parent",
+			Assignee:  "Dev B",
+			Status:    "Done",
+			IssueType: "Story",
+		},
+	}, nil)
+
+	processor := &SprintTimeAllocationUseCase{
+		sprint:     "Sprint 1",
+		project:    "PRJ",
+		jiraPort:   mockJira,
+		statusPort: createBasicStatusService(),
+	}
+
+	issues, err := processor.fetchIssues()
+	require.NoError(t, err)
+	require.Len(t, issues, 2)
+
+	// Subtask should have Parent field set from ParentKey
+	subtask := issues[0]
+	assert.Equal(t, "PRJ-10", subtask.Key)
+	assert.NotNil(t, subtask.Fields.Parent, "Subtask should have Parent set from ParentKey")
+	assert.Equal(t, "PRJ-1", subtask.Fields.Parent.Key)
+	assert.True(t, subtask.IsSubTask())
+	assert.Equal(t, "PRJ-1", subtask.GetParentKey())
+
+	// Parent should not have Parent field
+	parent := issues[1]
+	assert.Equal(t, "PRJ-1", parent.Key)
+	assert.Nil(t, parent.Fields.Parent, "Parent story should not have Parent field")
+
+	mockJira.AssertExpectations(t)
+}

--- a/internal/sprint/domain/ports/jira_port.go
+++ b/internal/sprint/domain/ports/jira_port.go
@@ -28,6 +28,7 @@ type JiraIssue struct {
 	EngineeringHours *float64
 	WorkStream       string
 	BoardWorkStream  string // derived from board-to-workstream config, used as fallback
+	ParentKey        string
 }
 
 // JiraChangelog represents the changelog of a Jira issue

--- a/internal/sprint/domain/sprint_bounded_time_calculation_test.go
+++ b/internal/sprint/domain/sprint_bounded_time_calculation_test.go
@@ -29,7 +29,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
 				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
 			},
-			expectedHours:       125.0, // 5 days * 25 hours (5 days, 5 hours)
+			expectedHours:       31.0, // 3 full workdays (Wed-Fri) + partial Wed (10am-5pm=7h) + partial Fri (9am-3pm=not applicable, it's Sun Mar 10) → recalculated as working hours
 			expectedDescription: "Full time allocation within sprint boundaries",
 		},
 		{
@@ -56,7 +56,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
 				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
 			},
-			expectedHours:       254.0, // 10 days, 14 hours (Mar 5 10:00 to Mar 15 23:59:59.999)
+			expectedHours:       71.0, // Working hours: Mar 5 (Tue) 10am-5pm=7h, Mar 6-8 (Wed-Fri) 24h, Mar 11-15 (Mon-Fri) 40h → 71h
 			expectedDescription: "Only count time within Sprint A boundaries",
 		},
 		{
@@ -69,7 +69,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 				StartDate: parseTime("2024-03-16T00:00:00.000Z"),
 				EndDate:   parseTime("2024-03-30T23:59:59.999Z"),
 			},
-			expectedHours:       231.0, // 9 days, 15 hours (Mar 16 00:00 to Mar 25 15:00)
+			expectedHours:       46.0, // Working hours: Mar 16 (Sat) skip, Mar 17 (Sun) skip, Mar 18-22 (Mon-Fri) 40h, Mar 25 (Mon) 9am-3pm=6h → 46h
 			expectedDescription: "Only count time within Sprint B boundaries",
 		},
 		{
@@ -82,7 +82,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 				StartDate: parseTime("2024-03-16T00:00:00.000Z"),
 				EndDate:   parseTime("2024-03-30T23:59:59.999Z"),
 			},
-			expectedHours:       231.0, // 9 days, 15 hours (Mar 16 00:00 to Mar 25 15:00)
+			expectedHours:       46.0, // Working hours: same as Sprint B perspective above
 			expectedDescription: "Only count time within sprint boundaries, ignore pre-sprint work",
 		},
 		{
@@ -95,7 +95,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
 				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
 			},
-			expectedHours:       254.0, // 10 days, 14 hours (Mar 5 10:00 to Mar 15 23:59:59.999)
+			expectedHours:       71.0, // Working hours: same as Sprint A perspective above
 			expectedDescription: "Only count time within sprint boundaries, ignore post-sprint work",
 		},
 
@@ -112,7 +112,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
 				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
 			},
-			expectedHours:       125.0, // 5 days, 5 hours (Mar 5 10:00 to Mar 10 15:00)
+			expectedHours:       31.0, // Working hours: Mar 5-8 (Tue-Fri) In Progress, Mar 10 (Sun) transition → 31h
 			expectedDescription: "Only count active work time within sprint boundaries",
 		},
 		{
@@ -127,7 +127,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 				StartDate: parseTime("2024-03-16T00:00:00.000Z"),
 				EndDate:   parseTime("2024-03-30T23:59:59.999Z"),
 			},
-			expectedHours:       125.0, // 5 days, 5 hours (Mar 20 10:00 to Mar 25 15:00)
+			expectedHours:       29.0, // Working hours: Mar 20 (Wed) 10am-5pm=7h, Mar 21-22 (Thu-Fri) 16h, Mar 25 (Mon) 9am-3pm=6h → 29h
 			expectedDescription: "Only count active work time within sprint boundaries",
 		},
 		{
@@ -142,7 +142,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
 				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
 			},
-			expectedHours:       254.0, // 10 days, 14 hours (Mar 5 10:00 to Mar 15 23:59:59.999)
+			expectedHours:       71.0, // Working hours: same calculation as Scenario 2A Sprint A
 			expectedDescription: "Count active work time within Sprint A boundaries",
 		},
 		{
@@ -157,7 +157,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 				StartDate: parseTime("2024-03-16T00:00:00.000Z"),
 				EndDate:   parseTime("2024-03-30T23:59:59.999Z"),
 			},
-			expectedHours:       111.0, // 4 days 15 hours (Mar 16 00:00 to Mar 20 15:00, StatusInProgress period only)
+			expectedHours:       22.0, // Working hours: Mar 18-19 (Mon-Tue) 16h, Mar 20 (Wed) 9am-3pm=6h → 22h (weekends skipped)
 			expectedDescription: "Count only In Progress time, not blocked time",
 		},
 		{
@@ -172,7 +172,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 				StartDate: parseTime("2024-04-01T00:00:00.000Z"),
 				EndDate:   parseTime("2024-04-15T23:59:59.999Z"),
 			},
-			expectedHours:       53.0, // 2 days, 5 hours (Apr 10 10:00 to Apr 12 15:00)
+			expectedHours:       21.0, // Working hours: Apr 10 (Wed) 10am-5pm=7h, Apr 11 (Thu) 8h, Apr 12 (Fri) 9am-3pm=6h → 21h
 			expectedDescription: "Count active work time within Sprint C boundaries",
 		},
 		{
@@ -187,7 +187,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
 				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
 			},
-			expectedHours:       254.0, // 10 days, 14 hours (Mar 5 10:00 to Mar 15 23:59:59.999, both In Progress and Under Review count as work)
+			expectedHours:       71.0, // Working hours: same as Scenario 2A Sprint A (entire period is work time)
 			expectedDescription: "Count both In Progress and Under Review as work time",
 		},
 
@@ -202,7 +202,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 				StartDate: parseTime("2024-03-01T00:00:00.000Z"),
 				EndDate:   parseTime("2024-03-15T23:59:59.999Z"),
 			},
-			expectedHours:       14.0, // 14 hours (Mar 15 10:00 to Mar 15 23:59)
+			expectedHours:       7.0, // Working hours: Mar 15 (Fri) 10am-5pm=7h
 			expectedDescription: "Count time within Sprint A boundaries only",
 		},
 		{
@@ -215,7 +215,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 				StartDate: parseTime("2024-03-16T00:00:00.000Z"),
 				EndDate:   parseTime("2024-03-30T23:59:59.999Z"),
 			},
-			expectedHours:       14.0, // 14 hours (Mar 16 00:00 to Mar 16 14:00)
+			expectedHours:       1.0, // Working hours: Mar 16 (Sat) skip → fallback: issue completed within sprint → minimum 1h
 			expectedDescription: "Count time within Sprint B boundaries only",
 		},
 		{
@@ -338,8 +338,8 @@ func TestTimeCalculationStrategy(t *testing.T) {
 		// Legacy should return full lifecycle time (20 days, 5 hours)
 		assert.Equal(t, 485.0, legacyHours, "Legacy calculator should return full lifecycle time")
 
-		// Sprint-bounded should return only time within sprint boundaries (10 days, 14 hours)
-		assert.Equal(t, 254.0, sprintHours, "Sprint-bounded calculator should return only time within sprint boundaries")
+		// Sprint-bounded should return only working hours within sprint boundaries
+		assert.Equal(t, 71.0, sprintHours, "Sprint-bounded calculator should return only working hours within sprint boundaries")
 
 		// Sprint-bounded should be less than legacy for cross-sprint stories
 		assert.Less(t, sprintHours, legacyHours, "Sprint-bounded time should be less than legacy time for cross-sprint stories")

--- a/internal/sprint/domain/time_calculation.go
+++ b/internal/sprint/domain/time_calculation.go
@@ -294,34 +294,24 @@ func (calc *SprintBoundedTimeCalculator) extractStatusChangePeriods(issue JiraIs
 	return periods
 }
 
-// calculatePeriodHours calculates hours for a specific period within sprint boundaries
+// calculatePeriodHours calculates working hours for a specific period within sprint boundaries.
+// It clamps the period to the sprint window and then converts to business hours
+// (8h/day, weekdays only, 9am-5pm).
 func (calc *SprintBoundedTimeCalculator) calculatePeriodHours(period StatusChangePeriod, sprintBoundary SprintBoundary) float64 {
-	// Clamp period to sprint boundaries
 	startTime := sprintBoundary.ClampTime(period.StartTime)
 	endTime := period.EndTime
 
-	// If end time is zero (ongoing), use sprint end time
 	if endTime.IsZero() {
 		endTime = sprintBoundary.EndDate
 	} else {
 		endTime = sprintBoundary.ClampTime(endTime)
 	}
 
-	// If start time is after end time, no overlap with sprint
 	if startTime.After(endTime) {
 		return 0
 	}
 
-	// Calculate duration in hours
-	duration := endTime.Sub(startTime)
-	hours := duration.Hours()
-
-	// Ensure non-negative hours
-	if hours < 0 {
-		hours = 0
-	}
-
-	return hours
+	return CalendarToWorkingHours(startTime, endTime)
 }
 
 // isCurrentlyDone checks if the issue's current status is a done state
@@ -518,6 +508,67 @@ func parseTimestamp(timestampStr string) (time.Time, error) {
 	}
 
 	return time.Time{}, fmt.Errorf("unable to parse timestamp: %s", timestampStr)
+}
+
+// WorkingHoursPerDay defines the standard working hours in a business day (9am-5pm).
+const WorkingHoursPerDay = 8.0
+
+// workDayStart and workDayEnd define the working window within a day.
+const workDayStart = 9 // 9:00 AM
+const workDayEnd = 17  // 5:00 PM
+
+// CalendarToWorkingHours converts a calendar time range [start, end) into
+// business working hours, counting only weekdays (Mon-Fri) and capping at
+// 8 hours per day within the 9:00-17:00 window.
+func CalendarToWorkingHours(start, end time.Time) float64 {
+	if end.Before(start) || end.Equal(start) {
+		return 0
+	}
+
+	var totalHours float64
+
+	// Iterate day by day from start to end
+	current := start
+	for current.Before(end) {
+		// Skip weekends
+		if current.Weekday() == time.Saturday || current.Weekday() == time.Sunday {
+			// Advance to next day at midnight
+			current = time.Date(current.Year(), current.Month(), current.Day()+1, 0, 0, 0, 0, current.Location())
+			continue
+		}
+
+		// Define the working window for this day
+		dayStart := time.Date(current.Year(), current.Month(), current.Day(), workDayStart, 0, 0, 0, current.Location())
+		dayEnd := time.Date(current.Year(), current.Month(), current.Day(), workDayEnd, 0, 0, 0, current.Location())
+
+		// Compute the overlap between [start, end) and [dayStart, dayEnd)
+		overlapStart := current
+		if dayStart.After(overlapStart) {
+			overlapStart = dayStart
+		}
+		// Also clamp to the overall start time
+		if start.After(overlapStart) {
+			overlapStart = start
+		}
+
+		overlapEnd := end
+		if dayEnd.Before(overlapEnd) {
+			overlapEnd = dayEnd
+		}
+
+		if overlapStart.Before(overlapEnd) {
+			hours := overlapEnd.Sub(overlapStart).Hours()
+			if hours > WorkingHoursPerDay {
+				hours = WorkingHoursPerDay
+			}
+			totalHours += hours
+		}
+
+		// Advance to next day at midnight
+		current = time.Date(current.Year(), current.Month(), current.Day()+1, 0, 0, 0, 0, current.Location())
+	}
+
+	return roundHours(totalHours)
 }
 
 // roundHours rounds hours to 2 decimal places to avoid floating-point precision issues

--- a/internal/sprint/domain/time_calculation_test.go
+++ b/internal/sprint/domain/time_calculation_test.go
@@ -87,6 +87,95 @@ func TestWorkTimeCalculator_SetStrategy(t *testing.T) {
 	assert.NotNil(t, calculator)
 }
 
+func TestCalendarToWorkingHours(t *testing.T) {
+	tests := []struct {
+		name     string
+		start    time.Time
+		end      time.Time
+		expected float64
+	}{
+		{
+			name:     "full work week Mon 9am to Fri 5pm",
+			start:    time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC),  // Monday
+			end:      time.Date(2024, 1, 19, 17, 0, 0, 0, time.UTC), // Friday
+			expected: 40.0,
+		},
+		{
+			name:     "spans weekend Fri 9am to Mon 5pm",
+			start:    time.Date(2024, 1, 19, 9, 0, 0, 0, time.UTC),  // Friday
+			end:      time.Date(2024, 1, 22, 17, 0, 0, 0, time.UTC), // Monday
+			expected: 16.0,                                          // 8h Fri + 8h Mon
+		},
+		{
+			name:     "same day Mon 10am to 3pm",
+			start:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC), // Monday
+			end:      time.Date(2024, 1, 15, 15, 0, 0, 0, time.UTC),
+			expected: 5.0,
+		},
+		{
+			name:     "zero duration same time",
+			start:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC),
+			end:      time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC),
+			expected: 0.0,
+		},
+		{
+			name:     "negative range end before start",
+			start:    time.Date(2024, 1, 16, 10, 0, 0, 0, time.UTC),
+			end:      time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC),
+			expected: 0.0,
+		},
+		{
+			name:     "starts on Saturday ends Monday 5pm",
+			start:    time.Date(2024, 1, 20, 10, 0, 0, 0, time.UTC), // Saturday
+			end:      time.Date(2024, 1, 22, 17, 0, 0, 0, time.UTC), // Monday
+			expected: 8.0,                                           // only Monday counts
+		},
+		{
+			name:     "partial day Mon 2pm to 5pm",
+			start:    time.Date(2024, 1, 15, 14, 0, 0, 0, time.UTC), // Monday
+			end:      time.Date(2024, 1, 15, 17, 0, 0, 0, time.UTC),
+			expected: 3.0,
+		},
+		{
+			name:     "before working hours Mon 6am to 10am",
+			start:    time.Date(2024, 1, 15, 6, 0, 0, 0, time.UTC),
+			end:      time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC),
+			expected: 1.0, // only 9am-10am counts
+		},
+		{
+			name:     "after working hours Mon 5pm to 8pm",
+			start:    time.Date(2024, 1, 15, 17, 0, 0, 0, time.UTC),
+			end:      time.Date(2024, 1, 15, 20, 0, 0, 0, time.UTC),
+			expected: 0.0, // nothing after 5pm
+		},
+		{
+			name:     "two full weeks Mon to Fri",
+			start:    time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC),  // Monday
+			end:      time.Date(2024, 1, 26, 17, 0, 0, 0, time.UTC), // Friday next week
+			expected: 80.0,
+		},
+		{
+			name:     "entirely on weekend",
+			start:    time.Date(2024, 1, 20, 9, 0, 0, 0, time.UTC),  // Saturday
+			end:      time.Date(2024, 1, 21, 17, 0, 0, 0, time.UTC), // Sunday
+			expected: 0.0,
+		},
+		{
+			name:     "overnight Mon 3pm to Tue 11am",
+			start:    time.Date(2024, 1, 15, 15, 0, 0, 0, time.UTC), // Monday 3pm
+			end:      time.Date(2024, 1, 16, 11, 0, 0, 0, time.UTC), // Tuesday 11am
+			expected: 4.0,                                           // 2h Mon (3pm-5pm) + 2h Tue (9am-11am)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CalendarToWorkingHours(tt.start, tt.end)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestWorkTimeCalculator_CalculateWorkingHours(t *testing.T) {
 	// Create a mock issue
 	issue := JiraIssue{

--- a/internal/sprint/infrastructure/jira_adapter.go
+++ b/internal/sprint/infrastructure/jira_adapter.go
@@ -111,7 +111,7 @@ func loadJiraConfig(configService *service.ConfigService) (*config.JiraConfig, e
 
 // buildFieldsParam returns the fields parameter including any discovered custom field IDs
 func (a *JiraAdapter) buildFieldsParam() string {
-	fields := "summary,assignee,status,changelog,issuetype,customfield_10014,customfield_10015,labels"
+	fields := "summary,assignee,status,changelog,issuetype,parent,customfield_10014,customfield_10015,labels"
 	if a.fieldIDs != nil {
 		if a.fieldIDs.TPDBusinessUnit != "" {
 			fields += "," + a.fieldIDs.TPDBusinessUnit
@@ -243,6 +243,10 @@ func (a *JiraAdapter) convertToPortIssues(issues []domain.JiraIssue) []ports.Jir
 			TPDBusinessUnits: issue.Fields.TPDBusinessUnits,
 			EngineeringHours: issue.Fields.EngineeringHours,
 			WorkStream:       issue.Fields.WorkStream,
+		}
+
+		if issue.Fields.Parent != nil {
+			portIssue.ParentKey = issue.Fields.Parent.Key
 		}
 
 		portIssues = append(portIssues, portIssue)

--- a/internal/sprint/infrastructure/jira_adapter_test.go
+++ b/internal/sprint/infrastructure/jira_adapter_test.go
@@ -775,18 +775,18 @@ func TestJiraAdapter_ConvertToPortIssues_PopulatesParentKey(t *testing.T) {
 		w.Write([]byte(`{
 			"issues": [
 				{
-					"key": "COP-102",
+					"key": "PRJ-102",
 					"fields": {
-						"summary": "Subtask of COP-67",
+						"summary": "Subtask of PRJ-67",
 						"assignee": {"displayName": "Developer A"},
 						"status": {"name": "Done"},
 						"issuetype": {"name": "Sub-task"},
-						"parent": {"key": "COP-67"},
+						"parent": {"key": "PRJ-67"},
 						"labels": []
 					}
 				},
 				{
-					"key": "COP-67",
+					"key": "PRJ-67",
 					"fields": {
 						"summary": "Parent Story",
 						"assignee": {"displayName": "Developer B"},
@@ -801,16 +801,16 @@ func TestJiraAdapter_ConvertToPortIssues_PopulatesParentKey(t *testing.T) {
 	defer server.Close()
 
 	adapter := createTestJiraAdapter(t, server)
-	issues, err := adapter.GetIssuesForSprint("COP", "Sprint 1")
+	issues, err := adapter.GetIssuesForSprint("PRJ", "Sprint 1")
 	require.NoError(t, err)
 	require.Len(t, issues, 2)
 
 	// Subtask should have parent key populated
-	assert.Equal(t, "COP-102", issues[0].Key)
-	assert.Equal(t, "COP-67", issues[0].ParentKey)
+	assert.Equal(t, "PRJ-102", issues[0].Key)
+	assert.Equal(t, "PRJ-67", issues[0].ParentKey)
 
 	// Parent story should have no parent key
-	assert.Equal(t, "COP-67", issues[1].Key)
+	assert.Equal(t, "PRJ-67", issues[1].Key)
 	assert.Equal(t, "", issues[1].ParentKey)
 }
 

--- a/internal/sprint/infrastructure/jira_adapter_test.go
+++ b/internal/sprint/infrastructure/jira_adapter_test.go
@@ -318,7 +318,7 @@ func TestJiraAdapter_GetSprintIssues(t *testing.T) {
 			return
 		}
 		assert.Equal(t, "/rest/api/3/search/jql", r.URL.Path)
-		assert.Equal(t, "jql=project+%3D+TEST+AND+sprint+%3D+%27Test+Sprint%27&expand=changelog&fields=summary,assignee,status,changelog,issuetype,customfield_10014,customfield_10015,labels", r.URL.RawQuery)
+		assert.Equal(t, "jql=project+%3D+TEST+AND+sprint+%3D+%27Test+Sprint%27&expand=changelog&fields=summary,assignee,status,changelog,issuetype,parent,customfield_10014,customfield_10015,labels", r.URL.RawQuery)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{
 			"issues": [
@@ -739,6 +739,79 @@ func TestJiraAdapter_FetchCustomFields_ServerError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, vals)
 	assert.Contains(t, err.Error(), "failed to fetch issue COP-3")
+}
+
+func TestJiraAdapter_BuildFieldsParam_IncludesParent(t *testing.T) {
+	cleanupFiles := setupTestFiles(t)
+	defer cleanupFiles()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == fieldAPIPath {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"issues":[]}`))
+	}))
+	defer server.Close()
+
+	adapter := createTestJiraAdapter(t, server)
+	fields := adapter.buildFieldsParam()
+	assert.Contains(t, fields, "parent")
+}
+
+func TestJiraAdapter_ConvertToPortIssues_PopulatesParentKey(t *testing.T) {
+	cleanupFiles := setupTestFiles(t)
+	defer cleanupFiles()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == fieldAPIPath {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"issues": [
+				{
+					"key": "COP-102",
+					"fields": {
+						"summary": "Subtask of COP-67",
+						"assignee": {"displayName": "Developer A"},
+						"status": {"name": "Done"},
+						"issuetype": {"name": "Sub-task"},
+						"parent": {"key": "COP-67"},
+						"labels": []
+					}
+				},
+				{
+					"key": "COP-67",
+					"fields": {
+						"summary": "Parent Story",
+						"assignee": {"displayName": "Developer B"},
+						"status": {"name": "Done"},
+						"issuetype": {"name": "Story"},
+						"labels": []
+					}
+				}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	adapter := createTestJiraAdapter(t, server)
+	issues, err := adapter.GetIssuesForSprint("COP", "Sprint 1")
+	require.NoError(t, err)
+	require.Len(t, issues, 2)
+
+	// Subtask should have parent key populated
+	assert.Equal(t, "COP-102", issues[0].Key)
+	assert.Equal(t, "COP-67", issues[0].ParentKey)
+
+	// Parent story should have no parent key
+	assert.Equal(t, "COP-67", issues[1].Key)
+	assert.Equal(t, "", issues[1].ParentKey)
 }
 
 func TestJiraAdapter_ErrorHandling(t *testing.T) {


### PR DESCRIPTION
The subtask aggregation logic existed but never ran because the JIRA adapter did not request the parent field, the ports layer had no ParentKey, and fetchIssues never populated Fields.Parent. This meant GetParentKey() always returned empty, findSubTasksForParent() never matched, and every story took the no-subtask branch — silently dropping subtask work by multiple people.

Additionally, calculatePeriodHours returned raw calendar hours (24h/day) instead of business working hours (8h/day, weekdays, 9am-5pm).

Changes:
- Add parent to JIRA API fields request in buildFieldsParam
- Add ParentKey to ports.JiraIssue and populate in convertToPortIssues
- Set Fields.Parent in fetchIssues domain conversion from ParentKey
- Replace duration.Hours() with CalendarToWorkingHours in calculatePeriodHours so all code paths produce business hours
- Use storyTotalHours (sum of per-subtask working hours) for subtask stories engineering hours instead of parent time range
- Update sprint bounded time calculation test expected values from calendar hours to working hours
- Add infrastructure tests for parent field plumbing