### PR TITLE
fix: preserve existing asset labels and fix asset label generation

### DIFF
--- a/internal/tasks/application/usecase/classify_tasks.go
+++ b/internal/tasks/application/usecase/classify_tasks.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	assetsapp "github.com/helmedeiros/digital-asset-capitalization/internal/assets/application"
+	assetdomain "github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
 	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain"
 	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain/ports"
 )
@@ -493,45 +494,34 @@ func (uc *ClassifyTasksUseCase) buildUpdatedLabels(existingLabels []string, work
 
 // getAssetLabel returns the proper asset label, preferring the asset ID if available
 func (uc *ClassifyTasksUseCase) getAssetLabel(asset interface{}) string {
-	// If we receive a full Asset object, use its ID
-	if assetObj, ok := asset.(interface{ GetID() string }); ok {
+	// If we receive a full Asset object, use its ID or Name
+	if assetObj, ok := asset.(*assetdomain.Asset); ok {
 		id := assetObj.GetID()
-		// Use the ID if it follows the cap-asset-* format
 		if strings.HasPrefix(id, "cap-asset-") {
 			return id
 		}
+		// Fallback to generating from Name
+		if assetObj.Name != "" {
+			return formatAssetLabel(assetObj.Name)
+		}
 	}
 
-	// Fallback: generate from asset name (for backward compatibility)
+	// Fallback: generate from asset name string
 	var assetName string
 	switch v := asset.(type) {
 	case string:
 		assetName = v
 	default:
-		// For assets without proper ID, we need to handle test assets that
-		// are created with direct struct initialization and don't have IDs
-		// but do have Name fields accessible through reflection
-		if asset == nil {
-			assetName = "unknown"
-		} else {
-			// For test purposes, we need a more sophisticated approach
-			// Since tests create assets with struct literals like &Asset{Name: "Test Asset"}
-			// we need to try to access the name through interface conversion
-			typeName := fmt.Sprintf("%T", asset)
-			if strings.Contains(typeName, "Asset") {
-				// Default fallback for test assets - in practice this should be rare
-				// since production assets should have proper IDs
-				assetName = "test-asset"
-			} else {
-				assetName = "unknown"
-			}
-		}
+		assetName = "unknown"
 	}
 
-	// Convert asset name to lowercase and replace spaces with hyphens for label format
-	labelName := strings.ToLower(assetName)
+	return formatAssetLabel(assetName)
+}
+
+// formatAssetLabel converts an asset name to a cap-asset-* label format
+func formatAssetLabel(name string) string {
+	labelName := strings.ToLower(name)
 	labelName = strings.ReplaceAll(labelName, " ", "-")
-	// Remove parentheses and other special characters
 	labelName = strings.ReplaceAll(labelName, "(", "")
 	labelName = strings.ReplaceAll(labelName, ")", "")
 	labelName = strings.ReplaceAll(labelName, "&", "and")

--- a/internal/tasks/application/usecase/classify_tasks_test.go
+++ b/internal/tasks/application/usecase/classify_tasks_test.go
@@ -803,6 +803,62 @@ func TestGetAssetLabel(t *testing.T) {
 	}
 }
 
+func TestGetAssetLabel_WithAssetObject(t *testing.T) {
+	mockLocalRepo := new(MockTaskRepository)
+	mockRemoteRepo := new(MockTaskRepository)
+	mockClassifier := new(MockTaskClassifier)
+	mockUserInput := new(MockUserInput)
+	assetService := testutil.NewMockAssetService()
+	uc := NewClassifyTasksUseCase(mockLocalRepo, mockRemoteRepo, mockClassifier, mockUserInput, assetService, nil)
+
+	t.Run("should use asset ID when it has cap-asset prefix", func(t *testing.T) {
+		asset := &assetsdomain.Asset{ID: "cap-asset-mode-comparison-optimization", Name: "Mode Comparison Optimization"}
+		result := uc.getAssetLabel(asset)
+		assert.Equal(t, "cap-asset-mode-comparison-optimization", result)
+	})
+
+	t.Run("should generate label from asset Name when ID has no cap-asset prefix", func(t *testing.T) {
+		asset := &assetsdomain.Asset{ID: "some-other-id", Name: "Mode Comparison Optimization"}
+		result := uc.getAssetLabel(asset)
+		assert.Equal(t, "cap-asset-mode-comparison-optimization", result)
+	})
+
+	t.Run("should generate label from asset Name when ID is empty", func(t *testing.T) {
+		asset := &assetsdomain.Asset{Name: "Home Page Optimization"}
+		result := uc.getAssetLabel(asset)
+		assert.Equal(t, "cap-asset-home-page-optimization", result)
+	})
+
+	t.Run("should handle asset with special characters in name", func(t *testing.T) {
+		asset := &assetsdomain.Asset{Name: "Dynamic Currency Conversion (DCC)"}
+		result := uc.getAssetLabel(asset)
+		assert.Equal(t, "cap-asset-dynamic-currency-conversion-dcc", result)
+	})
+
+	t.Run("should return unknown for nil asset", func(t *testing.T) {
+		result := uc.getAssetLabel(nil)
+		assert.Equal(t, "cap-asset-unknown", result)
+	})
+}
+
+func TestFormatAssetLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"simple name", "Home Page", "cap-asset-home-page"},
+		{"with ampersand", "Search & Filter", "cap-asset-search-and-filter"},
+		{"with parentheses", "Dynamic Currency Conversion (DCC)", "cap-asset-dynamic-currency-conversion-dcc"},
+		{"already lowercase", "booking success", "cap-asset-booking-success"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatAssetLabel(tt.input))
+		})
+	}
+}
+
 func TestClassifyTasksComprehensive(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/tasks/infrastructure/classifier/asset_classifier.go
+++ b/internal/tasks/infrastructure/classifier/asset_classifier.go
@@ -55,18 +55,8 @@ func (c *ContentBasedAssetClassifier) ClassifyTaskAsset(task *taskdomain.Task) (
 				Reason:     "existing asset label preserved",
 			}
 
-			// SMART LOGIC: Only override existing labels when natural classification
-			// is very strong (>= 0.9). Moderate-confidence natural classifications
-			// (0.7-0.89) should NOT override correct existing labels, as they often
-			// produce incorrect matches based on generic keyword overlap.
-			if naturalClassification.Confidence >= 0.9 {
-				// Natural classification is very strong, override existing label
-				naturalClassification.Reason = fmt.Sprintf("natural classification (%.0f%% confidence) overrides existing label '%s'",
-					naturalClassification.Confidence*100, assetIdentifier)
-				return naturalClassification, nil
-			}
-
-			// Natural classification is not strong enough, preserve existing label
+			// Always preserve existing human-applied labels.
+			// Existing cap-asset-* labels are the most reliable classification source.
 			return existingLabelResult, nil
 		}
 	}

--- a/internal/tasks/infrastructure/classifier/asset_classifier_test.go
+++ b/internal/tasks/infrastructure/classifier/asset_classifier_test.go
@@ -178,6 +178,32 @@ func TestContentBasedAssetClassifier_ClassifyTaskAsset(t *testing.T) {
 			expectedReason:    "no matching asset found",
 		},
 		{
+			name: "existing label preserved even when natural classification is strong",
+			task: &taskdomain.Task{
+				Key:         "TEST-8",
+				Summary:     "AB Mode Comparison on SRP - Desktop Web",
+				Description: "Implement mode comparison feature on search results page",
+				Epic:        "SRP Improvements",
+				Labels:      []string{"cap-asset-mode-comparison", "cap-development"},
+			},
+			assets: []*assetdomain.Asset{
+				{
+					Name:        "Mode Comparison",
+					Description: "Compare different travel modes",
+					Keywords:    []string{"mode", "comparison", "srp"},
+				},
+				{
+					Name:        "Search Results Page",
+					Description: "Search results page optimization",
+					Keywords:    []string{"search", "results", "srp", "filtering"},
+				},
+			},
+			expectedAssetName: "Mode Comparison",
+			expectedMinConf:   0.85,
+			expectedMaxConf:   0.85,
+			expectedReason:    "existing asset label preserved",
+		},
+		{
 			name: "case insensitive matching",
 			task: &taskdomain.Task{
 				Key:         "TEST-7",


### PR DESCRIPTION
The getAssetLabel function was falling back to "test-asset" for all Asset struct inputs because it could not extract the Name field through the generic interface{} parameter. This caused JIRA labels to be set as cap-asset-test-asset instead of the correct asset label.

Fixed by adding a direct type assertion for *assetdomain.Asset to access the Name field when the ID does not have a cap-asset prefix.

Also removed the logic that allowed natural classification to override existing human-applied cap-asset labels. These labels are the most reliable classification source and should always be preserved.