### PR TITLE
fix: use JIRA update operations to prevent overwriting non-cap labels

### DIFF
--- a/internal/deployments/infrastructure/asset_resolver_adapter_test.go
+++ b/internal/deployments/infrastructure/asset_resolver_adapter_test.go
@@ -68,8 +68,8 @@ func (m *MockTaskRepository) DeleteByProjectAndSprint(ctx context.Context, proje
 	return args.Error(0)
 }
 
-func (m *MockTaskRepository) UpdateLabels(ctx context.Context, taskKey string, labels []string) error {
-	args := m.Called(ctx, taskKey, labels)
+func (m *MockTaskRepository) UpdateLabels(ctx context.Context, taskKey string, addLabels, removeLabels []string) error {
+	args := m.Called(ctx, taskKey, addLabels, removeLabels)
 	return args.Error(0)
 }
 

--- a/internal/tasks/application/usecase/classify_tasks.go
+++ b/internal/tasks/application/usecase/classify_tasks.go
@@ -162,15 +162,15 @@ func (uc *ClassifyTasksUseCase) Execute(ctx context.Context, input domain.Classi
 
 		// Apply labels to Jira if requested
 		if input.Apply {
-			// Build new labels preserving existing ones but updating work type and asset
-			newLabels := uc.buildUpdatedLabels(task.Labels, workType, result.Asset)
+			// Build add/remove label sets for cap-prefixed labels only
+			addLabels, removeLabels := uc.buildLabelChanges(task.Labels, workType, result.Asset)
 
 			fmt.Printf("  🏷️  %s → %s", task.Key, workType)
 			if result.Asset != nil && result.Asset.Asset != nil {
 				fmt.Printf(" + %s", uc.getAssetLabel(result.Asset.Asset))
 			}
 
-			if err := uc.remoteRepo.UpdateLabels(ctx, task.Key, newLabels); err != nil {
+			if err := uc.remoteRepo.UpdateLabels(ctx, task.Key, addLabels, removeLabels); err != nil {
 				fmt.Printf(" ❌ Failed to update JIRA\n")
 				return fmt.Errorf("failed to apply labels to task %s: %w", task.Key, err)
 			}
@@ -454,42 +454,44 @@ func formatWorkType(workType domain.WorkType) string {
 	}
 }
 
-// buildUpdatedLabels builds new labels preserving existing ones but updating work type and asset
-func (uc *ClassifyTasksUseCase) buildUpdatedLabels(existingLabels []string, workType domain.WorkType, assetResult *ports.AssetClassificationResult) []string {
-	// Pre-allocate with estimated capacity: existing labels + work type + potential asset label
-	newLabels := make([]string, 0, len(existingLabels)+2)
-
-	// Check if we should preserve existing asset labels
+// buildLabelChanges computes which cap-prefixed labels to add and remove
+// so that JIRA's update operations only touch cap-prefixed labels
+func (uc *ClassifyTasksUseCase) buildLabelChanges(existingLabels []string, workType domain.WorkType, assetResult *ports.AssetClassificationResult) (addLabels, removeLabels []string) {
 	preserveExistingAsset := assetResult != nil && assetResult.Reason == "existing asset label preserved" && assetResult.Confidence >= 0.95
 
-	// Keep all labels except old work type and conditionally old asset labels
+	// Collect old cap work-type and asset labels to remove
 	for _, label := range existingLabels {
-		// Skip old work type labels
 		if label == "cap-development" || label == "cap-maintenance" || label == "cap-discovery" {
-			continue
+			removeLabels = append(removeLabels, label)
 		}
-		// Skip old asset labels ONLY if we're not preserving them
-		if strings.HasPrefix(label, "cap-asset-") {
-			if preserveExistingAsset {
-				// Keep existing asset labels when they should be preserved
-				newLabels = append(newLabels, label)
-			}
-			continue
+		if strings.HasPrefix(label, "cap-asset-") && !preserveExistingAsset {
+			removeLabels = append(removeLabels, label)
 		}
-		// Keep all other labels
-		newLabels = append(newLabels, label)
 	}
 
 	// Add new work type label
-	newLabels = append(newLabels, string(workType))
+	addLabels = append(addLabels, string(workType))
 
 	// Add new asset label if available and not preserving existing ones
 	if assetResult != nil && assetResult.Asset != nil && !preserveExistingAsset {
 		assetLabel := uc.getAssetLabel(assetResult.Asset)
-		newLabels = append(newLabels, assetLabel)
+		addLabels = append(addLabels, assetLabel)
 	}
 
-	return newLabels
+	// Remove the new label from removeLabels if it was already there (no-op)
+	addSet := make(map[string]bool, len(addLabels))
+	for _, l := range addLabels {
+		addSet[l] = true
+	}
+	filtered := removeLabels[:0]
+	for _, l := range removeLabels {
+		if !addSet[l] {
+			filtered = append(filtered, l)
+		}
+	}
+	removeLabels = filtered
+
+	return addLabels, removeLabels
 }
 
 // getAssetLabel returns the proper asset label, preferring the asset ID if available

--- a/internal/tasks/application/usecase/classify_tasks_test.go
+++ b/internal/tasks/application/usecase/classify_tasks_test.go
@@ -94,8 +94,8 @@ func (m *MockTaskRepository) DeleteByProjectAndSprint(ctx context.Context, proje
 	return args.Error(0)
 }
 
-func (m *MockTaskRepository) UpdateLabels(ctx context.Context, taskKey string, labels []string) error {
-	args := m.Called(ctx, taskKey, labels)
+func (m *MockTaskRepository) UpdateLabels(ctx context.Context, taskKey string, addLabels, removeLabels []string) error {
+	args := m.Called(ctx, taskKey, addLabels, removeLabels)
 	return args.Error(0)
 }
 
@@ -199,8 +199,8 @@ func TestClassifyTasksUseCase_Execute(t *testing.T) {
 					"TEST-2": domain.WorkTypeMaintenance,
 				}, nil)
 				localRepo.On("Save", ctx, mock.Anything).Return(nil).Times(2)
-				remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-development"}).Return(nil)
-				remoteRepo.On("UpdateLabels", ctx, "TEST-2", []string{"cap-maintenance"}).Return(nil)
+				remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-development"}, []string(nil)).Return(nil)
+				remoteRepo.On("UpdateLabels", ctx, "TEST-2", []string{"cap-maintenance"}, []string(nil)).Return(nil)
 			},
 		},
 		{
@@ -234,8 +234,8 @@ func TestClassifyTasksUseCase_Execute(t *testing.T) {
 					"TEST-3": domain.WorkTypeDiscovery,
 					"TEST-4": domain.WorkTypeDevelopment,
 				}, nil)
-				remoteRepo.On("UpdateLabels", ctx, "TEST-3", []string{"cap-discovery"}).Return(nil)
-				remoteRepo.On("UpdateLabels", ctx, "TEST-4", []string{"cap-development"}).Return(nil)
+				remoteRepo.On("UpdateLabels", ctx, "TEST-3", []string{"cap-discovery"}, []string(nil)).Return(nil)
+				remoteRepo.On("UpdateLabels", ctx, "TEST-4", []string{"cap-development"}, []string(nil)).Return(nil)
 			},
 		},
 		{
@@ -624,7 +624,7 @@ func TestFormatWorkType(t *testing.T) {
 	}
 }
 
-func TestBuildUpdatedLabels(t *testing.T) {
+func TestBuildLabelChanges(t *testing.T) {
 	// Create mocks for the use case (needed to call the method)
 	mockLocalRepo := new(MockTaskRepository)
 	mockRemoteRepo := new(MockTaskRepository)
@@ -638,21 +638,24 @@ func TestBuildUpdatedLabels(t *testing.T) {
 		existingLabels []string
 		workType       domain.WorkType
 		assetResult    *ports.AssetClassificationResult
-		expected       []string
+		expectedAdd    []string
+		expectedRemove []string
 	}{
 		{
 			name:           "should add new work type label to empty labels",
 			existingLabels: []string{},
 			workType:       domain.WorkTypeDevelopment,
 			assetResult:    nil,
-			expected:       []string{"cap-development"},
+			expectedAdd:    []string{"cap-development"},
+			expectedRemove: nil,
 		},
 		{
 			name:           "should replace existing work type label",
 			existingLabels: []string{"cap-maintenance", "other-label"},
 			workType:       domain.WorkTypeDevelopment,
 			assetResult:    nil,
-			expected:       []string{"other-label", "cap-development"},
+			expectedAdd:    []string{"cap-development"},
+			expectedRemove: []string{"cap-maintenance"},
 		},
 		{
 			name:           "should add asset label when provided",
@@ -663,7 +666,8 @@ func TestBuildUpdatedLabels(t *testing.T) {
 				Confidence: 0.85,
 				Reason:     "keyword match",
 			},
-			expected: []string{"existing-label", "cap-development", "cap-asset-test-asset"},
+			expectedAdd:    []string{"cap-development", "cap-asset-test-asset"},
+			expectedRemove: nil,
 		},
 		{
 			name:           "should preserve existing asset label when confidence is high and reason indicates preservation",
@@ -674,7 +678,8 @@ func TestBuildUpdatedLabels(t *testing.T) {
 				Confidence: 0.95,
 				Reason:     "existing asset label preserved",
 			},
-			expected: []string{"cap-asset-existing", "other-label", "cap-development"},
+			expectedAdd:    []string{"cap-development"},
+			expectedRemove: []string{"cap-maintenance"},
 		},
 		{
 			name:           "should replace asset label when confidence is low",
@@ -685,14 +690,16 @@ func TestBuildUpdatedLabels(t *testing.T) {
 				Confidence: 0.75,
 				Reason:     "keyword match",
 			},
-			expected: []string{"other-label", "cap-development", "cap-asset-new-asset"},
+			expectedAdd:    []string{"cap-development", "cap-asset-new-asset"},
+			expectedRemove: []string{"cap-maintenance", "cap-asset-old"},
 		},
 		{
 			name:           "should handle multiple work type labels and replace all",
 			existingLabels: []string{"cap-development", "cap-maintenance", "cap-discovery", "other-label"},
 			workType:       domain.WorkTypeMaintenance,
 			assetResult:    nil,
-			expected:       []string{"other-label", "cap-maintenance"},
+			expectedAdd:    []string{"cap-maintenance"},
+			expectedRemove: []string{"cap-development", "cap-discovery"},
 		},
 		{
 			name:           "should handle multiple asset labels and replace with new one",
@@ -703,14 +710,16 @@ func TestBuildUpdatedLabels(t *testing.T) {
 				Confidence: 0.90,
 				Reason:     "best match found",
 			},
-			expected: []string{"other-label", "cap-development", "cap-asset-new-asset"},
+			expectedAdd:    []string{"cap-development", "cap-asset-new-asset"},
+			expectedRemove: []string{"cap-asset-old1", "cap-asset-old2"},
 		},
 		{
-			name:           "should preserve non-asset and non-work-type labels",
+			name:           "should not touch non-cap labels",
 			existingLabels: []string{"bug", "priority-high", "team-backend", "cap-development"},
 			workType:       domain.WorkTypeDiscovery,
 			assetResult:    nil,
-			expected:       []string{"bug", "priority-high", "team-backend", "cap-discovery"},
+			expectedAdd:    []string{"cap-discovery"},
+			expectedRemove: []string{"cap-development"},
 		},
 		{
 			name:           "should handle asset result with nil asset",
@@ -721,7 +730,8 @@ func TestBuildUpdatedLabels(t *testing.T) {
 				Confidence: 0.0,
 				Reason:     "no match found",
 			},
-			expected: []string{"existing-label", "cap-development"},
+			expectedAdd:    []string{"cap-development"},
+			expectedRemove: nil,
 		},
 		{
 			name:           "should handle complex scenario with preservation and replacement",
@@ -732,14 +742,52 @@ func TestBuildUpdatedLabels(t *testing.T) {
 				Confidence: 0.98,
 				Reason:     "existing asset label preserved",
 			},
-			expected: []string{"cap-asset-preserved", "bug", "priority-high", "cap-development"},
+			expectedAdd:    []string{"cap-development"},
+			expectedRemove: []string{"cap-maintenance"},
+		},
+		{
+			name:           "should not remove the same label being added",
+			existingLabels: []string{"cap-development"},
+			workType:       domain.WorkTypeDevelopment,
+			assetResult:    nil,
+			expectedAdd:    []string{"cap-development"},
+			expectedRemove: nil,
+		},
+		{
+			name:           "should never touch non-cap labels like workstream",
+			existingLabels: []string{"workstream", "cap-maintenance", "team-backend", "cap-asset-old-feature"},
+			workType:       domain.WorkTypeDevelopment,
+			assetResult: &ports.AssetClassificationResult{
+				Asset:      createTestAsset("New Feature"),
+				Confidence: 0.85,
+				Reason:     "keyword match",
+			},
+			expectedAdd:    []string{"cap-development", "cap-asset-new-feature"},
+			expectedRemove: []string{"cap-maintenance", "cap-asset-old-feature"},
+		},
+		{
+			name:           "should only produce cap-prefixed labels in add and remove lists",
+			existingLabels: []string{"bug", "priority-high", "workstream", "sprint-goal", "cap-discovery", "cap-asset-payments"},
+			workType:       domain.WorkTypeMaintenance,
+			assetResult: &ports.AssetClassificationResult{
+				Asset:      createTestAsset("Infrastructure"),
+				Confidence: 0.80,
+				Reason:     "keyword match",
+			},
+			expectedAdd:    []string{"cap-maintenance", "cap-asset-infrastructure"},
+			expectedRemove: []string{"cap-discovery", "cap-asset-payments"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := uc.buildUpdatedLabels(tt.existingLabels, tt.workType, tt.assetResult)
-			assert.ElementsMatch(t, tt.expected, result)
+			addLabels, removeLabels := uc.buildLabelChanges(tt.existingLabels, tt.workType, tt.assetResult)
+			assert.ElementsMatch(t, tt.expectedAdd, addLabels, "add labels mismatch")
+			if tt.expectedRemove == nil {
+				assert.Empty(t, removeLabels, "remove labels should be empty")
+			} else {
+				assert.ElementsMatch(t, tt.expectedRemove, removeLabels, "remove labels mismatch")
+			}
 		})
 	}
 }
@@ -912,8 +960,8 @@ func TestClassifyTasksComprehensive(t *testing.T) {
 		localRepo.On("FindByProjectAndSprint", ctx, testProject, testSprint).Return(tasks, nil)
 		comprehensiveClassifier.On("ClassifyTasksComprehensive", tasks).Return(comprehensiveResults, nil)
 		localRepo.On("Save", ctx, mock.Anything).Return(nil).Times(2)
-		remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-development", "cap-asset-test-asset"}).Return(nil)
-		remoteRepo.On("UpdateLabels", ctx, "TEST-2", []string{"cap-maintenance"}).Return(nil)
+		remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-development", "cap-asset-test-asset"}, []string(nil)).Return(nil)
+		remoteRepo.On("UpdateLabels", ctx, "TEST-2", []string{"cap-maintenance"}, []string(nil)).Return(nil)
 
 		// Act
 		err = uc.Execute(ctx, input)
@@ -986,7 +1034,7 @@ func TestClassifyTasksComprehensive(t *testing.T) {
 		localRepo.On("FindByProjectAndSprint", ctx, testProject, testSprint).Return(tasks, nil)
 		simpleClassifier.On("ClassifyTasks", tasks).Return(workTypes, nil)
 		localRepo.On("Save", ctx, mock.Anything).Return(nil)
-		remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-development"}).Return(nil)
+		remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-development"}, []string(nil)).Return(nil)
 
 		// Act
 		err := uc.Execute(ctx, input)
@@ -1130,7 +1178,7 @@ func TestClassifyTasksEdgeCases(t *testing.T) {
 		localRepo.On("FindByProjectAndSprint", ctx, testProject, testSprint).Return(tasks, nil)
 		classifier.On("ClassifyTasks", tasks).Return(workTypes, nil)
 		localRepo.On("Save", ctx, mock.Anything).Return(nil)
-		remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-development"}).Return(nil)
+		remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-development"}, []string(nil)).Return(nil)
 
 		// Act
 		err := uc.Execute(ctx, input)
@@ -1204,7 +1252,7 @@ func TestClassifyTasksEdgeCases(t *testing.T) {
 		localRepo.On("FindByProjectAndSprint", ctx, testProject, testSprint).Return(tasks, nil)
 		classifier.On("ClassifyTasks", tasks).Return(workTypes, nil)
 		localRepo.On("Save", ctx, mock.Anything).Return(nil)
-		remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-development"}).Return(fmt.Errorf("update error"))
+		remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-development"}, []string(nil)).Return(fmt.Errorf("update error"))
 
 		// Act
 		err := uc.Execute(ctx, input)
@@ -1757,7 +1805,7 @@ func TestAdditionalErrorHandlingAndEdgeCases(t *testing.T) {
 		comprehensiveClassifier.On("ClassifyTasksComprehensive", tasks).Return(results, nil)
 		// First task saves successfully
 		localRepo.On("Save", ctx, tasks[0]).Return(nil)
-		remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-development"}).Return(nil)
+		remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-development"}, []string(nil)).Return(nil)
 		// Second task fails to save
 		localRepo.On("Save", ctx, tasks[1]).Return(fmt.Errorf("save error"))
 
@@ -1867,17 +1915,75 @@ func TestAdditionalErrorHandlingAndEdgeCases(t *testing.T) {
 			},
 		}
 
-		expectedLabels := []string{"existing-label", "cap-development", "cap-asset-test-asset"}
+		expectedAddLabels := []string{"cap-development", "cap-asset-test-asset"}
+		expectedRemoveLabels := []string{"cap-maintenance", "cap-asset-old"}
 
 		localRepo.On("FindByProjectAndSprint", ctx, testProject, testSprint).Return([]*domain.Task{task}, nil)
 		comprehensiveClassifier.On("ClassifyTasksComprehensive", []*domain.Task{task}).Return(results, nil)
 		localRepo.On("Save", ctx, mock.Anything).Return(nil)
-		remoteRepo.On("UpdateLabels", ctx, "TEST-1", expectedLabels).Return(nil)
+		remoteRepo.On("UpdateLabels", ctx, "TEST-1", expectedAddLabels, expectedRemoveLabels).Return(nil)
 
 		// Act
 		err := uc.Execute(ctx, input)
 
 		// Assert
+		assert.NoError(t, err)
+		localRepo.AssertExpectations(t)
+		remoteRepo.AssertExpectations(t)
+		comprehensiveClassifier.AssertExpectations(t)
+	})
+
+	t.Run("should never include non-cap labels in add or remove operations", func(t *testing.T) {
+		// This test reproduces the original bug: COP-147 had a "workstream" label
+		// that was overwritten when classify --apply used PUT with full label replacement.
+		// With add/remove operations, "workstream" must never appear in either list.
+		localRepo := new(MockTaskRepository)
+		remoteRepo := new(MockTaskRepository)
+		comprehensiveClassifier := new(MockComprehensiveTaskClassifier)
+		userInput := new(MockUserInput)
+		assetService := testutil.NewMockAssetService()
+
+		uc := NewClassifyTasksUseCase(localRepo, remoteRepo, comprehensiveClassifier, userInput, assetService, nil)
+
+		input := domain.ClassifyTasksInput{
+			Project: testProject,
+			Sprint:  testSprint,
+			DryRun:  false,
+			Apply:   true,
+		}
+
+		task := &domain.Task{
+			Key:     "COP-147",
+			Summary: "Fix payment processing",
+			Labels:  []string{"workstream", "cap-maintenance"},
+		}
+
+		results := []*ports.ComprehensiveClassificationResult{
+			{
+				Task:     task,
+				WorkType: domain.WorkTypeDevelopment,
+				Asset: &ports.AssetClassificationResult{
+					Asset:      createTestAsset("Payment Processing"),
+					Confidence: 0.90,
+					Reason:     "keyword match",
+				},
+				WorkTypeReason: "Development pattern",
+			},
+		}
+
+		localRepo.On("FindByProjectAndSprint", ctx, testProject, testSprint).Return([]*domain.Task{task}, nil)
+		comprehensiveClassifier.On("ClassifyTasksComprehensive", []*domain.Task{task}).Return(results, nil)
+		localRepo.On("Save", ctx, mock.Anything).Return(nil)
+
+		// The key assertion: only cap-prefixed labels appear in add/remove.
+		// "workstream" must NOT appear in either list.
+		remoteRepo.On("UpdateLabels", ctx, "COP-147",
+			[]string{"cap-development", "cap-asset-payment-processing"},
+			[]string{"cap-maintenance"},
+		).Return(nil)
+
+		err := uc.Execute(ctx, input)
+
 		assert.NoError(t, err)
 		localRepo.AssertExpectations(t)
 		remoteRepo.AssertExpectations(t)
@@ -1939,17 +2045,17 @@ func TestSortingAndDisplayLogic(t *testing.T) {
 		localRepo.On("Save", ctx, mock.MatchedBy(func(task *domain.Task) bool {
 			return task.Key == "TEST-1"
 		})).Return(nil).Once()
-		remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-maintenance"}).Return(nil).Once()
+		remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-maintenance"}, []string(nil)).Return(nil).Once()
 
 		localRepo.On("Save", ctx, mock.MatchedBy(func(task *domain.Task) bool {
 			return task.Key == "TEST-2"
 		})).Return(nil).Once()
-		remoteRepo.On("UpdateLabels", ctx, "TEST-2", []string{"cap-discovery"}).Return(nil).Once()
+		remoteRepo.On("UpdateLabels", ctx, "TEST-2", []string{"cap-discovery"}, []string(nil)).Return(nil).Once()
 
 		localRepo.On("Save", ctx, mock.MatchedBy(func(task *domain.Task) bool {
 			return task.Key == "TEST-3"
 		})).Return(nil).Once()
-		remoteRepo.On("UpdateLabels", ctx, "TEST-3", []string{"cap-development"}).Return(nil).Once()
+		remoteRepo.On("UpdateLabels", ctx, "TEST-3", []string{"cap-development"}, []string(nil)).Return(nil).Once()
 
 		// Act
 		err := uc.Execute(ctx, input)
@@ -2249,7 +2355,7 @@ func TestSprintLockBehavior(t *testing.T) {
 		userInput.On("Confirm", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 		classifier.On("ClassifyTasks", tasks).Return(map[string]domain.WorkType{"TEST-1": "cap-development"}, nil)
 		localRepo.On("Save", mock.Anything, mock.Anything).Return(nil)
-		remoteRepo.On("UpdateLabels", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		remoteRepo.On("UpdateLabels", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		lockRepo.On("SaveLock", mock.Anything, mock.Anything).Return(nil)
 
 		input := domain.ClassifyTasksInput{

--- a/internal/tasks/application/usecase/testutil/mock_repository.go
+++ b/internal/tasks/application/usecase/testutil/mock_repository.go
@@ -11,7 +11,7 @@ import (
 type MockTaskRepository struct {
 	findByProjectAndSprintFunc func(ctx context.Context, project, sprint string) ([]*domain.Task, error)
 	saveFunc                   func(ctx context.Context, task *domain.Task) error
-	updateLabelsFunc           func(ctx context.Context, taskKey string, labels []string) error
+	updateLabelsFunc           func(ctx context.Context, taskKey string, addLabels, removeLabels []string) error
 	findAllFunc                func(ctx context.Context) ([]*domain.Task, error)
 	findByKeyFunc              func(ctx context.Context, key string) (*domain.Task, error)
 }
@@ -41,7 +41,7 @@ func (m *MockTaskRepository) SetSaveFunc(f func(ctx context.Context, task *domai
 }
 
 // SetUpdateLabelsFunc sets the mock function for UpdateLabels
-func (m *MockTaskRepository) SetUpdateLabelsFunc(f func(ctx context.Context, taskKey string, labels []string) error) {
+func (m *MockTaskRepository) SetUpdateLabelsFunc(f func(ctx context.Context, taskKey string, addLabels, removeLabels []string) error) {
 	m.updateLabelsFunc = f
 }
 
@@ -113,9 +113,9 @@ func (m *MockTaskRepository) DeleteByProjectAndSprint(ctx context.Context, proje
 }
 
 // UpdateLabels updates the labels of a task in the remote repository
-func (m *MockTaskRepository) UpdateLabels(ctx context.Context, taskKey string, labels []string) error {
+func (m *MockTaskRepository) UpdateLabels(ctx context.Context, taskKey string, addLabels, removeLabels []string) error {
 	if m.updateLabelsFunc != nil {
-		return m.updateLabelsFunc(ctx, taskKey, labels)
+		return m.updateLabelsFunc(ctx, taskKey, addLabels, removeLabels)
 	}
 	return nil
 }

--- a/internal/tasks/domain/ports/task_repository.go
+++ b/internal/tasks/domain/ports/task_repository.go
@@ -36,5 +36,6 @@ type TaskRepository interface {
 	DeleteByProjectAndSprint(ctx context.Context, project, sprint string) error
 
 	// UpdateLabels updates the labels of a task in the remote repository
-	UpdateLabels(ctx context.Context, taskKey string, labels []string) error
+	// using add/remove operations to avoid overwriting non-cap labels
+	UpdateLabels(ctx context.Context, taskKey string, addLabels, removeLabels []string) error
 }

--- a/internal/tasks/domain/ports/task_repository_test.go
+++ b/internal/tasks/domain/ports/task_repository_test.go
@@ -96,8 +96,8 @@ func (m *mockRepository) DeleteByProjectAndSprint(_ context.Context, project, sp
 	return nil
 }
 
-// UpdateLabels updates the labels of a task in the remote repository
-func (m *mockRepository) UpdateLabels(_ context.Context, taskKey string, labels []string) error {
+// UpdateLabels updates the labels of a task using add/remove semantics
+func (m *mockRepository) UpdateLabels(_ context.Context, taskKey string, addLabels, removeLabels []string) error {
 	if taskKey == "" {
 		return fmt.Errorf("task key cannot be empty")
 	}
@@ -107,7 +107,32 @@ func (m *mockRepository) UpdateLabels(_ context.Context, taskKey string, labels 
 		return fmt.Errorf("task %s not found", taskKey)
 	}
 
-	task.Labels = labels
+	// Build remove set
+	removeSet := make(map[string]bool, len(removeLabels))
+	for _, l := range removeLabels {
+		removeSet[l] = true
+	}
+
+	// Filter out removed labels
+	filtered := make([]string, 0, len(task.Labels))
+	for _, l := range task.Labels {
+		if !removeSet[l] {
+			filtered = append(filtered, l)
+		}
+	}
+
+	// Add new labels (avoid duplicates)
+	existing := make(map[string]bool, len(filtered))
+	for _, l := range filtered {
+		existing[l] = true
+	}
+	for _, l := range addLabels {
+		if !existing[l] {
+			filtered = append(filtered, l)
+		}
+	}
+
+	task.Labels = filtered
 	return nil
 }
 
@@ -191,23 +216,31 @@ func TestRepositoryOperations(t *testing.T) {
 	err = repo.Save(ctx, task3)
 	require.NoError(t, err)
 
-	// Test updating labels
-	newLabels := []string{"label1", "label2"}
-	err = repo.UpdateLabels(ctx, "TASK-3", newLabels)
+	// Test updating labels using add/remove semantics
+	addLabels := []string{"label1", "label2"}
+	err = repo.UpdateLabels(ctx, "TASK-3", addLabels, nil)
 	require.NoError(t, err)
 
-	// Verify the labels were updated
+	// Verify the labels were added
 	updatedTask, err := repo.FindByKey(ctx, "TASK-3")
 	require.NoError(t, err)
-	assert.Equal(t, newLabels, updatedTask.Labels)
+	assert.Equal(t, addLabels, updatedTask.Labels)
+
+	// Test removing a label and adding another
+	err = repo.UpdateLabels(ctx, "TASK-3", []string{"label3"}, []string{"label1"})
+	require.NoError(t, err)
+
+	updatedTask, err = repo.FindByKey(ctx, "TASK-3")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"label2", "label3"}, updatedTask.Labels)
 
 	// Test updating labels for non-existent task
-	err = repo.UpdateLabels(ctx, "NON-EXISTENT", newLabels)
+	err = repo.UpdateLabels(ctx, "NON-EXISTENT", addLabels, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "task NON-EXISTENT not found")
 
 	// Test updating labels with empty task key
-	err = repo.UpdateLabels(ctx, "", newLabels)
+	err = repo.UpdateLabels(ctx, "", addLabels, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "task key cannot be empty")
 }

--- a/internal/tasks/infrastructure/jira/client.go
+++ b/internal/tasks/infrastructure/jira/client.go
@@ -25,8 +25,8 @@ type Client interface {
 	// FetchTaskByKey retrieves a single task from Jira by its key
 	FetchTaskByKey(ctx context.Context, key string) (*domain.Task, error)
 
-	// UpdateLabels updates the labels of a Jira issue
-	UpdateLabels(ctx context.Context, issueKey string, labels []string) error
+	// UpdateLabels updates the labels of a Jira issue using add/remove operations
+	UpdateLabels(ctx context.Context, issueKey string, addLabels, removeLabels []string) error
 }
 
 // HTTPClient defines the interface for making HTTP requests
@@ -713,15 +713,35 @@ func (c *client) convertSingleIssueToDomainTask(issue api.Issue) (*domain.Task, 
 	return task, nil
 }
 
-// UpdateLabels updates the labels of a Jira issue
-func (c *client) UpdateLabels(ctx context.Context, issueKey string, labels []string) error {
-	// Construct the request body
+// labelOperation represents a single JIRA label add/remove operation
+type labelOperation struct {
+	Add    string `json:"add,omitempty"`
+	Remove string `json:"remove,omitempty"`
+}
+
+// UpdateLabels updates the labels of a Jira issue using add/remove operations
+// to avoid overwriting non-cap labels
+func (c *client) UpdateLabels(ctx context.Context, issueKey string, addLabels, removeLabels []string) error {
+	// Build label operations
+	ops := make([]labelOperation, 0, len(addLabels)+len(removeLabels))
+	for _, label := range removeLabels {
+		ops = append(ops, labelOperation{Remove: label})
+	}
+	for _, label := range addLabels {
+		ops = append(ops, labelOperation{Add: label})
+	}
+
+	if len(ops) == 0 {
+		return nil
+	}
+
+	// Construct the request body using JIRA update operations
 	body := struct {
-		Fields struct {
-			Labels []string `json:"labels"`
-		} `json:"fields"`
+		Update struct {
+			Labels []labelOperation `json:"labels"`
+		} `json:"update"`
 	}{}
-	body.Fields.Labels = labels
+	body.Update.Labels = ops
 
 	// Convert to JSON
 	jsonBody, err := json.Marshal(body)
@@ -748,8 +768,8 @@ func (c *client) UpdateLabels(ctx context.Context, issueKey string, labels []str
 
 	// Check response status
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("failed to update labels: status %d, body: %s", resp.StatusCode, string(body))
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to update labels: status %d, body: %s", resp.StatusCode, string(respBody))
 	}
 
 	return nil

--- a/internal/tasks/infrastructure/jira/client_test.go
+++ b/internal/tasks/infrastructure/jira/client_test.go
@@ -1037,66 +1037,94 @@ func TestClient_FetchTaskByKey(t *testing.T) {
 }
 
 func TestClient_UpdateLabels(t *testing.T) {
-	tests := []struct {
-		name           string
-		taskKey        string
-		labels         []string
-		serverResponse string
-		statusCode     int
-		expectError    bool
-	}{
-		{
-			name:           "successful update",
-			taskKey:        "TEST-1",
-			labels:         []string{"label1", "label2"},
-			serverResponse: `{"key": "TEST-1"}`,
-			statusCode:     200,
-			expectError:    false,
-		},
-		{
-			name:           "empty task key",
-			taskKey:        "",
-			labels:         []string{"label1"},
-			serverResponse: "",
-			statusCode:     400,
-			expectError:    true,
-		},
-		{
-			name:           "server error",
-			taskKey:        "TEST-1",
-			labels:         []string{"label1"},
-			serverResponse: `{"error": "Internal server error"}`,
-			statusCode:     500,
-			expectError:    true,
-		},
-	}
+	t.Run("successful update with add and remove operations", func(t *testing.T) {
+		var receivedBody map[string]interface{}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			bodyBytes, _ := io.ReadAll(r.Body)
+			json.Unmarshal(bodyBytes, &receivedBody)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(tt.statusCode)
-				w.Write([]byte(tt.serverResponse))
-			}))
-			defer server.Close()
+		config := &Config{
+			BaseURL: server.URL,
+			Email:   "test@example.com",
+			Token:   "test-token",
+		}
 
-			config := &Config{
-				BaseURL: server.URL,
-				Email:   "test@example.com",
-				Token:   "test-token",
-			}
+		client, err := NewClient(config)
+		require.NoError(t, err)
 
-			client, err := NewClient(config)
-			require.NoError(t, err)
+		err = client.UpdateLabels(context.Background(), "TEST-1",
+			[]string{"cap-development", "cap-asset-new"},
+			[]string{"cap-maintenance", "cap-asset-old"},
+		)
 
-			err = client.UpdateLabels(context.Background(), tt.taskKey, tt.labels)
+		assert.NoError(t, err)
 
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
+		// Verify the request body uses update operations
+		update, ok := receivedBody["update"].(map[string]interface{})
+		require.True(t, ok, "body should have 'update' key")
+		labels, ok := update["labels"].([]interface{})
+		require.True(t, ok, "update should have 'labels' key")
+
+		// Should have 4 operations: 2 removes + 2 adds
+		assert.Len(t, labels, 4)
+
+		// First two should be removes
+		op0 := labels[0].(map[string]interface{})
+		assert.Equal(t, "cap-maintenance", op0["remove"])
+		op1 := labels[1].(map[string]interface{})
+		assert.Equal(t, "cap-asset-old", op1["remove"])
+
+		// Last two should be adds
+		op2 := labels[2].(map[string]interface{})
+		assert.Equal(t, "cap-development", op2["add"])
+		op3 := labels[3].(map[string]interface{})
+		assert.Equal(t, "cap-asset-new", op3["add"])
+
+		// Verify no 'fields' key exists
+		_, hasFields := receivedBody["fields"]
+		assert.False(t, hasFields, "body should not have 'fields' key")
+	})
+
+	t.Run("no operations when both add and remove are empty", func(t *testing.T) {
+		config := &Config{
+			BaseURL: "http://unused.example.com",
+			Email:   "test@example.com",
+			Token:   "test-token",
+		}
+
+		client, err := NewClient(config)
+		require.NoError(t, err)
+
+		err = client.UpdateLabels(context.Background(), "TEST-1", nil, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error": "Internal server error"}`))
+		}))
+		defer server.Close()
+
+		config := &Config{
+			BaseURL: server.URL,
+			Email:   "test@example.com",
+			Token:   "test-token",
+		}
+
+		client, err := NewClient(config)
+		require.NoError(t, err)
+
+		err = client.UpdateLabels(context.Background(), "TEST-1",
+			[]string{"cap-development"}, nil,
+		)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to update labels")
+	})
 }
 
 func TestNewRepositoryLegacy_ErrorHandling(t *testing.T) {

--- a/internal/tasks/infrastructure/jira/jira_task_repository.go
+++ b/internal/tasks/infrastructure/jira/jira_task_repository.go
@@ -119,8 +119,8 @@ func (r *TaskRepository) DeleteByProjectAndSprint(_ context.Context, _, _ string
 }
 
 // UpdateLabels updates the labels of a task in the remote repository
-func (r *TaskRepository) UpdateLabels(ctx context.Context, taskKey string, labels []string) error {
-	return r.client.UpdateLabels(ctx, taskKey, labels)
+func (r *TaskRepository) UpdateLabels(ctx context.Context, taskKey string, addLabels, removeLabels []string) error {
+	return r.client.UpdateLabels(ctx, taskKey, addLabels, removeLabels)
 }
 
 // Ensure Repository implements ports.Repository

--- a/internal/tasks/infrastructure/jira/jira_task_repository_test.go
+++ b/internal/tasks/infrastructure/jira/jira_task_repository_test.go
@@ -49,7 +49,7 @@ func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 type MockClient struct {
 	FetchTasksFunc     func(ctx context.Context, project, sprint string) ([]*domain.Task, error)
 	FetchTaskByKeyFunc func(ctx context.Context, key string) (*domain.Task, error)
-	UpdateLabelsFunc   func(ctx context.Context, issueKey string, labels []string) error
+	UpdateLabelsFunc   func(ctx context.Context, issueKey string, addLabels, removeLabels []string) error
 }
 
 func (m *MockClient) FetchTasks(ctx context.Context, project, sprint string) ([]*domain.Task, error) {
@@ -66,9 +66,9 @@ func (m *MockClient) FetchTaskByKey(ctx context.Context, key string) (*domain.Ta
 	return nil, nil
 }
 
-func (m *MockClient) UpdateLabels(ctx context.Context, issueKey string, labels []string) error {
+func (m *MockClient) UpdateLabels(ctx context.Context, issueKey string, addLabels, removeLabels []string) error {
 	if m.UpdateLabelsFunc != nil {
-		return m.UpdateLabelsFunc(ctx, issueKey, labels)
+		return m.UpdateLabelsFunc(ctx, issueKey, addLabels, removeLabels)
 	}
 	return nil
 }
@@ -76,7 +76,7 @@ func (m *MockClient) UpdateLabels(ctx context.Context, issueKey string, labels [
 type mockClient struct {
 	fetchTasksFunc     func(ctx context.Context, project, sprint string) ([]*domain.Task, error)
 	fetchTaskByKeyFunc func(ctx context.Context, key string) (*domain.Task, error)
-	updateLabelsFunc   func(ctx context.Context, issueKey string, labels []string) error
+	updateLabelsFunc   func(ctx context.Context, issueKey string, addLabels, removeLabels []string) error
 }
 
 func (m *mockClient) FetchTasks(ctx context.Context, project, sprint string) ([]*domain.Task, error) {
@@ -93,9 +93,9 @@ func (m *mockClient) FetchTaskByKey(ctx context.Context, key string) (*domain.Ta
 	return nil, nil
 }
 
-func (m *mockClient) UpdateLabels(ctx context.Context, issueKey string, labels []string) error {
+func (m *mockClient) UpdateLabels(ctx context.Context, issueKey string, addLabels, removeLabels []string) error {
 	if m.updateLabelsFunc != nil {
-		return m.updateLabelsFunc(ctx, issueKey, labels)
+		return m.updateLabelsFunc(ctx, issueKey, addLabels, removeLabels)
 	}
 	return nil
 }
@@ -418,21 +418,24 @@ func TestJiraTaskRepository_UpdateLabels(t *testing.T) {
 	tests := []struct {
 		name          string
 		taskKey       string
-		labels        []string
+		addLabels     []string
+		removeLabels  []string
 		mockError     error
 		expectedError bool
 	}{
 		{
 			name:          "successful label update",
 			taskKey:       "TEST-1",
-			labels:        []string{"development"},
+			addLabels:     []string{"cap-development"},
+			removeLabels:  []string{"cap-maintenance"},
 			mockError:     nil,
 			expectedError: false,
 		},
 		{
 			name:          "failed label update",
 			taskKey:       "TEST-1",
-			labels:        []string{"development"},
+			addLabels:     []string{"cap-development"},
+			removeLabels:  nil,
 			mockError:     fmt.Errorf("failed to update labels"),
 			expectedError: true,
 		},
@@ -442,7 +445,7 @@ func TestJiraTaskRepository_UpdateLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create mock client
 			mockClient := &mockClient{
-				updateLabelsFunc: func(_ context.Context, _ string, _ []string) error {
+				updateLabelsFunc: func(_ context.Context, _ string, _, _ []string) error {
 					return tt.mockError
 				},
 			}
@@ -453,7 +456,7 @@ func TestJiraTaskRepository_UpdateLabels(t *testing.T) {
 			}
 
 			// Test UpdateLabels
-			err := repo.UpdateLabels(context.Background(), tt.taskKey, tt.labels)
+			err := repo.UpdateLabels(context.Background(), tt.taskKey, tt.addLabels, tt.removeLabels)
 
 			if tt.expectedError {
 				assert.Error(t, err)

--- a/internal/tasks/infrastructure/storage/json_storage.go
+++ b/internal/tasks/infrastructure/storage/json_storage.go
@@ -183,8 +183,9 @@ func (s *JSONStorage) DeleteByProjectAndSprint(_ context.Context, project, sprin
 	return s.saveTasks(newTasks)
 }
 
-// UpdateLabels updates the labels of a task in the remote repository
-func (s *JSONStorage) UpdateLabels(_ context.Context, taskKey string, labels []string) error {
+// UpdateLabels updates the labels of a task in the local repository
+// using add/remove semantics to stay consistent with the port interface
+func (s *JSONStorage) UpdateLabels(_ context.Context, taskKey string, addLabels, removeLabels []string) error {
 	if taskKey == "" {
 		return fmt.Errorf("task key cannot be empty")
 	}
@@ -199,7 +200,32 @@ func (s *JSONStorage) UpdateLabels(_ context.Context, taskKey string, labels []s
 		return fmt.Errorf("task %s not found", taskKey)
 	}
 
-	task.Labels = labels
+	// Build a set of labels to remove for fast lookup
+	removeSet := make(map[string]bool, len(removeLabels))
+	for _, label := range removeLabels {
+		removeSet[label] = true
+	}
+
+	// Filter out removed labels
+	filtered := make([]string, 0, len(task.Labels))
+	for _, label := range task.Labels {
+		if !removeSet[label] {
+			filtered = append(filtered, label)
+		}
+	}
+
+	// Add new labels (avoid duplicates)
+	existing := make(map[string]bool, len(filtered))
+	for _, label := range filtered {
+		existing[label] = true
+	}
+	for _, label := range addLabels {
+		if !existing[label] {
+			filtered = append(filtered, label)
+		}
+	}
+
+	task.Labels = filtered
 	return s.saveTasks(tasks)
 }
 

--- a/internal/tasks/infrastructure/storage/json_storage_test.go
+++ b/internal/tasks/infrastructure/storage/json_storage_test.go
@@ -422,75 +422,88 @@ func TestJSONStorage_UpdateLabels(t *testing.T) {
 	h := setupTest(t)
 	defer h.cleanup(t)
 
-	t.Run("should update labels for existing task", func(t *testing.T) {
+	t.Run("should add labels to existing task", func(t *testing.T) {
 		task := h.createTestTask("TEST-1", "Test Task", "TEST", "Sprint 1")
 		err := h.storage.Save(context.Background(), task)
 		require.NoError(t, err, "Failed to save task")
 
-		// Update labels
-		newLabels := []string{"bug", "high-priority", "urgent"}
-		err = h.storage.UpdateLabels(context.Background(), task.Key, newLabels)
+		// Add labels
+		err = h.storage.UpdateLabels(context.Background(), task.Key, []string{"bug", "high-priority"}, nil)
 		require.NoError(t, err, "Failed to update labels")
 
-		// Verify labels were updated
+		// Verify labels were added
 		loaded, err := h.storage.FindByKey(context.Background(), task.Key)
 		require.NoError(t, err, "Failed to load task")
-		assert.Equal(t, newLabels, loaded.Labels, "Labels should be updated")
+		assert.ElementsMatch(t, []string{"bug", "high-priority"}, loaded.Labels)
 	})
 
-	t.Run("should update labels to empty slice", func(t *testing.T) {
+	t.Run("should remove labels from existing task", func(t *testing.T) {
 		task := h.createTestTask("TEST-1", "Test Task", "TEST", "Sprint 1")
-		task.Labels = []string{"old-label"}
+		task.Labels = []string{"bug", "cap-maintenance", "workstream"}
 		err := h.storage.Save(context.Background(), task)
 		require.NoError(t, err, "Failed to save task")
 
-		// Update to empty labels
-		err = h.storage.UpdateLabels(context.Background(), task.Key, []string{})
+		// Remove cap-maintenance and add cap-development
+		err = h.storage.UpdateLabels(context.Background(), task.Key,
+			[]string{"cap-development"}, []string{"cap-maintenance"})
 		require.NoError(t, err, "Failed to update labels")
 
-		// Verify labels were cleared
+		// Verify only cap-maintenance was removed and cap-development was added
 		loaded, err := h.storage.FindByKey(context.Background(), task.Key)
 		require.NoError(t, err, "Failed to load task")
-		assert.Empty(t, loaded.Labels, "Labels should be empty")
+		assert.ElementsMatch(t, []string{"bug", "workstream", "cap-development"}, loaded.Labels)
 	})
 
-	t.Run("should update labels to nil slice", func(t *testing.T) {
+	t.Run("should handle empty add and remove", func(t *testing.T) {
 		task := h.createTestTask("TEST-1", "Test Task", "TEST", "Sprint 1")
-		task.Labels = []string{"old-label"}
+		task.Labels = []string{"existing-label"}
 		err := h.storage.Save(context.Background(), task)
 		require.NoError(t, err, "Failed to save task")
 
-		// Update to nil labels
-		err = h.storage.UpdateLabels(context.Background(), task.Key, nil)
+		// No changes
+		err = h.storage.UpdateLabels(context.Background(), task.Key, nil, nil)
 		require.NoError(t, err, "Failed to update labels")
 
-		// Verify labels were cleared
 		loaded, err := h.storage.FindByKey(context.Background(), task.Key)
 		require.NoError(t, err, "Failed to load task")
-		assert.Nil(t, loaded.Labels, "Labels should be nil")
+		assert.Equal(t, []string{"existing-label"}, loaded.Labels)
+	})
+
+	t.Run("should not add duplicate labels", func(t *testing.T) {
+		task := h.createTestTask("TEST-1", "Test Task", "TEST", "Sprint 1")
+		task.Labels = []string{"cap-development"}
+		err := h.storage.Save(context.Background(), task)
+		require.NoError(t, err, "Failed to save task")
+
+		// Add same label again
+		err = h.storage.UpdateLabels(context.Background(), task.Key, []string{"cap-development"}, nil)
+		require.NoError(t, err, "Failed to update labels")
+
+		loaded, err := h.storage.FindByKey(context.Background(), task.Key)
+		require.NoError(t, err, "Failed to load task")
+		assert.Equal(t, []string{"cap-development"}, loaded.Labels)
 	})
 
 	t.Run("should return error for empty task key", func(t *testing.T) {
-		err := h.storage.UpdateLabels(context.Background(), "", []string{"label"})
+		err := h.storage.UpdateLabels(context.Background(), "", []string{"label"}, nil)
 		assert.Error(t, err, "Expected error for empty task key")
-		assert.Contains(t, err.Error(), "task key cannot be empty", "Expected specific error message")
+		assert.Contains(t, err.Error(), "task key cannot be empty")
 	})
 
 	t.Run("should return error for non-existent task", func(t *testing.T) {
-		err := h.storage.UpdateLabels(context.Background(), "NON-EXISTENT", []string{"label"})
+		err := h.storage.UpdateLabels(context.Background(), "NON-EXISTENT", []string{"label"}, nil)
 		assert.Error(t, err, "Expected error for non-existent task")
-		assert.Contains(t, err.Error(), "not found", "Expected not found error")
+		assert.Contains(t, err.Error(), "not found")
 	})
 
 	t.Run("should handle storage loading error", func(t *testing.T) {
-		// Create storage pointing to invalid directory (read-only)
 		invalidDir := filepath.Join(h.dir, "readonly")
-		err := os.MkdirAll(invalidDir, 0444) // Read-only directory
+		err := os.MkdirAll(invalidDir, 0444)
 		require.NoError(t, err, "Failed to create readonly directory")
 
 		invalidStorage := NewJSONStorage(invalidDir, "nonexistent.json")
 
-		err = invalidStorage.UpdateLabels(context.Background(), "TEST-1", []string{"label"})
+		err = invalidStorage.UpdateLabels(context.Background(), "TEST-1", []string{"label"}, nil)
 		assert.Error(t, err, "Expected error when loading from readonly directory")
 	})
 }


### PR DESCRIPTION
When classifying tasks with --apply, the JIRA client used a PUT with full label replacement (fields.labels), which overwrote ALL labels on the issue. This caused non-cap labels like "workstream" to be deleted.

Changed the approach to use JIRA's update.labels with add/remove operations so we only touch cap-prefixed labels. The port signature now takes (addLabels, removeLabels) instead of a single labels slice, making the intent explicit across all layers.

Replaced buildUpdatedLabels (which returned a full label list) with buildLabelChanges (which returns only the cap-prefixed labels to add and remove). This ensures non-cap labels are never included in the JIRA API request.