### PR TITLE
feat: add time-aware team composition via team timeline

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2517,6 +2517,181 @@ For more information about a command:
 							},
 						},
 					},
+					{
+						Name:  "team-timeline",
+						Usage: "Manage team member timeline (join/leave dates) for time-aware sprint allocation",
+						Subcommands: []*cli.Command{
+							{
+								Name:  "show",
+								Usage: "Show team timeline for a project",
+								Action: func(ctx *cli.Context) error {
+									project := ctx.String("project")
+									if project == "" {
+										return fmt.Errorf("project is required")
+									}
+
+									configRepo := configinfra.NewFileRepository(configDir)
+									configSvc := service.NewConfigService(configRepo)
+
+									teamConfig, err := configSvc.GetTeamConfig()
+									if err != nil {
+										return fmt.Errorf("failed to load team config: %v", err)
+									}
+
+									timeline := teamConfig.GetTeamTimeline(project)
+									if len(timeline) == 0 {
+										fmt.Printf("Project '%s' has no team timeline configured\n", project)
+										fmt.Println("Using flat team list for all sprints")
+										members, exists := teamConfig.GetTeam(project)
+										if exists {
+											fmt.Printf("Current team: %s\n", strings.Join(members, ", "))
+										}
+										return nil
+									}
+
+									fmt.Printf("Team Timeline for '%s':\n", project)
+									fmt.Println("===========================")
+									for _, p := range timeline {
+										status := "active"
+										leftStr := ""
+										if p.Left != nil {
+											status = "departed"
+											leftStr = p.Left.Format("2006-01-02")
+										}
+										fmt.Printf("  %-25s joined: %s  left: %-12s [%s]\n",
+											p.Member, p.Joined.Format("2006-01-02"), leftStr, status)
+									}
+
+									active := teamConfig.DeriveActiveTeamFromTimeline(project)
+									fmt.Printf("\nActive members (%d): %s\n", len(active), strings.Join(active, ", "))
+
+									return nil
+								},
+								Flags: []cli.Flag{
+									&cli.StringFlag{
+										Name:     "project",
+										Aliases:  []string{"p"},
+										Usage:    "Project key",
+										Required: true,
+									},
+								},
+							},
+							{
+								Name:  "add",
+								Usage: "Add a member to the team timeline with a join date",
+								Action: func(ctx *cli.Context) error {
+									project := ctx.String("project")
+									member := ctx.String("member")
+									joinedStr := ctx.String("joined")
+
+									if project == "" || member == "" || joinedStr == "" {
+										return fmt.Errorf("project, member, and joined date are required")
+									}
+
+									joined, err := time.Parse("2006-01-02", joinedStr)
+									if err != nil {
+										return fmt.Errorf("invalid date format, use YYYY-MM-DD: %v", err)
+									}
+
+									configRepo := configinfra.NewFileRepository(configDir)
+									configSvc := service.NewConfigService(configRepo)
+
+									teamConfig, err := configSvc.GetTeamConfig()
+									if err != nil {
+										return fmt.Errorf("failed to load team config: %v", err)
+									}
+
+									if err := teamConfig.AddMemberWithDates(project, member, joined); err != nil {
+										return fmt.Errorf("failed to add member: %v", err)
+									}
+
+									if err := configSvc.SaveTeamConfig(teamConfig); err != nil {
+										return fmt.Errorf("failed to save team config: %v", err)
+									}
+
+									fmt.Printf("Added '%s' to project '%s' timeline (joined: %s)\n", member, project, joinedStr)
+									return nil
+								},
+								Flags: []cli.Flag{
+									&cli.StringFlag{
+										Name:     "project",
+										Aliases:  []string{"p"},
+										Usage:    "Project key",
+										Required: true,
+									},
+									&cli.StringFlag{
+										Name:     "member",
+										Aliases:  []string{"m"},
+										Usage:    "Team member name",
+										Required: true,
+									},
+									&cli.StringFlag{
+										Name:     "joined",
+										Aliases:  []string{"j"},
+										Usage:    "Join date (YYYY-MM-DD)",
+										Required: true,
+									},
+								},
+							},
+							{
+								Name:  "remove",
+								Usage: "Set a member's departure date in the team timeline",
+								Action: func(ctx *cli.Context) error {
+									project := ctx.String("project")
+									member := ctx.String("member")
+									leftStr := ctx.String("left")
+
+									if project == "" || member == "" || leftStr == "" {
+										return fmt.Errorf("project, member, and left date are required")
+									}
+
+									left, err := time.Parse("2006-01-02", leftStr)
+									if err != nil {
+										return fmt.Errorf("invalid date format, use YYYY-MM-DD: %v", err)
+									}
+
+									configRepo := configinfra.NewFileRepository(configDir)
+									configSvc := service.NewConfigService(configRepo)
+
+									teamConfig, err := configSvc.GetTeamConfig()
+									if err != nil {
+										return fmt.Errorf("failed to load team config: %v", err)
+									}
+
+									if err := teamConfig.SetMemberLeft(project, member, left); err != nil {
+										return fmt.Errorf("failed to set departure: %v", err)
+									}
+
+									if err := configSvc.SaveTeamConfig(teamConfig); err != nil {
+										return fmt.Errorf("failed to save team config: %v", err)
+									}
+
+									fmt.Printf("Set '%s' departure from project '%s' (left: %s)\n", member, project, leftStr)
+									return nil
+								},
+								Flags: []cli.Flag{
+									&cli.StringFlag{
+										Name:     "project",
+										Aliases:  []string{"p"},
+										Usage:    "Project key",
+										Required: true,
+									},
+									&cli.StringFlag{
+										Name:     "member",
+										Aliases:  []string{"m"},
+										Usage:    "Team member name",
+										Required: true,
+									},
+									&cli.StringFlag{
+										Name:     "left",
+										Aliases:  []string{"l"},
+										Usage:    "Departure date (YYYY-MM-DD)",
+										Required: true,
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			{

--- a/internal/config/application/service/config_service.go
+++ b/internal/config/application/service/config_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/helmedeiros/digital-asset-capitalization/internal/config/domain"
 	configPorts "github.com/helmedeiros/digital-asset-capitalization/internal/config/domain/ports"
@@ -51,6 +52,41 @@ func (s *ConfigService) GetTeamMapForSprint() (sprintDomain.TeamMap, error) {
 	for _, project := range teamConfig.GetProjects() {
 		members, exists := teamConfig.GetTeam(project)
 		if exists {
+			teamMap[project] = sprintDomain.Team{
+				Team:               members,
+				ExcludedIssueTypes: teamConfig.GetExcludedIssueTypes(project),
+			}
+		}
+	}
+
+	return teamMap, nil
+}
+
+// GetTeamMapForSprintWithDates returns team data resolved for a specific date range.
+// For projects with a team timeline, members are resolved based on who was active
+// during [start, end]. For projects without a timeline, falls back to the flat team array.
+func (s *ConfigService) GetTeamMapForSprintWithDates(start, end time.Time) (sprintDomain.TeamMap, error) {
+	teamConfig, err := s.GetTeamConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get team configuration: %w", err)
+	}
+
+	teamMap := make(sprintDomain.TeamMap)
+	for _, project := range teamConfig.GetProjects() {
+		var members []string
+		if teamConfig.HasTeamTimeline(project) {
+			resolved, exists := teamConfig.GetTeamForPeriod(project, start, end)
+			if exists {
+				members = resolved
+			}
+		} else {
+			resolved, exists := teamConfig.GetTeam(project)
+			if exists {
+				members = resolved
+			}
+		}
+
+		if members != nil {
 			teamMap[project] = sprintDomain.Team{
 				Team:               members,
 				ExcludedIssueTypes: teamConfig.GetExcludedIssueTypes(project),

--- a/internal/config/application/service/config_service_test.go
+++ b/internal/config/application/service/config_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -760,6 +761,94 @@ func TestConfigService_GetExcludedIssueTypesForProject(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, types)
 		assert.Contains(t, err.Error(), "failed to load team configuration")
+		repo.AssertExpectations(t)
+	})
+}
+
+func TestConfigService_GetTeamMapForSprintWithDates(t *testing.T) {
+	date := func(year int, month time.Month, day int) time.Time {
+		return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	}
+	datePtr := func(year int, month time.Month, day int) *time.Time {
+		t := date(year, month, day)
+		return &t
+	}
+
+	t.Run("resolves team from timeline for given period", func(t *testing.T) {
+		repo := &MockConfigurationRepository{}
+		svc := NewConfigService(repo)
+
+		teams := map[string][]string{"PROJECT-A": {"Alice", "Charlie"}}
+		timelines := map[string][]domain.TeamMemberPeriod{
+			"PROJECT-A": {
+				{Member: "Alice", Joined: date(2024, 1, 1)},
+				{Member: "Bob", Joined: date(2024, 1, 1), Left: datePtr(2024, 6, 30)},
+				{Member: "Charlie", Joined: date(2024, 7, 1)},
+			},
+		}
+		config, err := domain.NewTeamConfigWithTimelines(teams, nil, nil, nil, nil, nil, nil, nil, timelines)
+		require.NoError(t, err)
+
+		repo.On("LoadTeamConfig").Return(config, nil)
+
+		// Q1: Alice + Bob active
+		teamMap, err := svc.GetTeamMapForSprintWithDates(date(2024, 1, 1), date(2024, 3, 31))
+		require.NoError(t, err)
+
+		team, exists := teamMap.GetTeam("PROJECT-A")
+		require.True(t, exists)
+		assert.ElementsMatch(t, []string{"Alice", "Bob"}, team.Team)
+	})
+
+	t.Run("falls back to flat team without timeline", func(t *testing.T) {
+		repo := &MockConfigurationRepository{}
+		svc := NewConfigService(repo)
+
+		teams := map[string][]string{"PROJECT-A": {"Alice", "Bob"}}
+		config, err := domain.NewTeamConfig(teams)
+		require.NoError(t, err)
+
+		repo.On("LoadTeamConfig").Return(config, nil)
+
+		teamMap, err := svc.GetTeamMapForSprintWithDates(date(2024, 1, 1), date(2024, 3, 31))
+		require.NoError(t, err)
+
+		team, exists := teamMap.GetTeam("PROJECT-A")
+		require.True(t, exists)
+		assert.Equal(t, []string{"Alice", "Bob"}, team.Team)
+	})
+
+	t.Run("includes excluded issue types", func(t *testing.T) {
+		repo := &MockConfigurationRepository{}
+		svc := NewConfigService(repo)
+
+		teams := map[string][]string{"PROJECT-A": {"Alice"}}
+		timelines := map[string][]domain.TeamMemberPeriod{
+			"PROJECT-A": {{Member: "Alice", Joined: date(2024, 1, 1)}},
+		}
+		excluded := map[string][]string{"PROJECT-A": {"Experiment"}}
+		config, err := domain.NewTeamConfigWithTimelines(teams, nil, nil, nil, nil, nil, excluded, nil, timelines)
+		require.NoError(t, err)
+
+		repo.On("LoadTeamConfig").Return(config, nil)
+
+		teamMap, err := svc.GetTeamMapForSprintWithDates(date(2024, 1, 1), date(2024, 3, 31))
+		require.NoError(t, err)
+
+		team, exists := teamMap.GetTeam("PROJECT-A")
+		require.True(t, exists)
+		assert.Equal(t, []string{"Experiment"}, team.ExcludedIssueTypes)
+	})
+
+	t.Run("returns error when config loading fails", func(t *testing.T) {
+		repo := &MockConfigurationRepository{}
+		svc := NewConfigService(repo)
+
+		repo.On("LoadTeamConfig").Return(nil, errors.New("repository error"))
+
+		teamMap, err := svc.GetTeamMapForSprintWithDates(date(2024, 1, 1), date(2024, 3, 31))
+		require.Error(t, err)
+		assert.Nil(t, teamMap)
 		repo.AssertExpectations(t)
 	})
 }

--- a/internal/config/application/usecase/sync_team_from_jira.go
+++ b/internal/config/application/usecase/sync_team_from_jira.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/helmedeiros/digital-asset-capitalization/internal/config/domain"
 	"github.com/helmedeiros/digital-asset-capitalization/internal/config/domain/ports"
@@ -66,6 +67,23 @@ func (s *SyncTeamFromJira) Execute(projectKey string) (*domain.TeamSyncResult, e
 
 	result.AddedMembers = findAddedMembers(currentMembers, newMemberNames)
 	result.RemovedMembers = findRemovedMembers(currentMembers, newMemberNames)
+
+	// Maintain team timeline if one exists
+	if currentTeamConfig.HasTeamTimeline(projectKey) {
+		now := time.Now()
+		for _, added := range result.AddedMembers {
+			if err := currentTeamConfig.AddMemberWithDates(projectKey, added, now); err != nil {
+				// Ignore duplicate errors — member may already have a timeline entry
+				_ = err
+			}
+		}
+		for _, removed := range result.RemovedMembers {
+			if err := currentTeamConfig.SetMemberLeft(projectKey, removed, now); err != nil {
+				// Ignore errors — member may already have a left date
+				_ = err
+			}
+		}
+	}
 
 	// Update team configuration
 	if err := currentTeamConfig.SetTeam(projectKey, newMemberNames); err != nil {

--- a/internal/config/domain/team_config.go
+++ b/internal/config/domain/team_config.go
@@ -4,24 +4,56 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 )
+
+// TeamMemberPeriod represents a team member's active period within a project
+type TeamMemberPeriod struct {
+	Member string
+	Joined time.Time
+	Left   *time.Time // nil means still active
+}
+
+// IsActiveAt returns true if the member was active at the given time
+func (p TeamMemberPeriod) IsActiveAt(t time.Time) bool {
+	if t.Before(p.Joined) {
+		return false
+	}
+	if p.Left != nil && t.After(*p.Left) {
+		return false
+	}
+	return true
+}
+
+// IsActiveDuring returns true if the member was active during any part of [start, end]
+func (p TeamMemberPeriod) IsActiveDuring(start, end time.Time) bool {
+	if p.Left != nil && p.Left.Before(start) {
+		return false
+	}
+	if p.Joined.After(end) {
+		return false
+	}
+	return true
+}
 
 // TeamConfig represents the team configuration domain entity
 type TeamConfig struct {
 	teams                 map[string][]string
-	nicknames             map[string][]string       // project -> nicknames mapping
-	tribes                map[string]string         // project -> tribe mapping
-	companies             map[string]string         // project -> company mapping
-	confluenceSpaces      map[string]string         // project -> confluence space mapping
-	confluenceParentPages map[string]string         // project -> confluence parent page ID mapping
-	excludedIssueTypes    map[string][]string       // project -> excluded issue types for sprint allocation
-	boardWorkStreams      map[string]map[int]string // project -> boardID -> workstream name
+	teamTimelines         map[string][]TeamMemberPeriod // project -> member periods
+	nicknames             map[string][]string           // project -> nicknames mapping
+	tribes                map[string]string             // project -> tribe mapping
+	companies             map[string]string             // project -> company mapping
+	confluenceSpaces      map[string]string             // project -> confluence space mapping
+	confluenceParentPages map[string]string             // project -> confluence parent page ID mapping
+	excludedIssueTypes    map[string][]string           // project -> excluded issue types for sprint allocation
+	boardWorkStreams      map[string]map[int]string     // project -> boardID -> workstream name
 }
 
 // NewTeamConfig creates a new TeamConfig with validation
 func NewTeamConfig(teams map[string][]string) (*TeamConfig, error) {
 	config := &TeamConfig{
 		teams:                 make(map[string][]string),
+		teamTimelines:         make(map[string][]TeamMemberPeriod),
 		nicknames:             make(map[string][]string),
 		tribes:                make(map[string]string),
 		companies:             make(map[string]string),
@@ -639,6 +671,161 @@ func (tc *TeamConfig) SetBoardWorkStreams(project string, mapping map[int]string
 	}
 	tc.boardWorkStreams[trimmedProject] = mapping
 	return nil
+}
+
+// GetTeamTimeline returns the timeline for a given project
+func (tc *TeamConfig) GetTeamTimeline(project string) []TeamMemberPeriod {
+	timeline, exists := tc.teamTimelines[project]
+	if !exists {
+		return nil
+	}
+	result := make([]TeamMemberPeriod, len(timeline))
+	copy(result, timeline)
+	return result
+}
+
+// HasTeamTimeline returns true if the project has a timeline configured
+func (tc *TeamConfig) HasTeamTimeline(project string) bool {
+	timeline, exists := tc.teamTimelines[project]
+	return exists && len(timeline) > 0
+}
+
+// SetTeamTimeline sets the timeline for a project
+func (tc *TeamConfig) SetTeamTimeline(project string, timeline []TeamMemberPeriod) error {
+	trimmedProject := strings.TrimSpace(project)
+	if trimmedProject == "" {
+		return fmt.Errorf("project key cannot be empty")
+	}
+	if _, exists := tc.teams[trimmedProject]; !exists {
+		return fmt.Errorf("project '%s' does not exist", trimmedProject)
+	}
+	tc.teamTimelines[trimmedProject] = timeline
+	return nil
+}
+
+// GetTeamForPeriod returns the union of members active during any part of [start, end].
+// A member who was active for even one day during the period is included.
+// Falls back to the flat team array if no timeline exists.
+func (tc *TeamConfig) GetTeamForPeriod(project string, start, end time.Time) ([]string, bool) {
+	timeline, exists := tc.teamTimelines[project]
+	if !exists || len(timeline) == 0 {
+		return tc.GetTeam(project)
+	}
+
+	seen := make(map[string]bool)
+	var members []string
+	for _, period := range timeline {
+		if period.IsActiveDuring(start, end) && !seen[period.Member] {
+			seen[period.Member] = true
+			members = append(members, period.Member)
+		}
+	}
+
+	if len(members) == 0 {
+		return nil, true
+	}
+	return members, true
+}
+
+// AddMemberWithDates adds a member to the timeline with a joined date
+func (tc *TeamConfig) AddMemberWithDates(project, member string, joined time.Time) error {
+	trimmedProject := strings.TrimSpace(project)
+	if trimmedProject == "" {
+		return fmt.Errorf("project key cannot be empty")
+	}
+	trimmedMember := strings.TrimSpace(member)
+	if trimmedMember == "" {
+		return fmt.Errorf("team member cannot be empty")
+	}
+	if _, exists := tc.teams[trimmedProject]; !exists {
+		return fmt.Errorf("project '%s' does not exist", trimmedProject)
+	}
+
+	// Check for duplicate active member
+	for _, p := range tc.teamTimelines[trimmedProject] {
+		if p.Member == trimmedMember && p.Left == nil {
+			return fmt.Errorf("team member '%s' already has an active period in project '%s'", trimmedMember, trimmedProject)
+		}
+	}
+
+	tc.teamTimelines[trimmedProject] = append(tc.teamTimelines[trimmedProject], TeamMemberPeriod{
+		Member: trimmedMember,
+		Joined: joined,
+	})
+	return nil
+}
+
+// SetMemberLeft sets the left date for an active member in the timeline
+func (tc *TeamConfig) SetMemberLeft(project, member string, left time.Time) error {
+	trimmedProject := strings.TrimSpace(project)
+	if trimmedProject == "" {
+		return fmt.Errorf("project key cannot be empty")
+	}
+	trimmedMember := strings.TrimSpace(member)
+	if trimmedMember == "" {
+		return fmt.Errorf("team member cannot be empty")
+	}
+
+	timeline, exists := tc.teamTimelines[trimmedProject]
+	if !exists {
+		return fmt.Errorf("project '%s' has no timeline", trimmedProject)
+	}
+
+	for i, p := range timeline {
+		if p.Member == trimmedMember && p.Left == nil {
+			tc.teamTimelines[trimmedProject][i].Left = &left
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no active period found for member '%s' in project '%s'", trimmedMember, trimmedProject)
+}
+
+// DeriveActiveTeamFromTimeline returns the currently active members from the timeline
+func (tc *TeamConfig) DeriveActiveTeamFromTimeline(project string) []string {
+	timeline, exists := tc.teamTimelines[project]
+	if !exists || len(timeline) == 0 {
+		return nil
+	}
+
+	var active []string
+	for _, p := range timeline {
+		if p.Left == nil {
+			active = append(active, p.Member)
+		}
+	}
+	return active
+}
+
+// GetAllTeamTimelines returns a copy of all team timelines
+func (tc *TeamConfig) GetAllTeamTimelines() map[string][]TeamMemberPeriod {
+	result := make(map[string][]TeamMemberPeriod, len(tc.teamTimelines))
+	for project, timeline := range tc.teamTimelines {
+		timelineCopy := make([]TeamMemberPeriod, len(timeline))
+		copy(timelineCopy, timeline)
+		result[project] = timelineCopy
+	}
+	return result
+}
+
+// NewTeamConfigWithTimelines creates a new TeamConfig with all fields including team timelines
+func NewTeamConfigWithTimelines(teams map[string][]string, nicknames map[string][]string, tribes map[string]string, companies map[string]string, confluenceSpaces map[string]string, confluenceParentPages map[string]string, excludedIssueTypes map[string][]string, boardWorkStreams map[string]map[int]string, teamTimelines map[string][]TeamMemberPeriod) (*TeamConfig, error) {
+	config, err := NewTeamConfigWithBoardWorkStreams(teams, nicknames, tribes, companies, confluenceSpaces, confluenceParentPages, excludedIssueTypes, boardWorkStreams)
+	if err != nil {
+		return nil, err
+	}
+
+	for project, timeline := range teamTimelines {
+		trimmedProject := strings.TrimSpace(project)
+		if trimmedProject == "" {
+			continue
+		}
+		if _, exists := config.teams[trimmedProject]; exists && len(timeline) > 0 {
+			config.teamTimelines[trimmedProject] = timeline
+		}
+	}
+
+	return config, nil
 }
 
 // ToCompleteMapWithBoardWorkStreams returns all maps including board work streams

--- a/internal/config/domain/team_config_test.go
+++ b/internal/config/domain/team_config_test.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1064,5 +1065,347 @@ func TestNewTeamConfigWithExcludedTypes(t *testing.T) {
 
 		_, _, _, _, _, _, resultExcluded := config.ToCompleteMapWithExcludedTypes()
 		assert.Equal(t, []string{"Experiment", "Spike"}, resultExcluded["COP"])
+	})
+}
+
+// --- Team Timeline Tests ---
+
+func date(year int, month time.Month, day int) time.Time {
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}
+
+func datePtr(year int, month time.Month, day int) *time.Time {
+	t := date(year, month, day)
+	return &t
+}
+
+func TestTeamMemberPeriod_IsActiveAt(t *testing.T) {
+	tests := []struct {
+		name   string
+		period TeamMemberPeriod
+		at     time.Time
+		want   bool
+	}{
+		{
+			name:   "active member at date after joined",
+			period: TeamMemberPeriod{Member: "Alice", Joined: date(2024, 1, 1)},
+			at:     date(2024, 6, 15),
+			want:   true,
+		},
+		{
+			name:   "active member on join date",
+			period: TeamMemberPeriod{Member: "Alice", Joined: date(2024, 1, 1)},
+			at:     date(2024, 1, 1),
+			want:   true,
+		},
+		{
+			name:   "before join date",
+			period: TeamMemberPeriod{Member: "Alice", Joined: date(2024, 6, 1)},
+			at:     date(2024, 1, 1),
+			want:   false,
+		},
+		{
+			name:   "after left date",
+			period: TeamMemberPeriod{Member: "Alice", Joined: date(2024, 1, 1), Left: datePtr(2024, 6, 30)},
+			at:     date(2024, 7, 15),
+			want:   false,
+		},
+		{
+			name:   "on left date",
+			period: TeamMemberPeriod{Member: "Alice", Joined: date(2024, 1, 1), Left: datePtr(2024, 6, 30)},
+			at:     date(2024, 6, 30),
+			want:   true,
+		},
+		{
+			name:   "between joined and left",
+			period: TeamMemberPeriod{Member: "Alice", Joined: date(2024, 1, 1), Left: datePtr(2024, 6, 30)},
+			at:     date(2024, 3, 15),
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.period.IsActiveAt(tt.at))
+		})
+	}
+}
+
+func TestTeamMemberPeriod_IsActiveDuring(t *testing.T) {
+	tests := []struct {
+		name   string
+		period TeamMemberPeriod
+		start  time.Time
+		end    time.Time
+		want   bool
+	}{
+		{
+			name:   "active member overlaps entire period",
+			period: TeamMemberPeriod{Member: "Alice", Joined: date(2024, 1, 1)},
+			start:  date(2024, 3, 1),
+			end:    date(2024, 3, 15),
+			want:   true,
+		},
+		{
+			name:   "left before period starts",
+			period: TeamMemberPeriod{Member: "Alice", Joined: date(2024, 1, 1), Left: datePtr(2024, 2, 28)},
+			start:  date(2024, 3, 1),
+			end:    date(2024, 3, 15),
+			want:   false,
+		},
+		{
+			name:   "joined after period ends",
+			period: TeamMemberPeriod{Member: "Alice", Joined: date(2024, 4, 1)},
+			start:  date(2024, 3, 1),
+			end:    date(2024, 3, 15),
+			want:   false,
+		},
+		{
+			name:   "left during period - partial overlap",
+			period: TeamMemberPeriod{Member: "Alice", Joined: date(2024, 1, 1), Left: datePtr(2024, 3, 5)},
+			start:  date(2024, 3, 1),
+			end:    date(2024, 3, 15),
+			want:   true,
+		},
+		{
+			name:   "joined during period - partial overlap",
+			period: TeamMemberPeriod{Member: "Alice", Joined: date(2024, 3, 10)},
+			start:  date(2024, 3, 1),
+			end:    date(2024, 3, 15),
+			want:   true,
+		},
+		{
+			name:   "left on period start date",
+			period: TeamMemberPeriod{Member: "Alice", Joined: date(2024, 1, 1), Left: datePtr(2024, 3, 1)},
+			start:  date(2024, 3, 1),
+			end:    date(2024, 3, 15),
+			want:   true,
+		},
+		{
+			name:   "joined on period end date",
+			period: TeamMemberPeriod{Member: "Alice", Joined: date(2024, 3, 15)},
+			start:  date(2024, 3, 1),
+			end:    date(2024, 3, 15),
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.period.IsActiveDuring(tt.start, tt.end))
+		})
+	}
+}
+
+func TestTeamConfig_GetTeamForPeriod(t *testing.T) {
+	teams := map[string][]string{
+		"PROJECT-A": {"Alice", "Bob", "Charlie", "Dave"},
+		"PROJECT-B": {"Eve"},
+	}
+
+	timeline := map[string][]TeamMemberPeriod{
+		"PROJECT-A": {
+			{Member: "Alice", Joined: date(2024, 1, 1)},                               // still active
+			{Member: "Bob", Joined: date(2024, 1, 1), Left: datePtr(2024, 6, 30)},     // left mid-year
+			{Member: "Charlie", Joined: date(2024, 1, 1), Left: datePtr(2024, 3, 31)}, // left Q1
+			{Member: "Dave", Joined: date(2024, 7, 1)},                                // joined mid-year
+			{Member: "Eve", Joined: date(2024, 10, 1), Left: datePtr(2024, 12, 31)},   // short stint
+		},
+	}
+
+	config, err := NewTeamConfigWithTimelines(teams, nil, nil, nil, nil, nil, nil, nil, timeline)
+	require.NoError(t, err)
+
+	t.Run("Q1 period includes Alice Bob Charlie", func(t *testing.T) {
+		members, exists := config.GetTeamForPeriod("PROJECT-A", date(2024, 1, 1), date(2024, 3, 31))
+		assert.True(t, exists)
+		assert.ElementsMatch(t, []string{"Alice", "Bob", "Charlie"}, members)
+	})
+
+	t.Run("Q2 period includes Alice Bob", func(t *testing.T) {
+		members, exists := config.GetTeamForPeriod("PROJECT-A", date(2024, 4, 1), date(2024, 6, 30))
+		assert.True(t, exists)
+		assert.ElementsMatch(t, []string{"Alice", "Bob"}, members)
+	})
+
+	t.Run("Q3 period includes Alice Dave", func(t *testing.T) {
+		members, exists := config.GetTeamForPeriod("PROJECT-A", date(2024, 7, 1), date(2024, 9, 30))
+		assert.True(t, exists)
+		assert.ElementsMatch(t, []string{"Alice", "Dave"}, members)
+	})
+
+	t.Run("Q4 period includes Alice Dave Eve", func(t *testing.T) {
+		members, exists := config.GetTeamForPeriod("PROJECT-A", date(2024, 10, 1), date(2024, 12, 31))
+		assert.True(t, exists)
+		assert.ElementsMatch(t, []string{"Alice", "Dave", "Eve"}, members)
+	})
+
+	t.Run("far future includes only active members", func(t *testing.T) {
+		members, exists := config.GetTeamForPeriod("PROJECT-A", date(2025, 6, 1), date(2025, 6, 15))
+		assert.True(t, exists)
+		assert.ElementsMatch(t, []string{"Alice", "Dave"}, members)
+	})
+
+	t.Run("project without timeline falls back to flat team", func(t *testing.T) {
+		members, exists := config.GetTeamForPeriod("PROJECT-B", date(2024, 1, 1), date(2024, 3, 31))
+		assert.True(t, exists)
+		assert.Equal(t, []string{"Eve"}, members)
+	})
+
+	t.Run("non-existent project", func(t *testing.T) {
+		members, exists := config.GetTeamForPeriod("UNKNOWN", date(2024, 1, 1), date(2024, 3, 31))
+		assert.False(t, exists)
+		assert.Nil(t, members)
+	})
+}
+
+func TestTeamConfig_AddMemberWithDates(t *testing.T) {
+	teams := map[string][]string{"PROJECT-A": {"Alice"}}
+	config, err := NewTeamConfig(teams)
+	require.NoError(t, err)
+
+	t.Run("add member with join date", func(t *testing.T) {
+		err := config.AddMemberWithDates("PROJECT-A", "Bob", date(2024, 6, 1))
+		require.NoError(t, err)
+
+		timeline := config.GetTeamTimeline("PROJECT-A")
+		require.Len(t, timeline, 1)
+		assert.Equal(t, "Bob", timeline[0].Member)
+		assert.Equal(t, date(2024, 6, 1), timeline[0].Joined)
+		assert.Nil(t, timeline[0].Left)
+	})
+
+	t.Run("add duplicate active member fails", func(t *testing.T) {
+		err := config.AddMemberWithDates("PROJECT-A", "Bob", date(2024, 7, 1))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "already has an active period")
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		err := config.AddMemberWithDates("", "Bob", date(2024, 6, 1))
+		assert.Error(t, err)
+	})
+
+	t.Run("empty member", func(t *testing.T) {
+		err := config.AddMemberWithDates("PROJECT-A", "", date(2024, 6, 1))
+		assert.Error(t, err)
+	})
+
+	t.Run("non-existent project", func(t *testing.T) {
+		err := config.AddMemberWithDates("UNKNOWN", "Bob", date(2024, 6, 1))
+		assert.Error(t, err)
+	})
+}
+
+func TestTeamConfig_SetMemberLeft(t *testing.T) {
+	teams := map[string][]string{"PROJECT-A": {"Alice"}}
+	timeline := map[string][]TeamMemberPeriod{
+		"PROJECT-A": {
+			{Member: "Alice", Joined: date(2024, 1, 1)},
+			{Member: "Bob", Joined: date(2024, 1, 1), Left: datePtr(2024, 6, 30)},
+		},
+	}
+
+	config, err := NewTeamConfigWithTimelines(teams, nil, nil, nil, nil, nil, nil, nil, timeline)
+	require.NoError(t, err)
+
+	t.Run("set left date for active member", func(t *testing.T) {
+		err := config.SetMemberLeft("PROJECT-A", "Alice", date(2024, 12, 31))
+		require.NoError(t, err)
+
+		tl := config.GetTeamTimeline("PROJECT-A")
+		for _, p := range tl {
+			if p.Member == "Alice" {
+				require.NotNil(t, p.Left)
+				assert.Equal(t, date(2024, 12, 31), *p.Left)
+			}
+		}
+	})
+
+	t.Run("cannot set left for already departed member", func(t *testing.T) {
+		err := config.SetMemberLeft("PROJECT-A", "Bob", date(2024, 12, 31))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no active period found")
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		err := config.SetMemberLeft("", "Alice", date(2024, 12, 31))
+		assert.Error(t, err)
+	})
+
+	t.Run("project without timeline", func(t *testing.T) {
+		err := config.SetMemberLeft("UNKNOWN", "Alice", date(2024, 12, 31))
+		assert.Error(t, err)
+	})
+}
+
+func TestTeamConfig_DeriveActiveTeamFromTimeline(t *testing.T) {
+	teams := map[string][]string{"PROJECT-A": {"Alice", "Bob", "Charlie"}}
+	timeline := map[string][]TeamMemberPeriod{
+		"PROJECT-A": {
+			{Member: "Alice", Joined: date(2024, 1, 1)},
+			{Member: "Bob", Joined: date(2024, 1, 1), Left: datePtr(2025, 6, 30)},
+			{Member: "Charlie", Joined: date(2024, 3, 1)},
+		},
+	}
+
+	config, err := NewTeamConfigWithTimelines(teams, nil, nil, nil, nil, nil, nil, nil, timeline)
+	require.NoError(t, err)
+
+	active := config.DeriveActiveTeamFromTimeline("PROJECT-A")
+	assert.ElementsMatch(t, []string{"Alice", "Charlie"}, active)
+}
+
+func TestTeamConfig_HasTeamTimeline(t *testing.T) {
+	teams := map[string][]string{
+		"PROJECT-A": {"Alice"},
+		"PROJECT-B": {"Bob"},
+	}
+	timeline := map[string][]TeamMemberPeriod{
+		"PROJECT-A": {{Member: "Alice", Joined: date(2024, 1, 1)}},
+	}
+
+	config, err := NewTeamConfigWithTimelines(teams, nil, nil, nil, nil, nil, nil, nil, timeline)
+	require.NoError(t, err)
+
+	assert.True(t, config.HasTeamTimeline("PROJECT-A"))
+	assert.False(t, config.HasTeamTimeline("PROJECT-B"))
+	assert.False(t, config.HasTeamTimeline("UNKNOWN"))
+}
+
+func TestNewTeamConfigWithTimelines(t *testing.T) {
+	t.Run("creates config with timelines", func(t *testing.T) {
+		teams := map[string][]string{"PROJECT-A": {"Alice"}}
+		timeline := map[string][]TeamMemberPeriod{
+			"PROJECT-A": {{Member: "Alice", Joined: date(2024, 1, 1)}},
+		}
+
+		config, err := NewTeamConfigWithTimelines(teams, nil, nil, nil, nil, nil, nil, nil, timeline)
+		require.NoError(t, err)
+		assert.True(t, config.HasTeamTimeline("PROJECT-A"))
+	})
+
+	t.Run("ignores timeline for non-existent project", func(t *testing.T) {
+		teams := map[string][]string{"PROJECT-A": {"Alice"}}
+		timeline := map[string][]TeamMemberPeriod{
+			"UNKNOWN": {{Member: "Bob", Joined: date(2024, 1, 1)}},
+		}
+
+		config, err := NewTeamConfigWithTimelines(teams, nil, nil, nil, nil, nil, nil, nil, timeline)
+		require.NoError(t, err)
+		assert.False(t, config.HasTeamTimeline("UNKNOWN"))
+	})
+
+	t.Run("nil timeline is fine", func(t *testing.T) {
+		teams := map[string][]string{"PROJECT-A": {"Alice"}}
+
+		config, err := NewTeamConfigWithTimelines(teams, nil, nil, nil, nil, nil, nil, nil, nil)
+		require.NoError(t, err)
+		assert.False(t, config.HasTeamTimeline("PROJECT-A"))
+
+		// Falls back to flat team
+		members, exists := config.GetTeamForPeriod("PROJECT-A", date(2024, 1, 1), date(2024, 3, 31))
+		assert.True(t, exists)
+		assert.Equal(t, []string{"Alice"}, members)
 	})
 }

--- a/internal/config/infrastructure/file_repository.go
+++ b/internal/config/infrastructure/file_repository.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/helmedeiros/digital-asset-capitalization/internal/config/domain"
 )
@@ -99,7 +100,12 @@ func (r *FileRepository) LoadTeamConfig() (*domain.TeamConfig, error) {
 
 	// Parse existing file format
 	var fileFormat map[string]struct {
-		Team                 []string          `json:"team"`
+		Team         []string `json:"team"`
+		TeamTimeline []struct {
+			Member string `json:"member"`
+			Joined string `json:"joined"`
+			Left   string `json:"left,omitempty"`
+		} `json:"team_timeline,omitempty"`
 		Nicknames            []string          `json:"nicknames,omitempty"`
 		Tribe                string            `json:"tribe,omitempty"`
 		Company              string            `json:"company,omitempty"`
@@ -115,6 +121,7 @@ func (r *FileRepository) LoadTeamConfig() (*domain.TeamConfig, error) {
 
 	// Transform to domain format
 	teams := make(map[string][]string)
+	teamTimelines := make(map[string][]domain.TeamMemberPeriod)
 	nicknames := make(map[string][]string)
 	tribes := make(map[string]string)
 	companies := make(map[string]string)
@@ -125,6 +132,29 @@ func (r *FileRepository) LoadTeamConfig() (*domain.TeamConfig, error) {
 
 	for project, teamInfo := range fileFormat {
 		teams[project] = teamInfo.Team
+
+		if len(teamInfo.TeamTimeline) > 0 {
+			var periods []domain.TeamMemberPeriod
+			for _, entry := range teamInfo.TeamTimeline {
+				joined, err := time.Parse("2006-01-02", entry.Joined)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse joined date for %s in %s: %w", entry.Member, project, err)
+				}
+				period := domain.TeamMemberPeriod{
+					Member: entry.Member,
+					Joined: joined,
+				}
+				if entry.Left != "" {
+					left, err := time.Parse("2006-01-02", entry.Left)
+					if err != nil {
+						return nil, fmt.Errorf("failed to parse left date for %s in %s: %w", entry.Member, project, err)
+					}
+					period.Left = &left
+				}
+				periods = append(periods, period)
+			}
+			teamTimelines[project] = periods
+		}
 		if len(teamInfo.Nicknames) > 0 {
 			nicknames[project] = teamInfo.Nicknames
 		}
@@ -158,7 +188,7 @@ func (r *FileRepository) LoadTeamConfig() (*domain.TeamConfig, error) {
 		}
 	}
 
-	return domain.NewTeamConfigWithBoardWorkStreams(teams, nicknames, tribes, companies, confluenceSpaces, confluenceParentPages, excludedIssueTypes, boardWorkStreams)
+	return domain.NewTeamConfigWithTimelines(teams, nicknames, tribes, companies, confluenceSpaces, confluenceParentPages, excludedIssueTypes, boardWorkStreams, teamTimelines)
 }
 
 // SaveTeamConfig saves team configuration to file with format transformation
@@ -167,8 +197,17 @@ func (r *FileRepository) SaveTeamConfig(config *domain.TeamConfig) error {
 
 	// Transform from domain format to file format
 	teams, nicknames, tribes, companies, confluenceSpaces, confluenceParentPages, excludedIssueTypes, boardWorkStreams := config.ToCompleteMapWithBoardWorkStreams()
+	allTimelines := config.GetAllTeamTimelines()
+
+	type timelineEntry struct {
+		Member string `json:"member"`
+		Joined string `json:"joined"`
+		Left   string `json:"left,omitempty"`
+	}
+
 	fileFormat := make(map[string]struct {
 		Team                 []string          `json:"team"`
+		TeamTimeline         []timelineEntry   `json:"team_timeline,omitempty"`
 		Nicknames            []string          `json:"nicknames,omitempty"`
 		Tribe                string            `json:"tribe,omitempty"`
 		Company              string            `json:"company,omitempty"`
@@ -179,8 +218,15 @@ func (r *FileRepository) SaveTeamConfig(config *domain.TeamConfig) error {
 	})
 
 	for project, members := range teams {
+		// If timeline exists, derive active team from it
+		activeMembers := members
+		if timeline, hasTimeline := allTimelines[project]; hasTimeline && len(timeline) > 0 {
+			activeMembers = config.DeriveActiveTeamFromTimeline(project)
+		}
+
 		entry := struct {
 			Team                 []string          `json:"team"`
+			TeamTimeline         []timelineEntry   `json:"team_timeline,omitempty"`
 			Nicknames            []string          `json:"nicknames,omitempty"`
 			Tribe                string            `json:"tribe,omitempty"`
 			Company              string            `json:"company,omitempty"`
@@ -189,7 +235,23 @@ func (r *FileRepository) SaveTeamConfig(config *domain.TeamConfig) error {
 			ExcludedIssueTypes   []string          `json:"excluded_issue_types,omitempty"`
 			BoardWorkStreams     map[string]string `json:"board_work_streams,omitempty"`
 		}{
-			Team: members,
+			Team: activeMembers,
+		}
+
+		// Add timeline if it exists for this project
+		if timeline, hasTimeline := allTimelines[project]; hasTimeline && len(timeline) > 0 {
+			entries := make([]timelineEntry, 0, len(timeline))
+			for _, p := range timeline {
+				te := timelineEntry{
+					Member: p.Member,
+					Joined: p.Joined.Format("2006-01-02"),
+				}
+				if p.Left != nil {
+					te.Left = p.Left.Format("2006-01-02")
+				}
+				entries = append(entries, te)
+			}
+			entry.TeamTimeline = entries
 		}
 
 		// Add nicknames if they exist for this project

--- a/internal/config/infrastructure/file_repository_test.go
+++ b/internal/config/infrastructure/file_repository_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -607,5 +608,141 @@ func TestFileRepository_TeamConfigWithExcludedIssueTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Nil(t, config.GetExcludedIssueTypes("COP"))
+	})
+}
+
+func TestFileRepository_TeamConfigWithTimeline(t *testing.T) {
+	t.Run("should load team_timeline from teams.json", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := NewFileRepository(tempDir)
+
+		teamsJSON := `{
+			"PROJECT-A": {
+				"team": ["Alice", "Charlie"],
+				"team_timeline": [
+					{"member": "Alice", "joined": "2024-01-01"},
+					{"member": "Bob", "joined": "2024-01-01", "left": "2024-06-30"},
+					{"member": "Charlie", "joined": "2024-03-01"}
+				]
+			}
+		}`
+
+		teamsPath := filepath.Join(tempDir, "teams.json")
+		err := os.WriteFile(teamsPath, []byte(teamsJSON), 0644)
+		require.NoError(t, err)
+
+		config, err := repo.LoadTeamConfig()
+		require.NoError(t, err)
+
+		assert.True(t, config.HasTeamTimeline("PROJECT-A"))
+
+		timeline := config.GetTeamTimeline("PROJECT-A")
+		require.Len(t, timeline, 3)
+
+		assert.Equal(t, "Alice", timeline[0].Member)
+		assert.Nil(t, timeline[0].Left)
+
+		assert.Equal(t, "Bob", timeline[1].Member)
+		require.NotNil(t, timeline[1].Left)
+		assert.Equal(t, time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC), *timeline[1].Left)
+
+		assert.Equal(t, "Charlie", timeline[2].Member)
+		assert.Nil(t, timeline[2].Left)
+	})
+
+	t.Run("should save and load team_timeline round-trip", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := NewFileRepository(tempDir)
+
+		joined := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		left := time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC)
+
+		teams := map[string][]string{"PROJECT-A": {"Alice", "Bob"}}
+		timelines := map[string][]domain.TeamMemberPeriod{
+			"PROJECT-A": {
+				{Member: "Alice", Joined: joined},
+				{Member: "Bob", Joined: joined, Left: &left},
+			},
+		}
+
+		config, err := domain.NewTeamConfigWithTimelines(teams, nil, nil, nil, nil, nil, nil, nil, timelines)
+		require.NoError(t, err)
+
+		err = repo.SaveTeamConfig(config)
+		require.NoError(t, err)
+
+		loadedConfig, err := repo.LoadTeamConfig()
+		require.NoError(t, err)
+
+		assert.True(t, loadedConfig.HasTeamTimeline("PROJECT-A"))
+
+		loadedTimeline := loadedConfig.GetTeamTimeline("PROJECT-A")
+		require.Len(t, loadedTimeline, 2)
+		assert.Equal(t, "Alice", loadedTimeline[0].Member)
+		assert.Nil(t, loadedTimeline[0].Left)
+		assert.Equal(t, "Bob", loadedTimeline[1].Member)
+		require.NotNil(t, loadedTimeline[1].Left)
+	})
+
+	t.Run("save derives active team from timeline", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := NewFileRepository(tempDir)
+
+		joined := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		left := time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC)
+
+		teams := map[string][]string{"PROJECT-A": {"Alice", "Bob"}}
+		timelines := map[string][]domain.TeamMemberPeriod{
+			"PROJECT-A": {
+				{Member: "Alice", Joined: joined},
+				{Member: "Bob", Joined: joined, Left: &left},
+			},
+		}
+
+		config, err := domain.NewTeamConfigWithTimelines(teams, nil, nil, nil, nil, nil, nil, nil, timelines)
+		require.NoError(t, err)
+
+		err = repo.SaveTeamConfig(config)
+		require.NoError(t, err)
+
+		// Read raw JSON to verify team array was derived
+		data, err := os.ReadFile(filepath.Join(tempDir, "teams.json"))
+		require.NoError(t, err)
+
+		var raw map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(data, &raw))
+
+		var projectData struct {
+			Team []string `json:"team"`
+		}
+		require.NoError(t, json.Unmarshal(raw["PROJECT-A"], &projectData))
+
+		// Only Alice should be in the active team (Bob has left)
+		assert.Equal(t, []string{"Alice"}, projectData.Team)
+	})
+
+	t.Run("should handle missing team_timeline field gracefully", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := NewFileRepository(tempDir)
+
+		teamsJSON := `{
+			"PROJECT-A": {
+				"team": ["Alice", "Bob"]
+			}
+		}`
+
+		teamsPath := filepath.Join(tempDir, "teams.json")
+		err := os.WriteFile(teamsPath, []byte(teamsJSON), 0644)
+		require.NoError(t, err)
+
+		config, err := repo.LoadTeamConfig()
+		require.NoError(t, err)
+
+		assert.False(t, config.HasTeamTimeline("PROJECT-A"))
+
+		// Should fall back to flat team
+		members, exists := config.GetTeam("PROJECT-A")
+		assert.True(t, exists)
+		assert.Equal(t, []string{"Alice", "Bob"}, members)
 	})
 }

--- a/internal/sprint/application/usecase/sprint_time_allocation.go
+++ b/internal/sprint/application/usecase/sprint_time_allocation.go
@@ -90,9 +90,16 @@ func NewSprintTimeAllocationUseCaseWithStrategy(project, sprint, override string
 	configSvc := configService.NewConfigService(configRepo)
 
 	// Load teams data using shared configuration service
-	teams, err := configSvc.GetTeamMapForSprint()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load team configuration: %w", err)
+	// When sprint boundary is available, resolve team membership for the sprint period
+	var teams domain.TeamMap
+	if useSprintBoundedCalculation {
+		// We need sprint dates first, so defer team loading until after sprint boundary is resolved
+		teams = nil
+	} else {
+		teams, err = configSvc.GetTeamMapForSprint()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load team configuration: %w", err)
+		}
 	}
 
 	// Create StatusService for team-specific status mapping
@@ -129,6 +136,12 @@ func NewSprintTimeAllocationUseCaseWithStrategy(project, sprint, override string
 			return nil, fmt.Errorf("failed to create sprint boundary: %w", err)
 		}
 		sprintBoundary = &boundary
+
+		// Load teams resolved for the sprint date range
+		teams, err = configSvc.GetTeamMapForSprintWithDates(startDate, endDate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load team configuration for sprint dates: %w", err)
+		}
 
 		// Use sprint-bounded time calculator with status checker
 		// For sprint-bounded calculation, we need team info which we'll get from the first issue processed


### PR DESCRIPTION
## Summary
- Add optional `team_timeline` field to `teams.json` recording member join/leave dates
- Sprint allocation automatically resolves team membership for the sprint date range when using `--sprint-bounded`
- Full backwards compatibility: projects without timeline use the flat team array as before
- CLI commands: `config team-timeline show/add/remove` for managing member periods
- JIRA sync (`config sync-team`) automatically maintains timeline entries