### PR TITLE
test(prompt): cover pure formatters and context-command early returns (52.5% → 70.2%)

### DIFF
--- a/internal/console/infrastructure/prompt/enhanced_handler_test.go
+++ b/internal/console/infrastructure/prompt/enhanced_handler_test.go
@@ -3,9 +3,12 @@ package prompt
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/helmedeiros/digital-asset-capitalization/internal/console/application"
 	"github.com/helmedeiros/digital-asset-capitalization/internal/console/domain"
@@ -227,4 +230,487 @@ func TestEnhancedHandler_DisplayListOutput_Standalone(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestEnhancedHandler_AddToCommandHistory(t *testing.T) {
+	t.Run("empty input is skipped", func(t *testing.T) {
+		h := NewEnhancedHandler(nil)
+		h.addToCommandHistory("")
+		assert.Empty(t, h.commandHistory)
+	})
+
+	t.Run("consecutive duplicate is skipped", func(t *testing.T) {
+		h := NewEnhancedHandler(nil)
+		h.addToCommandHistory("show assets")
+		h.addToCommandHistory("show assets")
+		assert.Equal(t, []string{"show assets"}, h.commandHistory)
+	})
+
+	t.Run("non-consecutive duplicate is recorded", func(t *testing.T) {
+		h := NewEnhancedHandler(nil)
+		h.addToCommandHistory("show assets")
+		h.addToCommandHistory("list tasks")
+		h.addToCommandHistory("show assets")
+		assert.Equal(t, []string{"show assets", "list tasks", "show assets"}, h.commandHistory)
+	})
+
+	t.Run("caps history at 100 entries with FIFO eviction", func(t *testing.T) {
+		h := NewEnhancedHandler(nil)
+		for i := 0; i < 105; i++ {
+			h.addToCommandHistory(fmt.Sprintf("cmd-%03d", i))
+		}
+		assert.Len(t, h.commandHistory, 100)
+		assert.Equal(t, "cmd-005", h.commandHistory[0], "earliest non-evicted entry")
+		assert.Equal(t, "cmd-104", h.commandHistory[99], "most recent entry")
+	})
+
+	t.Run("resets historyIndex on insert", func(t *testing.T) {
+		h := NewEnhancedHandler(nil)
+		h.historyIndex = 7
+		h.addToCommandHistory("show assets")
+		assert.Equal(t, -1, h.historyIndex)
+	})
+}
+
+func TestEnhancedHandler_FormatResultForHistory(t *testing.T) {
+	h := NewEnhancedHandler(nil)
+
+	tests := []struct {
+		name   string
+		result *application.ProcessResult
+		want   string
+	}{
+		{
+			name:   "nil output reports generic success",
+			result: &application.ProcessResult{Success: true, Output: nil},
+			want:   "Command executed successfully",
+		},
+		{
+			name: "map with message returns that message",
+			result: &application.ProcessResult{Output: map[string]interface{}{
+				"message": "Asset created",
+				"id":      "42",
+			}},
+			want: "Asset created",
+		},
+		{
+			name: "map without message reports field count",
+			result: &application.ProcessResult{Output: map[string]interface{}{
+				"id":     "42",
+				"status": "active",
+			}},
+			want: "Returned 2 fields",
+		},
+		{
+			name:   "slice reports item count",
+			result: &application.ProcessResult{Output: []interface{}{"a", "b", "c"}},
+			want:   "Returned 3 items",
+		},
+		{
+			name:   "string is returned as-is",
+			result: &application.ProcessResult{Output: "hello"},
+			want:   "hello",
+		},
+		{
+			name:   "other types fall through to fmt %v",
+			result: &application.ProcessResult{Output: 42},
+			want:   "42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, h.formatResultForHistory(tt.result))
+		})
+	}
+}
+
+func TestEnhancedHandler_FormatKeyName(t *testing.T) {
+	h := NewEnhancedHandler(nil)
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"name", "Name"},
+		{"created_at", "Created At"},
+		{"total_investment", "Total Investment"},
+		{"", ""},
+		{"already_Capitalized_INPUT", "Already Capitalized Input"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.want, h.formatKeyName(tt.in))
+		})
+	}
+}
+
+func TestEnhancedHandler_CreateGenericTable(t *testing.T) {
+	h := NewEnhancedHandler(nil)
+
+	t.Run("produces one column per key in sorted order with humanized headers", func(t *testing.T) {
+		table := h.createGenericTable(map[string]interface{}{
+			"updated_at": "2026-06-14",
+			"name":       "Asset A",
+			"status":     "active",
+		})
+		require.NotNil(t, table)
+		require.Len(t, table.Columns, 3)
+
+		// SortMapKeys yields lexical order: name, status, updated_at.
+		assert.Equal(t, []string{"name", "status", "updated_at"},
+			[]string{table.Columns[0].Key, table.Columns[1].Key, table.Columns[2].Key})
+		assert.Equal(t, []string{"Name", "Status", "Updated At"},
+			[]string{table.Columns[0].Header, table.Columns[1].Header, table.Columns[2].Header})
+
+		for _, col := range table.Columns {
+			assert.Equal(t, "left", col.Align)
+		}
+	})
+
+	t.Run("assigns a formatter to status/state columns", func(t *testing.T) {
+		table := h.createGenericTable(map[string]interface{}{
+			"name":   "Asset A",
+			"status": "active",
+		})
+		statusCol := table.Columns[1]
+		require.Equal(t, "status", statusCol.Key)
+		assert.NotNil(t, statusCol.Formatter, "status should get the status formatter")
+	})
+
+	t.Run("assigns a date formatter to timestamp columns", func(t *testing.T) {
+		table := h.createGenericTable(map[string]interface{}{
+			"created_at": "2026-06-14",
+			"id":         "1",
+		})
+		// created_at sorts before id.
+		require.Equal(t, "created_at", table.Columns[0].Key)
+		assert.NotNil(t, table.Columns[0].Formatter)
+	})
+
+	t.Run("money branch only matches exact-keyed money fields (current behavior)", func(t *testing.T) {
+		// The production switch matches on exact lowered key ("cost",
+		// "investment", "price", "amount"), then guards on key containing
+		// "total". Since none of those exact keys contain "total", the
+		// MoneyFormatter branch is effectively unreachable today --
+		// neither "cost" nor "total_cost" gets a formatter. This test
+		// pins that observable behavior so a future refactor of the
+		// switch shape can't quietly change it.
+		table := h.createGenericTable(map[string]interface{}{
+			"cost":       1.0,
+			"total_cost": 2.0,
+			"name":       "x",
+		})
+		require.Len(t, table.Columns, 3)
+		byKey := map[string]func(interface{}) string{}
+		for _, col := range table.Columns {
+			byKey[col.Key] = col.Formatter
+		}
+		assert.Nil(t, byKey["cost"])
+		assert.Nil(t, byKey["total_cost"])
+		assert.Nil(t, byKey["name"])
+	})
+}
+
+func TestEnhancedHandler_CreateTableForData(t *testing.T) {
+	h := NewEnhancedHandler(nil)
+
+	// Each branch in createTableForData dispatches to a different factory
+	// method. We can't distinguish factory tables by identity, but we can
+	// distinguish the generic fallback by its column count + key set, which
+	// is what we assert for the generic case. For the typed branches we
+	// just assert that the dispatch produced a table at all -- the factory
+	// methods themselves are covered by ui package tests.
+	tests := []struct {
+		name   string
+		sample map[string]interface{}
+	}{
+		{"asset-shaped", map[string]interface{}{"name": "A", "status": "active"}},
+		{"task-shaped", map[string]interface{}{"key": "TASK-1", "summary": "do thing"}},
+		{"investment-shaped via asset+investment", map[string]interface{}{"asset": "A", "investment": 10.0}},
+		{"investment-shaped via total_investment", map[string]interface{}{"total_investment": 10.0}},
+		{"engineer-shaped", map[string]interface{}{"name": "Eng", "level": "L4", "hours": 40.0, "cost": 1000.0}},
+		{"sprint-shaped via dates", map[string]interface{}{"name": "Sprint 1", "start_date": "x", "end_date": "y"}},
+		{"sprint-shaped via state+goal", map[string]interface{}{"state": "active", "goal": "ship"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := h.createTableForData(tt.sample)
+			require.NotNil(t, table)
+			assert.NotEmpty(t, table.Columns, "branch should produce a table with columns")
+		})
+	}
+
+	t.Run("unknown shape falls through to createGenericTable", func(t *testing.T) {
+		sample := map[string]interface{}{"foo": "bar", "baz": 1}
+		table := h.createTableForData(sample)
+		require.NotNil(t, table)
+		require.Len(t, table.Columns, len(sample), "generic table has one column per key")
+		// Verify keys round-trip through createGenericTable
+		keys := map[string]bool{}
+		for _, col := range table.Columns {
+			keys[col.Key] = true
+		}
+		assert.True(t, keys["foo"] && keys["baz"])
+	})
+}
+
+func TestEnhancedHandler_DisplayEnhancedCommandHelp(t *testing.T) {
+	t.Cleanup(setupTestEnvironment(t))
+	h := NewEnhancedHandler(nil)
+
+	tests := []struct {
+		name     string
+		commands []interface{}
+	}{
+		{"empty list", []interface{}{}},
+		{
+			"command without description or examples",
+			[]interface{}{map[string]interface{}{"command": "exit"}},
+		},
+		{
+			"command with description only",
+			[]interface{}{map[string]interface{}{"command": "help", "description": "Show help"}},
+		},
+		{
+			"command with description and examples",
+			[]interface{}{map[string]interface{}{
+				"command":     "list",
+				"description": "List assets",
+				"examples":    []interface{}{"list assets", "list assets --filter active"},
+			}},
+		},
+		{
+			"command name is a long string (exercises padding clamp)",
+			[]interface{}{map[string]interface{}{
+				"command":     strings.Repeat("x", 40),
+				"description": "Long-named command",
+			}},
+		},
+		{
+			"malformed entries are skipped without panic",
+			[]interface{}{
+				"not a map",
+				map[string]interface{}{"description": "missing command key"},
+				map[string]interface{}{"command": 42, "description": "command is not a string"},
+				map[string]interface{}{"command": "ok", "description": "fine"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				h.displayEnhancedCommandHelp(tt.commands)
+			})
+		})
+	}
+}
+
+func TestEnhancedHandler_DisplayEnhancedMapOutput_AllBranches(t *testing.T) {
+	t.Cleanup(setupTestEnvironment(t))
+	h := NewEnhancedHandler(nil)
+
+	tests := []struct {
+		name   string
+		output map[string]interface{}
+	}{
+		{
+			"tabular data (array of objects) triggers displayAsTable",
+			map[string]interface{}{
+				"assets": []interface{}{
+					map[string]interface{}{"name": "A", "status": "active"},
+					map[string]interface{}{"name": "B", "status": "archived"},
+				},
+			},
+		},
+		{
+			"single asset detail triggers displayAssetDetail",
+			map[string]interface{}{
+				"name":        "Asset A",
+				"id":          "42",
+				"description": "primary asset",
+				"status":      "active",
+			},
+		},
+		{
+			"map with message key prints the message and continues",
+			map[string]interface{}{
+				"message": "Asset created",
+				"other":   "field",
+			},
+		},
+		{
+			"map with commands key dispatches to displayEnhancedCommandHelp",
+			map[string]interface{}{
+				"commands": []interface{}{
+					map[string]interface{}{"command": "help", "description": "Show help"},
+				},
+			},
+		},
+		{
+			"map with non-string message value falls through without crash",
+			map[string]interface{}{
+				"message": 42, // not a string -- branch type assertion fails
+				"other":   "field",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() { h.displayEnhancedMapOutput(tt.output) })
+		})
+	}
+}
+
+func TestEnhancedHandler_DisplayEnhancedListOutput_AllBranches(t *testing.T) {
+	t.Cleanup(setupTestEnvironment(t))
+	h := NewEnhancedHandler(nil)
+
+	tests := []struct {
+		name   string
+		output []interface{}
+	}{
+		{
+			"list of objects with table-shape fields triggers displayListAsTable",
+			[]interface{}{
+				map[string]interface{}{"name": "A", "id": "1", "status": "active"},
+				map[string]interface{}{"name": "B", "id": "2", "status": "archived"},
+			},
+		},
+		{
+			"list of objects without table-shape fields renders as numbered list",
+			[]interface{}{
+				map[string]interface{}{"foo": "bar"},
+				map[string]interface{}{"baz": "qux"},
+			},
+		},
+		{
+			"list of scalars renders as numbered list",
+			[]interface{}{"one", "two", "three"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() { h.displayEnhancedListOutput(tt.output) })
+		})
+	}
+}
+
+func TestEnhancedHandler_DisplayEnhancedResult_DurationBranch(t *testing.T) {
+	t.Cleanup(setupTestEnvironment(t))
+	h := NewEnhancedHandler(nil)
+
+	tests := []struct {
+		name   string
+		result *application.ProcessResult
+	}{
+		{
+			"result with significant duration prints the elapsed line",
+			&application.ProcessResult{
+				Output:   "ok",
+				Duration: 250 * time.Millisecond,
+			},
+		},
+		{
+			"string output path",
+			&application.ProcessResult{Output: "plain string"},
+		},
+		{
+			"default case for unsupported output type",
+			&application.ProcessResult{Output: 42},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() { h.displayEnhancedResult(tt.result) })
+		})
+	}
+}
+
+func TestEnhancedHandler_DisplayInteractivePrompt(t *testing.T) {
+	t.Cleanup(setupTestEnvironment(t))
+	h := NewEnhancedHandler(nil)
+	assert.NotPanics(t, func() { h.displayInteractivePrompt() })
+}
+
+func TestEnhancedHandler_HandleEnhancedContextCommand_EarlyReturns(t *testing.T) {
+	t.Cleanup(setupTestEnvironment(t))
+	h := NewEnhancedHandler(nil)
+	ctx := context.Background()
+
+	t.Run("nil command returns nil", func(t *testing.T) {
+		err := h.handleEnhancedContextCommand(ctx, &application.ProcessResult{Command: nil})
+		assert.NoError(t, err)
+	})
+
+	t.Run("single-word interpreted returns nil before service call", func(t *testing.T) {
+		result := &application.ProcessResult{
+			Command: &domain.Command{Interpreted: "context"},
+		}
+		err := h.handleEnhancedContextCommand(ctx, result)
+		assert.NoError(t, err)
+	})
+
+	t.Run("unknown action falls through switch without service call", func(t *testing.T) {
+		result := &application.ProcessResult{
+			Command: &domain.Command{Interpreted: "context unknownaction"},
+		}
+		err := h.handleEnhancedContextCommand(ctx, result)
+		assert.NoError(t, err)
+	})
+}
+
+func TestHandler_HandleContextCommand_EarlyReturns(t *testing.T) {
+	t.Cleanup(setupTestEnvironment(t))
+	h := &Handler{promptStyle: DefaultStyle()}
+	ctx := context.Background()
+
+	t.Run("nil command returns nil", func(t *testing.T) {
+		err := h.handleContextCommand(ctx, &application.ProcessResult{Command: nil})
+		assert.NoError(t, err)
+	})
+
+	t.Run("single-word interpreted returns nil before service call", func(t *testing.T) {
+		result := &application.ProcessResult{
+			Command: &domain.Command{Interpreted: "context"},
+		}
+		err := h.handleContextCommand(ctx, result)
+		assert.NoError(t, err)
+	})
+
+	t.Run("unknown action falls through switch without service call", func(t *testing.T) {
+		result := &application.ProcessResult{
+			Command: &domain.Command{Interpreted: "context whatever"},
+		}
+		err := h.handleContextCommand(ctx, result)
+		assert.NoError(t, err)
+	})
+}
+
+func TestHandler_HandleInput_EmptyInput(t *testing.T) {
+	h := &Handler{promptStyle: DefaultStyle()}
+
+	err := h.handleInput(context.Background(), "")
+	assert.NoError(t, err)
+}
+
+func TestEnhancedHandler_DisplayCommandHistory_PopulatedAndOverflow(t *testing.T) {
+	t.Cleanup(setupTestEnvironment(t))
+
+	t.Run("populated history renders without panic", func(t *testing.T) {
+		h := NewEnhancedHandler(nil)
+		for i := 0; i < 5; i++ {
+			h.commandHistory = append(h.commandHistory, fmt.Sprintf("cmd-%d", i))
+		}
+		assert.NotPanics(t, func() { h.displayCommandHistory() })
+	})
+
+	t.Run("history with more than 20 entries triggers the trimming branch", func(t *testing.T) {
+		h := NewEnhancedHandler(nil)
+		for i := 0; i < 25; i++ {
+			h.commandHistory = append(h.commandHistory, fmt.Sprintf("cmd-%02d", i))
+		}
+		assert.NotPanics(t, func() { h.displayCommandHistory() })
+	})
 }


### PR DESCRIPTION
## Summary

One commit, one file, test-only. Lifts `console/infrastructure/prompt` from 52.5% → 70.2%. This was the third of the three critical-gap packages from the project review; unlike the first two, this one stops short of the 80% architectural target — see the **Honest gap report** at the bottom.

`enhanced_handler.go` is 916 production LOC with only 230 LOC of tests. The big concentrations of zero coverage were either pure helpers nobody had touched, or branches of the context-command handlers that return early before touching `ConsoleService`. Both are testable without changing production code.

## What's now covered

| Target | Before | After |
|---|---|---|
| `addToCommandHistory` | 0% | 100% |
| `formatResultForHistory` | 0% | 100% |
| `formatKeyName` | (transitive) | 100% |
| `createGenericTable` | 0% | 91% |
| `createTableForData` | 25% | 92% |
| `displayEnhancedCommandHelp` | 0% | high |
| `displayEnhancedMapOutput` | 45.5% | 86.4% |
| `displayEnhancedListOutput` | 80% | higher |
| `displayInteractivePrompt` | 0% | 100% |
| `Handler.handleContextCommand` (early returns) | 0% | 47.1% |
| `EnhancedHandler.handleEnhancedContextCommand` (early returns) | 0% | 47.1% |
| `Handler.handleInput` (empty-input branch) | 0% | 10% |
| `displayCommandHistory` | 41% | higher |

Specific scenarios per target:

- **`addToCommandHistory`**: empty skip, consecutive-duplicate skip, non-consecutive duplicate recorded, 100-entry FIFO cap, `historyIndex` reset on insert.
- **`formatResultForHistory`**: all six output-type branches (nil, map with message, map without message, slice, string, fmt-fallback default).
- **`formatKeyName`**: snake_case → Title Case across edge cases including empty input and already-cased input.
- **`createGenericTable`**: column count and ordering, header humanization, status and date formatter assignment. Also includes an explicit pin on the observable behavior of the money branch — the inner `if strings.Contains(strings.ToLower(key), "total")` guard is **effectively unreachable** because the outer switch only matches exact keys (`"cost"`, `"investment"`, `"price"`, `"amount"`), none of which contain `"total"`. Pinned so a future refactor catches it.
- **`createTableForData`**: every dispatch branch (asset, task, two investment shapes, engineer, two sprint shapes, generic fallthrough).
- **`displayEnhancedCommandHelp`**: empty list, no-description, description-only, with examples, long-name padding clamp, malformed entries (skip without panic).
- **`displayEnhancedMapOutput`**: the four previously-unhit branches (tabular data, single-asset detail, message key, commands key) plus the non-string message fallthrough.
- **Context-command early returns** (both Handler and EnhancedHandler): nil command, single-word interpreted (no action), unknown action — the three branches reachable without a real `ConsoleService`.

## Honest gap report

The package didn't clear 80%. Remaining 0% functions:

- `Start` (both Handler and EnhancedHandler) — main loop
- `processInput` / `processEnhancedInput` — read from `bufio.NewReader(os.Stdin)`
- service-bound paths of `handleInput` / `handleEnhancedInput` / `handleContextCommand` / `handleEnhancedContextCommand` — call `consoleService.ProcessInput` / `GetSessionContext`

Closing the rest of the gap requires either:
1. **Refactor production**: extract `bufio.NewReader(os.Stdin)` to an injectable `io.Reader` on the handler, then tests can pipe input.
2. **Local stubs**: add `ContextStore` / `AIInterpreter` / `CommandExecutor` stubs at the test boundary to exercise the service-bound paths.

Both are separate concerns from this test-only pass and warrant their own discussion before landing.

## Unrelated finding

`go test -race ./internal/console/infrastructure/prompt/` surfaces a **pre-existing data race** in `animateSpinner` (read at `enhanced_handler.go:267`) vs `stopProcessingIndicator` (write at `enhanced_handler.go:261`). It reproduces on `main` independently of these tests. CI runs without `-race` so it has not been flagged. Out of scope here, but worth opening a follow-up.

## Test plan

- [x] `go test ./internal/console/infrastructure/prompt/ -count=1` — green
- [x] `go test ./internal/console/...` — full console package suite green
- [x] Coverage 52.5% → 70.2%
- [ ] `-race` flagged the pre-existing spinner race — not introduced by these tests