### PR TITLE
fix(prompt): eliminate spinner data race

### DIFF
--- a/internal/console/infrastructure/prompt/enhanced_handler.go
+++ b/internal/console/infrastructure/prompt/enhanced_handler.go
@@ -28,6 +28,8 @@ type EnhancedHandler struct {
 	promptSession  *ui.PromptSession
 	palette        ui.ColorPalette
 	spinner        *ui.Spinner
+	spinnerStop    chan struct{} // closed by stopProcessingIndicator to signal exit
+	spinnerDone    chan struct{} // closed by the animate goroutine on exit
 	smartFormatter *ui.SmartFormatter
 	maxWidth       int
 	commandHistory []string
@@ -245,43 +247,54 @@ func (h *EnhancedHandler) addToHistory(input, output string, duration time.Durat
 func (h *EnhancedHandler) startProcessingIndicator(message string) {
 	h.spinner = ui.NewSpinner(ui.SpinnerDots, message)
 	h.spinner.SetColor(ui.ColorInfo)
+	h.spinnerStop = make(chan struct{})
+	h.spinnerDone = make(chan struct{})
 
 	// Show initial spinner state
 	fmt.Printf("\n%s", h.spinner.Render())
 
-	// Start a goroutine to animate the spinner
-	go h.animateSpinner()
+	// Start a goroutine to animate the spinner. We pass the spinner and
+	// channels by value so the goroutine never reads h.spinner concurrently
+	// with the field being cleared in stopProcessingIndicator.
+	go animateSpinner(h.spinner, h.spinnerStop, h.spinnerDone)
 }
 
-// stopProcessingIndicator stops the processing spinner
+// stopProcessingIndicator stops the processing spinner. Safe to call when
+// no spinner is running.
 func (h *EnhancedHandler) stopProcessingIndicator() {
-	if h.spinner != nil {
-		// Clear the spinner line and move to next line
-		fmt.Print("\r" + strings.Repeat(" ", h.maxWidth) + "\r")
-		h.spinner = nil
-	}
-}
-
-// animateSpinner animates the spinner while processing
-func (h *EnhancedHandler) animateSpinner() {
 	if h.spinner == nil {
 		return
 	}
 
-	ticker := time.NewTicker(h.spinner.GetInterval())
+	close(h.spinnerStop)
+	<-h.spinnerDone
+
+	// Clear the spinner line. Safe to do now that the animate goroutine
+	// has exited and won't race with us.
+	fmt.Print("\r" + strings.Repeat(" ", h.maxWidth) + "\r")
+	h.spinner = nil
+	h.spinnerStop = nil
+	h.spinnerDone = nil
+}
+
+// animateSpinner animates the given spinner until stop is closed, then
+// signals done. It does not touch any handler state, which is what makes
+// it race-free against stopProcessingIndicator.
+func animateSpinner(spinner *ui.Spinner, stop <-chan struct{}, done chan<- struct{}) {
+	defer close(done)
+	if spinner == nil {
+		return
+	}
+
+	ticker := time.NewTicker(spinner.GetInterval())
 	defer ticker.Stop()
 
 	for {
-		<-ticker.C
-		if h.spinner == nil {
+		select {
+		case <-stop:
 			return
-		}
-		// Update spinner and redraw
-		fmt.Printf("\r%s", h.spinner.Render())
-
-		// Check if spinner was stopped
-		if h.spinner == nil {
-			return
+		case <-ticker.C:
+			fmt.Printf("\r%s", spinner.Render())
 		}
 	}
 }

--- a/internal/console/infrastructure/prompt/enhanced_handler_test.go
+++ b/internal/console/infrastructure/prompt/enhanced_handler_test.go
@@ -85,6 +85,28 @@ func TestEnhancedHandler_SpinnerMethods_Standalone(t *testing.T) {
 	})
 }
 
+// TestEnhancedHandler_Spinner_StartStopIsRaceFree asserts that
+// startProcessingIndicator and stopProcessingIndicator do not race on
+// h.spinner. Before the fix, the animate goroutine read h.spinner three
+// times per tick while stopProcessingIndicator wrote h.spinner = nil from
+// the caller's goroutine; the data race was reproducible under `go test
+// -race`. Running start/stop multiple times here -- and especially within
+// less than one tick interval -- exercises both the happy stop path and
+// the case where the goroutine is still picking up the spinner pointer
+// when stop fires.
+func TestEnhancedHandler_Spinner_StartStopIsRaceFree(t *testing.T) {
+	handler := NewEnhancedHandler(nil)
+
+	for i := 0; i < 5; i++ {
+		handler.startProcessingIndicator("Working...")
+		handler.stopProcessingIndicator()
+	}
+
+	// Also drive a stop on an idle handler -- previously a no-op, must
+	// stay a no-op.
+	handler.stopProcessingIndicator()
+}
+
 func TestEnhancedHandler_DisplayMethods_Standalone(t *testing.T) {
 	handler := NewEnhancedHandler(nil)
 


### PR DESCRIPTION
## Summary

Fixes a real data race in `EnhancedHandler`'s spinner code that the previous test PR (#69) surfaced under `-race`. CI runs without `-race`, so this race has been hiding in production code.

## The bug

In the original implementation:

- The animate goroutine read `h.spinner` three times per tick: once to call `h.spinner.Render()` and twice for the `h.spinner == nil` exit guards.
- `stopProcessingIndicator` wrote `h.spinner = nil` from the caller's goroutine.
- No mutex, no channel, no atomic. `go test -race ./internal/console/infrastructure/prompt/` reported a clean data race on the field.

## The fix

Replace the polling-for-nil pattern with a stop/done channel pair, and lift `animateSpinner` out of the method receiver so the goroutine cannot reach handler state:

- `startProcessingIndicator` allocates fresh `stop` and `done` channels and hands the spinner pointer plus channels to the goroutine **by value**. The goroutine never touches `h.*` fields.
- `stopProcessingIndicator` closes the stop channel, waits on done, then clears `h.spinner` and the channels. The wait guarantees the goroutine has exited before any mutation, so no read/write overlap.
- Re-entrant calls on an idle handler short-circuit on `h.spinner == nil` and stay a no-op (matching old behavior).
- `animateSpinner` selects on the ticker and stop; no more per-tick nil checks.

## Test plan

- [x] Existing `TestEnhancedHandler_SpinnerMethods_Standalone` keeps its don't-panic guarantee.
- [x] New `TestEnhancedHandler_Spinner_StartStopIsRaceFree` drives five back-to-back start/stop cycles plus a stop on an idle handler.
- [x] `go test -race ./internal/console/infrastructure/prompt/ -count=5` — clean.
- [x] `go test -race ./internal/console/...` — clean across the whole console package.
- [x] Full project suite `go test ./...` — green.

## Note

This bug was independently flagged in #69's PR description. Closing that loop.