### PR TITLE
perf(tasks): batch JSON task saves and serialize mutations

### DIFF
--- a/internal/deployments/infrastructure/asset_resolver_adapter_test.go
+++ b/internal/deployments/infrastructure/asset_resolver_adapter_test.go
@@ -58,6 +58,15 @@ func (m *MockTaskRepository) Save(ctx context.Context, task *tasksDomain.Task) e
 	return args.Error(0)
 }
 
+func (m *MockTaskRepository) SaveAll(ctx context.Context, tasks []*tasksDomain.Task) error {
+	for _, task := range tasks {
+		if err := m.Save(ctx, task); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (m *MockTaskRepository) Delete(ctx context.Context, key string) error {
 	args := m.Called(ctx, key)
 	return args.Error(0)

--- a/internal/tasks/application/usecase/classify_tasks.go
+++ b/internal/tasks/application/usecase/classify_tasks.go
@@ -65,11 +65,10 @@ func (uc *ClassifyTasksUseCase) Execute(ctx context.Context, input domain.Classi
 				return fmt.Errorf("failed to fetch tasks: %w", fetchErr)
 			}
 
-			// Save fetched tasks to repository
-			for _, task := range fetchedTasks {
-				if saveErr := uc.localRepo.Save(ctx, task); saveErr != nil {
-					return fmt.Errorf("failed to save fetched task %s: %w", task.Key, saveErr)
-				}
+			// Save fetched tasks to repository in one batch -- per-task Save
+			// would re-read and re-write the entire JSON file once per task.
+			if saveErr := uc.localRepo.SaveAll(ctx, fetchedTasks); saveErr != nil {
+				return fmt.Errorf("failed to save fetched tasks: %w", saveErr)
 			}
 			tasks = fetchedTasks
 		} else {
@@ -146,23 +145,34 @@ func (uc *ClassifyTasksUseCase) Execute(ctx context.Context, input domain.Classi
 		}
 	}
 
+	// Phase 1: stamp every task with its new work type in memory.
+	updatedTasks := make([]*domain.Task, 0, len(classificationResults))
+	for _, result := range classificationResults {
+		if err := result.Task.UpdateWorkType(result.WorkType); err != nil {
+			return fmt.Errorf("failed to update work type for task %s: %w", result.Task.Key, err)
+		}
+		updatedTasks = append(updatedTasks, result.Task)
+	}
+
+	// Phase 2: persist the whole batch locally in a single load/store
+	// cycle. Doing this BEFORE pushing to JIRA preserves the original
+	// invariant that any task whose classification we attempted to push
+	// remotely is already saved locally -- so a mid-loop JIRA failure
+	// doesn't leave the on-disk state out of sync with what's already
+	// landed on the remote.
+	if err := uc.localRepo.SaveAll(ctx, updatedTasks); err != nil {
+		return fmt.Errorf("failed to persist classified tasks: %w", err)
+	}
+
+	// Phase 3: apply label updates to JIRA (or just narrate when in
+	// local-only mode). Errors here abort the run; previously persisted
+	// local state stays correct because of phase 2.
 	successCount := 0
 	for _, result := range classificationResults {
 		task := result.Task
 		workType := result.WorkType
 
-		if err := task.UpdateWorkType(workType); err != nil {
-			return fmt.Errorf("failed to update work type for task %s: %w", task.Key, err)
-		}
-
-		// Save updated task locally
-		if err := uc.localRepo.Save(ctx, task); err != nil {
-			return fmt.Errorf("failed to save classified task %s: %w", task.Key, err)
-		}
-
-		// Apply labels to Jira if requested
 		if input.Apply {
-			// Build add/remove label sets for cap-prefixed labels only
 			addLabels, removeLabels := uc.buildLabelChanges(task.Labels, workType, result.Asset)
 
 			fmt.Printf("  🏷️  %s → %s", task.Key, workType)
@@ -418,11 +428,9 @@ func (uc *ClassifyTasksUseCase) GetTasks(ctx context.Context, project, sprint st
 			return nil, fmt.Errorf("failed to fetch tasks from remote: %w", fetchErr)
 		}
 
-		// Save remote tasks to local repository
-		for _, task := range remoteTasks {
-			if saveErr := uc.localRepo.Save(ctx, task); saveErr != nil {
-				return nil, fmt.Errorf("failed to save fetched task: %w", saveErr)
-			}
+		// Save remote tasks to local repository in one batch.
+		if saveErr := uc.localRepo.SaveAll(ctx, remoteTasks); saveErr != nil {
+			return nil, fmt.Errorf("failed to save fetched tasks: %w", saveErr)
 		}
 
 		return remoteTasks, nil

--- a/internal/tasks/application/usecase/classify_tasks_test.go
+++ b/internal/tasks/application/usecase/classify_tasks_test.go
@@ -84,6 +84,18 @@ func (m *MockTaskRepository) Save(ctx context.Context, task *domain.Task) error 
 	return args.Error(0)
 }
 
+// SaveAll defers to Save so existing test expectations set on Save
+// (with Times(N), specific task args, or mock.Anything) cover the new
+// batch path without needing to be rewritten.
+func (m *MockTaskRepository) SaveAll(ctx context.Context, tasks []*domain.Task) error {
+	for _, task := range tasks {
+		if err := m.Save(ctx, task); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (m *MockTaskRepository) Delete(ctx context.Context, key string) error {
 	args := m.Called(ctx, key)
 	return args.Error(0)
@@ -1293,6 +1305,7 @@ func TestClassifyTasksEdgeCases(t *testing.T) {
 
 		localRepo.On("FindByProjectAndSprint", ctx, testProject, testSprint).Return(tasks, nil)
 		classifier.On("ClassifyTasks", tasks).Return(workTypes, nil)
+		// Save delegation under MockTaskRepository.SaveAll covers this expectation.
 		localRepo.On("Save", ctx, mock.Anything).Return(fmt.Errorf("save error"))
 
 		// Act
@@ -1300,7 +1313,7 @@ func TestClassifyTasksEdgeCases(t *testing.T) {
 
 		// Assert
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to save classified task TEST-1")
+		assert.Contains(t, err.Error(), "failed to persist classified tasks")
 		localRepo.AssertExpectations(t)
 		classifier.AssertExpectations(t)
 	})
@@ -1763,17 +1776,23 @@ func TestAdditionalErrorHandlingAndEdgeCases(t *testing.T) {
 	})
 
 	t.Run("should handle classification with mixed success and failure", func(t *testing.T) {
-		// Create mocks
+		// Under the original semantics this exercised an interleaved Save/Apply
+		// loop where Save(TEST-1) + Apply(TEST-1) succeeded before Save(TEST-2)
+		// failed. The batch-then-push design persists every task in one
+		// SaveAll call BEFORE any remote update, so a save failure now aborts
+		// before any UpdateLabels call. The test therefore asserts that:
+		//   - SaveAll returns the second task's failure (delegation routes
+		//     to Save(tasks[1]) which is wired to fail);
+		//   - the error message reports the batch-level persistence failure;
+		//   - no UpdateLabels expectation fires because phase 3 never runs.
 		localRepo := new(MockTaskRepository)
 		remoteRepo := new(MockTaskRepository)
 		comprehensiveClassifier := new(MockComprehensiveTaskClassifier)
 		userInput := new(MockUserInput)
 		assetService := testutil.NewMockAssetService()
 
-		// Create use case
 		uc := NewClassifyTasksUseCase(localRepo, remoteRepo, comprehensiveClassifier, userInput, assetService, nil)
 
-		// Arrange
 		input := domain.ClassifyTasksInput{
 			Project: testProject,
 			Sprint:  testSprint,
@@ -1803,18 +1822,13 @@ func TestAdditionalErrorHandlingAndEdgeCases(t *testing.T) {
 
 		localRepo.On("FindByProjectAndSprint", ctx, testProject, testSprint).Return(tasks, nil)
 		comprehensiveClassifier.On("ClassifyTasksComprehensive", tasks).Return(results, nil)
-		// First task saves successfully
 		localRepo.On("Save", ctx, tasks[0]).Return(nil)
-		remoteRepo.On("UpdateLabels", ctx, "TEST-1", []string{"cap-development"}, []string(nil)).Return(nil)
-		// Second task fails to save
 		localRepo.On("Save", ctx, tasks[1]).Return(fmt.Errorf("save error"))
 
-		// Act
 		err := uc.Execute(ctx, input)
 
-		// Assert
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to save classified task TEST-2")
+		assert.Contains(t, err.Error(), "failed to persist classified tasks")
 		localRepo.AssertExpectations(t)
 		remoteRepo.AssertExpectations(t)
 		comprehensiveClassifier.AssertExpectations(t)

--- a/internal/tasks/application/usecase/fetch_tasks.go
+++ b/internal/tasks/application/usecase/fetch_tasks.go
@@ -53,11 +53,10 @@ func (u *FetchTasksUseCase) Execute(ctx context.Context, project, sprint, platfo
 		return fmt.Errorf("failed to fetch tasks: %w", err)
 	}
 
-	// Save tasks to local storage
-	for _, task := range tasks {
-		if err := u.localRepo.Save(ctx, task); err != nil {
-			return fmt.Errorf("failed to save task %s: %w", task.Key, err)
-		}
+	// Save tasks to local storage in one batch -- per-task Save would
+	// re-read and re-write the entire JSON file once per task.
+	if err := u.localRepo.SaveAll(ctx, tasks); err != nil {
+		return fmt.Errorf("failed to save tasks: %w", err)
 	}
 
 	// Display tasks

--- a/internal/tasks/application/usecase/testutil/mock_repository.go
+++ b/internal/tasks/application/usecase/testutil/mock_repository.go
@@ -55,6 +55,17 @@ func (m *MockTaskRepository) SetFindByKeyFunc(f func(ctx context.Context, key st
 	m.findByKeyFunc = f
 }
 
+// SaveAll persists multiple tasks. The default implementation routes
+// each entry through Save so callers don't need a separate hook.
+func (m *MockTaskRepository) SaveAll(ctx context.Context, tasks []*domain.Task) error {
+	for _, task := range tasks {
+		if err := m.Save(ctx, task); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Save saves a task to the repository
 func (m *MockTaskRepository) Save(ctx context.Context, task *domain.Task) error {
 	if m.saveFunc != nil {

--- a/internal/tasks/domain/ports/task_repository.go
+++ b/internal/tasks/domain/ports/task_repository.go
@@ -11,6 +11,14 @@ type TaskRepository interface {
 	// Save persists a task
 	Save(ctx context.Context, task *domain.Task) error
 
+	// SaveAll persists multiple tasks atomically with respect to the
+	// repository's internal load/store cycle. For implementations backed
+	// by a file (e.g. JSON storage) this is dramatically cheaper than
+	// calling Save in a loop, which would re-read and re-write the
+	// entire file once per task. Implementations MAY treat SaveAll as
+	// equivalent to Save-in-a-loop when no batch path applies.
+	SaveAll(ctx context.Context, tasks []*domain.Task) error
+
 	// FindByKey retrieves a task by its key
 	FindByKey(ctx context.Context, key string) (*domain.Task, error)
 

--- a/internal/tasks/domain/ports/task_repository_test.go
+++ b/internal/tasks/domain/ports/task_repository_test.go
@@ -27,6 +27,16 @@ func (m *mockRepository) Save(_ context.Context, task *domain.Task) error {
 	return nil
 }
 
+func (m *mockRepository) SaveAll(_ context.Context, tasks []*domain.Task) error {
+	for _, task := range tasks {
+		if task == nil {
+			continue
+		}
+		m.tasks[task.Key] = task
+	}
+	return nil
+}
+
 func (m *mockRepository) FindByKey(_ context.Context, key string) (*domain.Task, error) {
 	if task, exists := m.tasks[key]; exists {
 		return task, nil

--- a/internal/tasks/infrastructure/jira/jira_task_repository.go
+++ b/internal/tasks/infrastructure/jira/jira_task_repository.go
@@ -62,6 +62,18 @@ func (r *TaskRepository) Save(_ context.Context, _ *domain.Task) error {
 	return fmt.Errorf("not implemented")
 }
 
+// SaveAll persists a batch of tasks. JIRA has no atomic bulk-write
+// endpoint for the fields we care about, so we satisfy the port by
+// delegating to Save in a loop. Returns on the first error.
+func (r *TaskRepository) SaveAll(ctx context.Context, tasks []*domain.Task) error {
+	for _, task := range tasks {
+		if err := r.Save(ctx, task); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // FindByKey finds a task by its key
 func (r *TaskRepository) FindByKey(ctx context.Context, key string) (*domain.Task, error) {
 	if key == "" {

--- a/internal/tasks/infrastructure/storage/json_storage.go
+++ b/internal/tasks/infrastructure/storage/json_storage.go
@@ -6,13 +6,22 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain"
 	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain/ports"
 )
 
-// JSONStorage implements TaskRepository using JSON files
+// JSONStorage implements TaskRepository using JSON files.
+//
+// Every mutation does a full load / modify / write cycle. The mutex
+// serialises mutations and read methods so concurrent callers (the
+// classify-and-save loop, future parallel classification work) cannot
+// race read-modify-write cycles and lose updates. SaveAll exists for
+// the bulk-update path where calling Save in a loop would do N reads
+// and N writes; SaveAll does one of each.
 type JSONStorage struct {
+	mu   sync.RWMutex
 	dir  string
 	file string
 }
@@ -31,16 +40,41 @@ func (s *JSONStorage) Save(_ context.Context, task *domain.Task) error {
 		return fmt.Errorf("task cannot be nil")
 	}
 
-	// Load existing tasks
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	tasks, err := s.loadTasks()
 	if err != nil {
 		return fmt.Errorf("failed to load tasks: %w", err)
 	}
 
-	// Update or add the task
 	tasks[task.Key] = task
 
-	// Save back to file
+	return s.saveTasks(tasks)
+}
+
+// SaveAll persists multiple tasks in a single load/store cycle. Nil
+// entries in the slice are skipped; an empty input is a no-op.
+func (s *JSONStorage) SaveAll(_ context.Context, batch []*domain.Task) error {
+	if len(batch) == 0 {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tasks, err := s.loadTasks()
+	if err != nil {
+		return fmt.Errorf("failed to load tasks: %w", err)
+	}
+
+	for _, task := range batch {
+		if task == nil {
+			continue
+		}
+		tasks[task.Key] = task
+	}
+
 	return s.saveTasks(tasks)
 }
 
@@ -49,6 +83,9 @@ func (s *JSONStorage) FindByKey(_ context.Context, key string) (*domain.Task, er
 	if key == "" {
 		return nil, fmt.Errorf("task key cannot be empty")
 	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	tasks, err := s.loadTasks()
 	if err != nil {
@@ -65,6 +102,9 @@ func (s *JSONStorage) FindByKey(_ context.Context, key string) (*domain.Task, er
 
 // FindByProjectAndSprint retrieves tasks for a specific project and sprint
 func (s *JSONStorage) FindByProjectAndSprint(_ context.Context, project, sprint string) ([]*domain.Task, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	tasks, err := s.loadTasks()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load tasks: %w", err)
@@ -82,6 +122,9 @@ func (s *JSONStorage) FindByProjectAndSprint(_ context.Context, project, sprint 
 
 // FindByProject retrieves all tasks for a specific project
 func (s *JSONStorage) FindByProject(_ context.Context, project string) ([]*domain.Task, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	tasks, err := s.loadTasks()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load tasks: %w", err)
@@ -99,6 +142,9 @@ func (s *JSONStorage) FindByProject(_ context.Context, project string) ([]*domai
 
 // FindBySprint retrieves all tasks for a specific sprint
 func (s *JSONStorage) FindBySprint(_ context.Context, sprint string) ([]*domain.Task, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	tasks, err := s.loadTasks()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load tasks: %w", err)
@@ -116,6 +162,9 @@ func (s *JSONStorage) FindBySprint(_ context.Context, sprint string) ([]*domain.
 
 // FindByPlatform retrieves all tasks for a specific platform
 func (s *JSONStorage) FindByPlatform(_ context.Context, platform string) ([]*domain.Task, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	tasks, err := s.loadTasks()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load tasks: %w", err)
@@ -133,6 +182,9 @@ func (s *JSONStorage) FindByPlatform(_ context.Context, platform string) ([]*dom
 
 // FindAll retrieves all tasks
 func (s *JSONStorage) FindAll(_ context.Context) ([]*domain.Task, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	tasks, err := s.loadTasks()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load tasks: %w", err)
@@ -152,6 +204,9 @@ func (s *JSONStorage) Delete(_ context.Context, key string) error {
 		return fmt.Errorf("task key cannot be empty")
 	}
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	tasks, err := s.loadTasks()
 	if err != nil {
 		return fmt.Errorf("failed to load tasks: %w", err)
@@ -167,6 +222,9 @@ func (s *JSONStorage) Delete(_ context.Context, key string) error {
 
 // DeleteByProjectAndSprint removes all tasks for a specific project and sprint
 func (s *JSONStorage) DeleteByProjectAndSprint(_ context.Context, project, sprint string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	tasks, err := s.loadTasks()
 	if err != nil {
 		return fmt.Errorf("failed to load tasks: %w", err)
@@ -189,6 +247,9 @@ func (s *JSONStorage) UpdateLabels(_ context.Context, taskKey string, addLabels,
 	if taskKey == "" {
 		return fmt.Errorf("task key cannot be empty")
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	tasks, err := s.loadTasks()
 	if err != nil {

--- a/internal/tasks/infrastructure/storage/json_storage_test.go
+++ b/internal/tasks/infrastructure/storage/json_storage_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -589,4 +590,119 @@ func TestJSONStorage_LoadTasks_ErrorCases(t *testing.T) {
 		err = os.Chmod(restrictedFile, 0644)
 		assert.NoError(t, err, "Failed to make file removable for cleanup")
 	})
+}
+
+func TestJSONStorage_SaveAll(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty batch is a no-op and returns nil", func(t *testing.T) {
+		h := setupTest(t)
+		defer h.cleanup(t)
+
+		require.NoError(t, h.storage.SaveAll(ctx, nil))
+		require.NoError(t, h.storage.SaveAll(ctx, []*domain.Task{}))
+
+		all, err := h.storage.FindAll(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, all)
+	})
+
+	t.Run("persists every task in a single load/store cycle", func(t *testing.T) {
+		h := setupTest(t)
+		defer h.cleanup(t)
+
+		batch := []*domain.Task{
+			h.createTestTask("TST-1", "First", "TST", "Sprint A"),
+			h.createTestTask("TST-2", "Second", "TST", "Sprint A"),
+			h.createTestTask("TST-3", "Third", "TST", "Sprint B"),
+		}
+
+		require.NoError(t, h.storage.SaveAll(ctx, batch))
+
+		all, err := h.storage.FindAll(ctx)
+		require.NoError(t, err)
+		assert.Len(t, all, 3)
+	})
+
+	t.Run("nil entries in the batch are skipped", func(t *testing.T) {
+		h := setupTest(t)
+		defer h.cleanup(t)
+
+		batch := []*domain.Task{
+			h.createTestTask("TST-1", "First", "TST", "Sprint A"),
+			nil,
+			h.createTestTask("TST-2", "Second", "TST", "Sprint A"),
+		}
+
+		require.NoError(t, h.storage.SaveAll(ctx, batch))
+
+		all, err := h.storage.FindAll(ctx)
+		require.NoError(t, err)
+		assert.Len(t, all, 2)
+	})
+
+	t.Run("merges with existing tasks instead of replacing", func(t *testing.T) {
+		h := setupTest(t)
+		defer h.cleanup(t)
+
+		require.NoError(t, h.storage.Save(ctx, h.createTestTask("EXIST-1", "Pre-existing", "TST", "Sprint A")))
+
+		batch := []*domain.Task{
+			h.createTestTask("TST-1", "Fresh", "TST", "Sprint A"),
+			h.createTestTask("EXIST-1", "Updated description", "TST", "Sprint A"),
+		}
+		require.NoError(t, h.storage.SaveAll(ctx, batch))
+
+		updated, err := h.storage.FindByKey(ctx, "EXIST-1")
+		require.NoError(t, err)
+		assert.Equal(t, "Updated description", updated.Summary, "SaveAll should overwrite existing entries by key")
+
+		all, err := h.storage.FindAll(ctx)
+		require.NoError(t, err)
+		assert.Len(t, all, 2)
+	})
+}
+
+// TestJSONStorage_ConcurrentSaves drives many concurrent Save / SaveAll
+// callers and asserts every write is persisted. Without the mutex, the
+// read-modify-write inside each call would race and the final file would
+// silently miss writes. Designed to run under -race.
+func TestJSONStorage_ConcurrentSaves(t *testing.T) {
+	h := setupTest(t)
+	defer h.cleanup(t)
+
+	ctx := context.Background()
+	const single = 12
+	const batches = 4
+	const perBatch = 5
+	expected := single + batches*perBatch
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < single; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			task := h.createTestTask(fmt.Sprintf("ONE-%02d", i), "single", "TST", "Sprint A")
+			require.NoError(t, h.storage.Save(ctx, task))
+		}(i)
+	}
+
+	for b := 0; b < batches; b++ {
+		wg.Add(1)
+		go func(b int) {
+			defer wg.Done()
+			batch := make([]*domain.Task, 0, perBatch)
+			for j := 0; j < perBatch; j++ {
+				batch = append(batch, h.createTestTask(fmt.Sprintf("BATCH-%d-%02d", b, j), "batch", "TST", "Sprint A"))
+			}
+			require.NoError(t, h.storage.SaveAll(ctx, batch))
+		}(b)
+	}
+
+	wg.Wait()
+
+	all, err := h.storage.FindAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, expected, "every concurrent Save and SaveAll should be persisted")
 }


### PR DESCRIPTION
## Summary

Closes the O(n²) issue in `tasks/infrastructure/storage/json_storage.go` flagged in the original project review: each `Save` reads/parses/writes the whole `tasks.json`. The sprint-classify loop calls it once per task, so a sprint of fifty new tasks reads-and-rewrites the entire on-disk pile fifty times.

## The change

**Port** (`task_repository.go`): adds `SaveAll(ctx, []*Task) error` to `TaskRepository`. Implementations MAY treat it as Save-in-a-loop where no batch path applies.

**JSONStorage**: implements `SaveAll` as a single load → in-memory merge → single save. Also picks up a `sync.RWMutex`, mirroring the asset `JSONRepository` change from #66 — reads take `RLock`, writes take `Lock`. Today's callers are sequential, but the per-task `Save` path was already racy under any concurrent caller, and this is a prerequisite for the planned parallel-classifier follow-up.

**JIRA `TaskRepository`**: `SaveAll` delegates to `Save` in a loop. `Save` itself is still `"not implemented"`; no perf regression because nobody hits it in a tight loop.

**Mocks** (three of them — `testutil/mock_repository.go`, `domain/ports/task_repository_test.go`, `usecase/classify_tasks_test.go`, plus `deployments/infrastructure/asset_resolver_adapter_test.go`): each `SaveAll` delegates to `Save` so existing per-task expectations (with `Times(N)`, specific task args, or `mock.Anything`) cover the new code path without needing rewrites.

**Call sites** — four loops swapped to `SaveAll`:
1. `classify_tasks.go:69` — fetched-tasks save
2. `classify_tasks.go:155` — post-classification save (the main hotspot)
3. `classify_tasks.go:417` — `GetTasks` remote fallback
4. `fetch_tasks.go:57` — bulk-fetched tasks

## Semantics tightening on the classify loop

The previous interleaved `Save(task) + UpdateLabels(task)` per iteration meant an apply failure mid-loop left an inconsistent state: tasks `0..N-1` saved-and-pushed, task `N` saved-but-not-pushed, tasks `N+1..` neither.

The new structure is **phase 1 stamp**, **phase 2 SaveAll**, **phase 3 push**. An apply failure now aborts with local state already on disk for every task we'll attempt to push — the original invariant, enforced up-front instead of incrementally. Two tests pinned the old interleaved behavior and were updated to assert the new (stronger) one.

## Test plan

- [x] `go test ./...` — green across the whole project.
- [x] `go test -race ./internal/tasks/infrastructure/storage -count=3` — `TestJSONStorage_ConcurrentSaves` drives 12 single `Save` + 4 `SaveAll` batches in parallel and asserts every write persists. Clean.
- [x] `go test -race ./internal/tasks/... ./internal/deployments/...` — all clean except a pre-existing jira race (below).

## Unrelated finding (pre-existing)

`go test -race ./internal/tasks/infrastructure/jira/ -run TestClient_FetchTasks` flags a separate data race in `client.go`'s `fetchTasksWithDualStrategy` / `resolveFieldIDs`: two goroutines mutate shared client state through `resolveFieldIDs` without synchronization. Reproducible on `main` without this PR — confirmed via `git stash`. CI doesn't use `-race`, so this has been hiding too. Out of scope here; flagging for a follow-up (it's adjacent to the "no rate limiting on JIRA API calls" item from the original review).