### PR TITLE
perf(classifier): parallelize ClassifyTask passes with bounded concurrency

### DIFF
--- a/internal/tasks/infrastructure/classifier/classification_chain.go
+++ b/internal/tasks/infrastructure/classifier/classification_chain.go
@@ -3,12 +3,33 @@ package classifier
 import (
 	"fmt"
 	"log"
+	"runtime"
 	"strings"
+
+	"golang.org/x/sync/errgroup"
 
 	assetdomain "github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
 	taskdomain "github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain"
 	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain/ports"
 )
+
+// classifyConcurrencyCap bounds the number of in-flight ClassifyTask
+// invocations during a parallel pass. CPU-bound classification scales
+// with NumCPU, while LLM-enabled runs would happily DOS the local Ollama
+// if uncapped; eight is a reasonable middle ground that helps real
+// workloads without being hostile to either case.
+const classifyConcurrencyCap = 8
+
+func classifyConcurrency() int {
+	n := runtime.NumCPU()
+	if n > classifyConcurrencyCap {
+		n = classifyConcurrencyCap
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
 
 // ComprehensiveClassificationChain orchestrates multiple classifiers for comprehensive task classification
 type ComprehensiveClassificationChain struct {
@@ -460,23 +481,24 @@ func (c *ComprehensiveClassificationChainWithInheritance) ClassifyTasks(tasks []
 		}
 	}
 
-	// Classify non-subtasks first
-	for _, task := range nonSubtasks {
-		result, err := c.ClassifyTask(task)
-		if err != nil {
-			return nil, fmt.Errorf("failed to classify task %s: %w", task.Key, err)
-		}
-		results = append(results, result)
+	// Phase 1: classify non-subtasks in parallel. The phase ordering is
+	// load-bearing -- subtasks read parent classifications via taskLookup,
+	// which is populated above. Within a phase, ClassifyTask only reads
+	// the chain's shared state (taskLookup, the classifiers) and writes
+	// nothing, so the goroutines are race-free.
+	nonSubtaskResults, err := c.classifyParallel(nonSubtasks)
+	if err != nil {
+		return nil, err
 	}
+	results = append(results, nonSubtaskResults...)
 
-	// Then classify subtasks (which can inherit from the already classified parents)
-	for _, task := range subtasks {
-		result, err := c.ClassifyTask(task)
-		if err != nil {
-			return nil, fmt.Errorf("failed to classify task %s: %w", task.Key, err)
-		}
-		results = append(results, result)
+	// Phase 2: classify subtasks in parallel. Parent results are already
+	// resolved, and inheritFromParent reads taskLookup without mutating.
+	subtaskResults, err := c.classifyParallel(subtasks)
+	if err != nil {
+		return nil, err
 	}
+	results = append(results, subtaskResults...)
 
 	// Step 3: Run batched LLM classification if enabled
 	if c.llmEnabled && c.llmClassifier != nil {
@@ -484,6 +506,37 @@ func (c *ComprehensiveClassificationChainWithInheritance) ClassifyTasks(tasks []
 	}
 
 	return results, nil
+}
+
+// classifyParallel runs ClassifyTask over the given tasks with bounded
+// concurrency and returns results in input order. Errors are wrapped
+// with the offending task key and the first failure aborts the pass,
+// matching the previous sequential semantics.
+func (c *ComprehensiveClassificationChainWithInheritance) classifyParallel(tasks []*taskdomain.Task) ([]*ports.ComprehensiveClassificationResult, error) {
+	if len(tasks) == 0 {
+		return nil, nil
+	}
+
+	out := make([]*ports.ComprehensiveClassificationResult, len(tasks))
+	eg := new(errgroup.Group)
+	eg.SetLimit(classifyConcurrency())
+
+	for i, task := range tasks {
+		i, task := i, task
+		eg.Go(func() error {
+			result, err := c.ClassifyTask(task)
+			if err != nil {
+				return fmt.Errorf("failed to classify task %s: %w", task.Key, err)
+			}
+			out[i] = result
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // runBatchLLMClassification runs LLM classification for all tasks in batch and attaches results

--- a/internal/tasks/infrastructure/classifier/classification_chain_inheritance_test.go
+++ b/internal/tasks/infrastructure/classifier/classification_chain_inheritance_test.go
@@ -1,10 +1,13 @@
 package classifier
 
 import (
+	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	assetdomain "github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
 	taskdomain "github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain"
@@ -775,4 +778,99 @@ func TestSubtaskInheritance_needsInheritance(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// concurrentAssetClassifier is a hand-rolled fake (no testify Mock,
+// which is not safe for concurrent use) that returns a fresh result
+// per call so we can drive the parallel classification path under
+// -race without setup ceremony.
+type concurrentAssetClassifier struct {
+	calls int64
+}
+
+func (c *concurrentAssetClassifier) ClassifyTaskAsset(task *taskdomain.Task) (*ports.AssetClassificationResult, error) {
+	atomic.AddInt64(&c.calls, 1)
+	return &ports.AssetClassificationResult{
+		Task:       task,
+		Asset:      &assetdomain.Asset{Name: "Auto-assigned"},
+		Confidence: 0.95,
+		Reason:     "stub asset",
+	}, nil
+}
+
+func (c *concurrentAssetClassifier) ClassifyTasksAssets(tasks []*taskdomain.Task) ([]*ports.AssetClassificationResult, error) {
+	out := make([]*ports.AssetClassificationResult, 0, len(tasks))
+	for _, task := range tasks {
+		r, _ := c.ClassifyTaskAsset(task)
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+type concurrentWorkTypeClassifier struct {
+	calls int64
+}
+
+func (c *concurrentWorkTypeClassifier) ClassifyTask(_ *taskdomain.Task) (taskdomain.WorkType, error) {
+	atomic.AddInt64(&c.calls, 1)
+	return taskdomain.WorkTypeDevelopment, nil
+}
+
+func (c *concurrentWorkTypeClassifier) ClassifyTasks(tasks []*taskdomain.Task) (map[string]taskdomain.WorkType, error) {
+	out := make(map[string]taskdomain.WorkType, len(tasks))
+	for _, t := range tasks {
+		out[t.Key] = taskdomain.WorkTypeDevelopment
+	}
+	return out, nil
+}
+
+// TestComprehensiveClassificationChainWithInheritance_ClassifyTasks_ParallelOrder
+// asserts that the parallel pass preserves input order in its output
+// slice (non-subtasks first in their input order, then subtasks in theirs)
+// and that every task is classified exactly once. Designed to run under
+// -race; the high task count makes any per-iteration races likely to
+// surface and an out-of-order result obvious.
+func TestComprehensiveClassificationChainWithInheritance_ClassifyTasks_ParallelOrder(t *testing.T) {
+	const total = 200
+	tasks := make([]*taskdomain.Task, 0, total)
+	expectedOrder := make([]string, 0, total)
+
+	// Half non-subtasks (no Epic), half subtasks (Epic pointing at a non-subtask).
+	for i := 0; i < total/2; i++ {
+		key := fmt.Sprintf("STORY-%03d", i)
+		tasks = append(tasks, &taskdomain.Task{Key: key, Type: taskdomain.TaskTypeStory})
+		expectedOrder = append(expectedOrder, key)
+	}
+	for i := 0; i < total/2; i++ {
+		key := fmt.Sprintf("SUB-%03d", i)
+		tasks = append(tasks, &taskdomain.Task{
+			Key:  key,
+			Type: taskdomain.TaskTypeSubtask,
+			Epic: fmt.Sprintf("STORY-%03d", i),
+		})
+	}
+	// After the two-phase split, non-subtasks come first (in their input order)
+	// then subtasks (in their input order).
+	for i := 0; i < total/2; i++ {
+		expectedOrder = append(expectedOrder, fmt.Sprintf("SUB-%03d", i))
+	}
+
+	chain := NewComprehensiveClassificationChainWithInheritance(
+		&concurrentAssetClassifier{},
+		&concurrentWorkTypeClassifier{},
+	).(*ComprehensiveClassificationChainWithInheritance)
+
+	results, err := chain.ClassifyTasks(tasks)
+	require.NoError(t, err)
+	require.Len(t, results, total)
+
+	seen := make(map[string]bool, total)
+	for i, r := range results {
+		require.NotNil(t, r, "result %d should be non-nil", i)
+		require.NotNil(t, r.Task, "result %d task should be non-nil", i)
+		assert.Equal(t, expectedOrder[i], r.Task.Key, "order preserved within each phase")
+		assert.False(t, seen[r.Task.Key], "task %s classified more than once", r.Task.Key)
+		seen[r.Task.Key] = true
+	}
+	assert.Len(t, seen, total, "every input task should appear exactly once in results")
 }


### PR DESCRIPTION
## Summary

Closes the final perf item from the original project review: `ComprehensiveClassificationChainWithInheritance.ClassifyTasks` ran `ClassifyTask` strictly sequentially across two phases (non-subtasks, then subtasks). Each call does two classifier invocations + an optional inheritance lookup + an optional per-task LLM call — none of which depend on the previous task's result *within the same phase*.

## The change

- New `classifyParallel(tasks)` helper runs `ClassifyTask` over a slice with `errgroup.SetLimit(min(NumCPU, 8))` and returns results in input order via a pre-allocated `out[i]` slot. No goroutine appends to a shared slice; first error wraps the offending task key and aborts the pass.
- Both phases of `ClassifyTasks` now go through `classifyParallel`. The phases themselves remain strictly ordered — subtask inheritance still reads parent results via `taskLookup`, populated in Step 1.

## Why the concurrency cap

- **CPU-bound runs**: classification is mostly map lookups and string matching; scaling with `NumCPU` is the right shape.
- **LLM-enabled runs**: each `ClassifyTask` may fire a per-task LLM call. An unbounded fanout would DoS the local Ollama. Eight is a reasonable middle ground.

## Why this is safe

- Within a phase, `ClassifyTask` only **reads** chain state (`taskLookup`, the asset/work-type classifiers).
- The asset and work-type classifiers carry no mutable state beyond `assetRepo`, which the previous PR already wrapped in a `sync.RWMutex`.
- The embedding asset classifier's caches are already guarded by `sync.Once` and `sync.RWMutex`.
- `runBatchLLMClassification` (Step 3) builds its lookup by task key, so result order doesn't matter to it — and we preserve order anyway.

## Test plan

- [x] `go test -race ./internal/tasks/infrastructure/classifier -count=3` — clean.
- [x] New `TestComprehensiveClassificationChainWithInheritance_ClassifyTasks_ParallelOrder`: runs 200 tasks (100 stories + 100 subtasks pointing at them) through the chain. Asserts every task appears exactly once and non-subtasks come first in input order followed by subtasks in input order — matches the previous two-phase emit shape that `runBatchLLMClassification` and the caller depend on.
- [x] Fakes are hand-rolled rather than `testify/mock` because `mock.Mock` itself is not safe for concurrent use; using it would have masked any real production-side race under the test's noise.
- [x] `go test ./...` — full suite green.
- [ ] `-race` flagged the pre-existing `jira/client.go` `resolveFieldIDs` race already documented in #71's body. Not in this PR's scope.

## Notes

This completes the three perf/quality items I called out after the original review: spinner race (#70), JSON storage batching (#71), classifier parallelism (this PR). The remaining open thread is the pre-existing JIRA `fetchTasksWithDualStrategy` race, which is adjacent to the "no rate limiting on JIRA API calls" item from the review and is worth a separate, scoped fix.