### PR TITLE
fix(jira): eliminate resolveFieldIDs data race

### DIFF
--- a/internal/tasks/infrastructure/jira/client.go
+++ b/internal/tasks/infrastructure/jira/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain"
@@ -42,10 +43,15 @@ var NewClient ClientFactory = newClient
 
 // client implements the Client interface
 type client struct {
-	httpClient       HTTPClient
-	config           *Config
-	customFieldIDs   *sharedjira.CustomFieldIDs
-	fieldIDsResolved bool
+	httpClient HTTPClient
+	config     *Config
+
+	// customFieldIDs is lazily populated via resolveFieldIDsOnce on first
+	// use. After the Once.Do fires, customFieldIDs is read-only for the
+	// rest of the client's lifetime, so the field is safe to read from
+	// any goroutine that calls resolveFieldIDs() to drive the Once.
+	resolveFieldIDsOnce sync.Once
+	customFieldIDs      *sharedjira.CustomFieldIDs
 }
 
 // NewClient creates a new Jira client instance
@@ -62,22 +68,21 @@ func newClient(config *Config) (Client, error) {
 	}, nil
 }
 
-// resolveFieldIDs lazily resolves custom field IDs on first use
+// resolveFieldIDs lazily resolves custom field IDs on first use. Safe
+// to call from multiple goroutines concurrently: the initialisation
+// happens exactly once via sync.Once, and the post-init read of
+// customFieldIDs synchronises through Once.Do's happens-before guarantee.
 func (c *client) resolveFieldIDs() *sharedjira.CustomFieldIDs {
-	if c.fieldIDsResolved {
-		return c.customFieldIDs
-	}
-	c.fieldIDsResolved = true
-
-	if c.config == nil {
-		return nil
-	}
-
-	resolver := sharedjira.NewFieldResolver(c.config.GetBaseURL(), c.config.GetAuthHeader())
-	fieldIDs, err := resolver.ResolveCustomFieldIDs()
-	if err == nil {
-		c.customFieldIDs = fieldIDs
-	}
+	c.resolveFieldIDsOnce.Do(func() {
+		if c.config == nil {
+			return
+		}
+		resolver := sharedjira.NewFieldResolver(c.config.GetBaseURL(), c.config.GetAuthHeader())
+		fieldIDs, err := resolver.ResolveCustomFieldIDs()
+		if err == nil {
+			c.customFieldIDs = fieldIDs
+		}
+	})
 	return c.customFieldIDs
 }
 
@@ -703,11 +708,15 @@ func (c *client) convertSingleIssueToDomainTask(issue api.Issue) (*domain.Task, 
 	task.UpdatedAt = updated
 	task.WorkType = workType
 
-	// Populate TPD fields from custom field IDs
-	if c.customFieldIDs != nil {
-		task.TPDBusinessUnits = issue.Fields.GetTPDBusinessUnits(c.customFieldIDs.TPDBusinessUnit)
-		task.EngineeringHours = issue.Fields.GetEngineeringHours(c.customFieldIDs.EngineeringHours)
-		task.WorkStream = issue.Fields.GetWorkStream(c.customFieldIDs.WorkStream)
+	// Populate TPD fields from custom field IDs. Going through
+	// resolveFieldIDs (instead of reading c.customFieldIDs directly)
+	// ensures we initialise the cache lazily even when FetchTaskByKey
+	// is the first call against this client, and stays race-free with
+	// any concurrent fetch-tasks path that drives the same sync.Once.
+	if fieldIDs := c.resolveFieldIDs(); fieldIDs != nil {
+		task.TPDBusinessUnits = issue.Fields.GetTPDBusinessUnits(fieldIDs.TPDBusinessUnit)
+		task.EngineeringHours = issue.Fields.GetEngineeringHours(fieldIDs.EngineeringHours)
+		task.WorkStream = issue.Fields.GetWorkStream(fieldIDs.WorkStream)
 	}
 
 	return task, nil

--- a/internal/tasks/infrastructure/jira/client_test.go
+++ b/internal/tasks/infrastructure/jira/client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1634,4 +1635,54 @@ func convertIssuesToResponse(issues []api.Issue) []map[string]interface{} {
 		response = append(response, issueData)
 	}
 	return response
+}
+
+// TestClient_ResolveFieldIDs_IsRaceFree pins the fix for the race that
+// fetchTasksWithDualStrategy used to trip: two goroutines calling
+// resolveFieldIDs concurrently would each read fieldIDsResolved, both
+// see false, both set it, and both write customFieldIDs without
+// synchronisation. The replacement uses sync.Once so initialisation
+// runs exactly once and subsequent reads are race-free by the Once.Do
+// happens-before guarantee. Designed to run under -race.
+func TestClient_ResolveFieldIDs_IsRaceFree(t *testing.T) {
+	// Field-resolver endpoint returns an empty schema so customFieldIDs
+	// stays nil after init -- we only care about the synchronisation,
+	// not the parsed result.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/field") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	c := &client{
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		config: &Config{
+			BaseURL: server.URL,
+			Email:   "x@example.com",
+			Token:   "t",
+		},
+	}
+
+	const callers = 32
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			// Each goroutine reads the (initialised) value back. With the
+			// previous check-then-set, all 32 of these reads would race
+			// the writes inside resolveFieldIDs.
+			_ = c.resolveFieldIDs()
+		}()
+	}
+	wg.Wait()
+
+	// One more call from the test goroutine to assert the second-call
+	// happy path keeps returning the same (possibly-nil) cached value
+	// without re-doing the work.
+	_ = c.resolveFieldIDs()
 }


### PR DESCRIPTION
## Summary

Closes the pre-existing JIRA data race flagged in #71 and #72: `fetchTasksWithDualStrategy` spawns two goroutines that each call `fetchTasksWithQuery` → `convertToDomainTasks` → `resolveFieldIDs`. The original lazy-init was a textbook check-then-set:

```go
if c.fieldIDsResolved {
    return c.customFieldIDs
}
c.fieldIDsResolved = true
...
c.customFieldIDs = fieldIDs
```

Both goroutines read `fieldIDsResolved`, both see `false`, both set it, both write `customFieldIDs` without synchronisation. `go test -race ./internal/tasks/infrastructure/jira -run TestClient_FetchTasks` reported clean data races on both fields. CI runs without `-race`, so this has been hiding alongside the spinner race fixed in #70.

## The fix

Replace `fieldIDsResolved` + the manual gate with a `sync.Once`. Both fields collapse into the `Once.Do` closure. `resolveFieldIDs` becomes trivially safe for concurrent callers: the initialisation runs exactly once and post-init reads of `customFieldIDs` synchronise through the `Once.Do` happens-before guarantee.

## Related correctness bug (also fixed)

`convertSingleIssueToDomainTask` (used by `FetchTaskByKey`) was reading `c.customFieldIDs` **directly without ever calling `resolveFieldIDs`**. If `FetchTaskByKey` was the first thing a client did, the TPD / EngineeringHours / WorkStream fields would silently never populate. With the `Once`-based lazy init it now drives the same initialisation as the bulk fetch path, regardless of call order.

## Test plan

- [x] New `TestClient_ResolveFieldIDs_IsRaceFree` fires 32 concurrent calls into `resolveFieldIDs`. Without the fix this was a reliable race reproducer; with the fix it passes under `go test -race -count=5`.
- [x] `go test -race ./internal/tasks/infrastructure/jira -count=1` — clean.
- [x] `go test ./...` — full project suite green.

## What's left

With this PR, **all open `-race` findings from the recent series are closed**:

- spinner race (`enhanced_handler.go`) — #70
- `JSONStorage` mutation races — #71
- `resolveFieldIDs` dual-strategy race — this PR

CI still doesn't use `-race`. Adding it is a small follow-up if you want hardening; otherwise the explicit `*_IsRaceFree` tests act as targeted regression tests for the patches we made.