### PR TITLE
ci: enable -race on the test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,13 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
-      - name: Run tests with coverage
+      - name: Run tests with coverage and race detector
         id: test
+        # -race catches data races on every PR; multiple were already
+        # found and fixed in recent work (#70, #71, #72, #73) that CI
+        # was missing because tests were not race-instrumented.
         run: |
-          go test -v -coverprofile=coverage.out ./...
+          go test -v -race -coverprofile=coverage.out ./...
           go tool cover -func=coverage.out | tee coverage.txt
           COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
           echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Adds `-race` to CI's `go test` invocation. Closes the implicit ask from the recent series of `-race`-flagged bugfixes — CI was running `go test -v -coverprofile=coverage.out ./...` without race instrumentation, so concurrency bugs in production code only surfaced on local runs.

The recent series turned up four such bugs that landed because nothing in the automated path would have caught them:

| # | Race |
|---|---|
| #70 | `EnhancedHandler` spinner field — concurrent read/write |
| #71 | `JSONStorage` read-modify-write cycle on tasks.json |
| #72 | (prerequisite) safe fan-out for classifier parallelism |
| #73 | JIRA client `resolveFieldIDs` check-then-set on dual-strategy fetch |

## Cost

Roughly 2–3× test wall-clock per PR. Acceptable for the protection it buys; every PR now guards against the same class of bug going in.

`-race` and `-coverprofile` compose, so the coverage badge step is unaffected.

## Test plan

- [x] Local `go test -race ./... -count=1` — full project green.
- [ ] Once CI runs with this change, all subsequent PRs get race-instrumented automatically.