### PR TITLE
perf(classifier): cache FindAll per classifier instance

### DIFF
--- a/internal/tasks/infrastructure/classifier/asset_classifier.go
+++ b/internal/tasks/infrastructure/classifier/asset_classifier.go
@@ -3,6 +3,7 @@ package classifier
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	assetdomain "github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
 	assetports "github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain/ports"
@@ -13,6 +14,15 @@ import (
 // ContentBasedAssetClassifier implements asset classification based on content analysis
 type ContentBasedAssetClassifier struct {
 	assetRepo assetports.AssetRepository
+
+	// loadOnce caches the FindAll() result for the lifetime of the
+	// classifier. Each CLI invocation builds a fresh chain, so the cache
+	// lives for one command and reads the assets file exactly once
+	// across the full sprint -- matching the sync.Once pattern that
+	// EmbeddingAssetClassifier already uses for the same reason.
+	loadOnce     sync.Once
+	cachedAssets []*assetdomain.Asset
+	cachedErr    error
 }
 
 // NewContentBasedAssetClassifier creates a new content-based asset classifier
@@ -22,14 +32,22 @@ func NewContentBasedAssetClassifier(assetRepo assetports.AssetRepository) ports.
 	}
 }
 
+// loadAssets returns the asset list, reading the repository exactly
+// once per classifier instance.
+func (c *ContentBasedAssetClassifier) loadAssets() ([]*assetdomain.Asset, error) {
+	c.loadOnce.Do(func() {
+		c.cachedAssets, c.cachedErr = c.assetRepo.FindAll()
+	})
+	return c.cachedAssets, c.cachedErr
+}
+
 // ClassifyTaskAsset determines which asset a task belongs to based on content analysis
 func (c *ContentBasedAssetClassifier) ClassifyTaskAsset(task *taskdomain.Task) (*ports.AssetClassificationResult, error) {
 	if task == nil {
 		return nil, fmt.Errorf("task cannot be nil")
 	}
 
-	// Get all assets to analyze against
-	assets, err := c.assetRepo.FindAll()
+	assets, err := c.loadAssets()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch assets: %w", err)
 	}

--- a/internal/tasks/infrastructure/classifier/asset_classifier_test.go
+++ b/internal/tasks/infrastructure/classifier/asset_classifier_test.go
@@ -1,10 +1,13 @@
 package classifier
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	assetdomain "github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
 	taskdomain "github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain"
@@ -681,4 +684,50 @@ func TestContentBasedAssetClassifier_TitleWeighting(t *testing.T) {
 			mockRepo.AssertExpectations(t)
 		})
 	}
+}
+
+// countingAssetRepo is a minimal AssetRepository stub that records how
+// many times FindAll is called. Used to assert the per-classifier
+// sync.Once cache coalesces all reads into one, even under concurrent
+// callers. Hand-rolled because testify mock.Mock is not safe for
+// concurrent use.
+type countingAssetRepo struct {
+	calls  int64
+	assets []*assetdomain.Asset
+}
+
+func (r *countingAssetRepo) Save(*assetdomain.Asset) error { return nil }
+func (r *countingAssetRepo) FindAll() ([]*assetdomain.Asset, error) {
+	atomic.AddInt64(&r.calls, 1)
+	return r.assets, nil
+}
+func (r *countingAssetRepo) FindByID(string) (*assetdomain.Asset, error)   { return nil, nil }
+func (r *countingAssetRepo) FindByName(string) (*assetdomain.Asset, error) { return nil, nil }
+func (r *countingAssetRepo) Delete(string) error                           { return nil }
+
+// TestContentBasedAssetClassifier_LoadAssets_CoalescedAndRaceFree asserts
+// the sync.Once cache fires FindAll exactly once across many concurrent
+// ClassifyTaskAsset calls. Designed to run under -race; before the fix,
+// each call did its own assetRepo.FindAll() and the test would observe
+// `tasks` calls instead of 1.
+func TestContentBasedAssetClassifier_LoadAssets_CoalescedAndRaceFree(t *testing.T) {
+	repo := &countingAssetRepo{
+		assets: []*assetdomain.Asset{{Name: "Asset A", Keywords: []string{"foo"}}},
+	}
+	c := NewContentBasedAssetClassifier(repo)
+
+	const callers = 32
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := c.ClassifyTaskAsset(&taskdomain.Task{Key: "TST-1", Summary: "do foo"})
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(1), atomic.LoadInt64(&repo.calls),
+		"sync.Once should coalesce all concurrent reads into one FindAll")
 }

--- a/internal/tasks/infrastructure/classifier/business_rules.go
+++ b/internal/tasks/infrastructure/classifier/business_rules.go
@@ -2,6 +2,7 @@ package classifier
 
 import (
 	"strings"
+	"sync"
 	"time"
 
 	assetdomain "github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
@@ -12,6 +13,14 @@ import (
 // BusinessRulesClassifier implements TaskClassifier using business rules from the spec
 type BusinessRulesClassifier struct {
 	assetRepo assetports.AssetRepository
+
+	// loadOnce caches the FindAll() result for the lifetime of the
+	// classifier. Each CLI invocation builds a fresh chain, so the cache
+	// lives for one command. With #72's parallel classifier loop, this
+	// turns N concurrent FindAll() calls into a single coalesced load.
+	loadOnce     sync.Once
+	cachedAssets []*assetdomain.Asset
+	cachedErr    error
 }
 
 // NewBusinessRulesClassifier creates a new business rules classifier
@@ -19,6 +28,15 @@ func NewBusinessRulesClassifier(assetRepo assetports.AssetRepository) *BusinessR
 	return &BusinessRulesClassifier{
 		assetRepo: assetRepo,
 	}
+}
+
+// loadAssets returns the asset list, reading the repository exactly
+// once per classifier instance.
+func (c *BusinessRulesClassifier) loadAssets() ([]*assetdomain.Asset, error) {
+	c.loadOnce.Do(func() {
+		c.cachedAssets, c.cachedErr = c.assetRepo.FindAll()
+	})
+	return c.cachedAssets, c.cachedErr
 }
 
 // ClassifyTask determines the work type of a task based on business rules
@@ -101,8 +119,7 @@ func (c *BusinessRulesClassifier) isSpikeOrResearch(task *taskdomain.Task) bool 
 
 // findRelatedAsset attempts to find the asset related to this task
 func (c *BusinessRulesClassifier) findRelatedAsset(task *taskdomain.Task) (*assetdomain.Asset, error) {
-	// Get all assets to check against
-	assets, err := c.assetRepo.FindAll()
+	assets, err := c.loadAssets()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tasks/infrastructure/classifier/business_rules_test.go
+++ b/internal/tasks/infrastructure/classifier/business_rules_test.go
@@ -131,8 +131,10 @@ func TestBusinessRulesClassifier_ClassifyTask_SpikeOrResearch(t *testing.T) {
 }
 
 func TestBusinessRulesClassifier_ClassifyTask_WithinDevelopmentPeriod(t *testing.T) {
-	assetRepo := new(MockAssetRepository)
-	classifier := NewBusinessRulesClassifier(assetRepo)
+	// Each subtest builds a fresh classifier because the BusinessRules
+	// classifier caches its FindAll() result via sync.Once for the
+	// lifetime of the instance -- mirroring the production setup where
+	// one classifier is built per CLI invocation.
 
 	// Create test assets
 	now := time.Now()
@@ -180,6 +182,8 @@ func TestBusinessRulesClassifier_ClassifyTask_WithinDevelopmentPeriod(t *testing
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assetRepo := new(MockAssetRepository)
+			classifier := NewBusinessRulesClassifier(assetRepo)
 			assetRepo.On("FindAll").Return(tt.assets, nil).Once()
 
 			workType, err := classifier.ClassifyTask(tt.task)
@@ -251,8 +255,8 @@ func TestBusinessRulesClassifier_ClassifyTask_NewAPIOrInventory(t *testing.T) {
 }
 
 func TestBusinessRulesClassifier_ClassifyTask_BugFixPastRollout(t *testing.T) {
-	assetRepo := new(MockAssetRepository)
-	classifier := NewBusinessRulesClassifier(assetRepo)
+	// Each subtest builds a fresh classifier because BusinessRulesClassifier
+	// caches its FindAll() result for the lifetime of the instance.
 
 	// Create test asset that was rolled out more than 6 months ago
 	now := time.Now()
@@ -295,6 +299,8 @@ func TestBusinessRulesClassifier_ClassifyTask_BugFixPastRollout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assetRepo := new(MockAssetRepository)
+			classifier := NewBusinessRulesClassifier(assetRepo)
 			assetRepo.On("FindAll").Return(tt.assets, nil).Once()
 
 			workType, err := classifier.ClassifyTask(tt.task)
@@ -307,8 +313,8 @@ func TestBusinessRulesClassifier_ClassifyTask_BugFixPastRollout(t *testing.T) {
 }
 
 func TestBusinessRulesClassifier_ClassifyTask_ContentFallback(t *testing.T) {
-	assetRepo := new(MockAssetRepository)
-	classifier := NewBusinessRulesClassifier(assetRepo)
+	// Each subtest builds a fresh classifier because BusinessRulesClassifier
+	// caches its FindAll() result for the lifetime of the instance.
 
 	tests := []struct {
 		name       string
@@ -355,6 +361,8 @@ func TestBusinessRulesClassifier_ClassifyTask_ContentFallback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assetRepo := new(MockAssetRepository)
+			classifier := NewBusinessRulesClassifier(assetRepo)
 			// For content fallback tests, asset lookup will be attempted but no assets found
 			assetRepo.On("FindAll").Return([]*assetdomain.Asset{}, nil).Once()
 
@@ -763,8 +771,8 @@ func TestBusinessRulesClassifier_TaskMatchesAsset_Comprehensive(t *testing.T) {
 }
 
 func TestBusinessRulesClassifier_FindRelatedAsset_EdgeCases(t *testing.T) {
-	assetRepo := new(MockAssetRepository)
-	classifier := NewBusinessRulesClassifier(assetRepo)
+	// Each subtest builds a fresh classifier because BusinessRulesClassifier
+	// caches its FindAll() result for the lifetime of the instance.
 
 	tests := []struct {
 		name          string
@@ -813,6 +821,8 @@ func TestBusinessRulesClassifier_FindRelatedAsset_EdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assetRepo := new(MockAssetRepository)
+			classifier := NewBusinessRulesClassifier(assetRepo)
 			assetRepo.On("FindAll").Return(tt.assets, tt.repoError).Once()
 
 			asset, err := classifier.findRelatedAsset(tt.task)
@@ -830,8 +840,8 @@ func TestBusinessRulesClassifier_FindRelatedAsset_EdgeCases(t *testing.T) {
 }
 
 func TestBusinessRulesClassifier_ClassifyTask_EdgeCases(t *testing.T) {
-	assetRepo := new(MockAssetRepository)
-	classifier := NewBusinessRulesClassifier(assetRepo)
+	// Each subtest builds a fresh classifier because BusinessRulesClassifier
+	// caches its FindAll() result for the lifetime of the instance.
 
 	tests := []struct {
 		name        string
@@ -868,6 +878,8 @@ func TestBusinessRulesClassifier_ClassifyTask_EdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assetRepo := new(MockAssetRepository)
+			classifier := NewBusinessRulesClassifier(assetRepo)
 			// Only set up mock if not testing spike/research
 			if !strings.Contains(strings.ToLower(tt.task.Summary+" "+tt.task.Description), "spike") &&
 				!containsLabel(tt.task.Labels, []string{"spike", "research", "poc"}) {
@@ -889,8 +901,8 @@ func TestBusinessRulesClassifier_ClassifyTask_EdgeCases(t *testing.T) {
 }
 
 func TestBusinessRulesClassifier_ClassifyTasks_EdgeCases(t *testing.T) {
-	assetRepo := new(MockAssetRepository)
-	classifier := NewBusinessRulesClassifier(assetRepo)
+	// Each subtest builds a fresh classifier because BusinessRulesClassifier
+	// caches its FindAll() result for the lifetime of the instance.
 
 	tests := []struct {
 		name        string
@@ -916,6 +928,8 @@ func TestBusinessRulesClassifier_ClassifyTasks_EdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assetRepo := new(MockAssetRepository)
+			classifier := NewBusinessRulesClassifier(assetRepo)
 			if tt.name == "repository error handled gracefully" {
 				assetRepo.On("FindAll").Return(nil, assert.AnError).Once()
 			}


### PR DESCRIPTION
## Summary

`ContentBasedAssetClassifier` and `BusinessRulesClassifier` both called `assetRepo.FindAll()` at the start of every classification. After #72 parallelised the per-task loop, a sprint of N tasks fires N concurrent `FindAll()` calls; each goes through `JSONRepository.loadAssets()` which reads and JSON-unmarshals the entire `assets.json`. A sprint of fifty tasks parsed the asset map fifty times, under the asset repo's `RWMutex` contention.

`EmbeddingAssetClassifier` already solved this for itself with a `sync.Once` cache (`assetsMu` / `cachedAssets` / `assetsErr`). This PR mirrors the same pattern in the other two classifiers — surgical change, validated pattern.

## Lifetime

Each CLI invocation builds a fresh chain in `initializeApp`, so the cache lives for exactly one command run and never goes stale relative to on-disk asset state.

## Test plan

- [x] New `TestContentBasedAssetClassifier_LoadAssets_CoalescedAndRaceFree` fires 32 concurrent `ClassifyTaskAsset` calls through a hand-rolled `countingAssetRepo` (`testify/mock` itself isn't safe for concurrent use) and asserts `FindAll` was called **exactly once**. Passes under `-race -count=3`.
- [x] Existing tests that reused a single classifier across table-driven subtests with `.Once()` `FindAll` expectations are reshaped to build a **fresh classifier per subtest** — matching both production lifetime (one classifier per CLI invocation) and cache semantics. Six tables in `business_rules_test.go`.
- [x] Full project suite `go test ./...` green.

## Note

Combined with #71 (`JSONStorage` mutex) and #72 (parallel classifier), this means sprint-classify now does **one** assets.json read and **one** tasks.json write per run, regardless of sprint size — down from O(n²) reads/writes a few PRs ago.