### PR TITLE
perf(classifier): drop hand-rolled contains() for stdlib + hoist content lowering

### DIFF
--- a/internal/tasks/infrastructure/classifier/classification_chain.go
+++ b/internal/tasks/infrastructure/classifier/classification_chain.go
@@ -347,20 +347,15 @@ func (c *ComprehensiveClassificationChainWithInheritance) generateWorkTypeReason
 
 // containsResearchKeywords checks if task contains research-related keywords (inheritance version)
 func (c *ComprehensiveClassificationChainWithInheritance) containsResearchKeywords(task *taskdomain.Task) bool {
-	content := task.Summary + " " + task.Description
 	keywords := []string{"spike", "research", "discovery", "investigation", "poc", "proof-of-concept"}
 
-	for _, keyword := range keywords {
-		if contains(content, keyword) {
-			return true
-		}
+	if containsAny(task.Summary+" "+task.Description, keywords) {
+		return true
 	}
 
 	for _, label := range task.Labels {
-		for _, keyword := range keywords {
-			if contains(label, keyword) {
-				return true
-			}
+		if containsAny(label, keywords) {
+			return true
 		}
 	}
 
@@ -369,30 +364,15 @@ func (c *ComprehensiveClassificationChainWithInheritance) containsResearchKeywor
 
 // containsBugKeywords checks if task contains bug-related keywords (inheritance version)
 func (c *ComprehensiveClassificationChainWithInheritance) containsBugKeywords(task *taskdomain.Task) bool {
-	content := task.Summary + " " + task.Description
-	keywords := []string{"bug", "fix", "hotfix", "error", "issue", "defect"}
-
-	for _, keyword := range keywords {
-		if contains(content, keyword) {
-			return true
-		}
+	if containsAny(task.Summary+" "+task.Description, []string{"bug", "fix", "hotfix", "error", "issue", "defect"}) {
+		return true
 	}
-
 	return task.Type == taskdomain.TaskTypeBug
 }
 
 // containsAPIKeywords checks if task contains API-related keywords (inheritance version)
 func (c *ComprehensiveClassificationChainWithInheritance) containsAPIKeywords(task *taskdomain.Task) bool {
-	content := task.Summary + " " + task.Description
-	keywords := []string{"api", "endpoint", "service", "new", "add", "create", "implement"}
-
-	for _, keyword := range keywords {
-		if contains(content, keyword) {
-			return true
-		}
-	}
-
-	return false
+	return containsAny(task.Summary+" "+task.Description, []string{"api", "endpoint", "service", "new", "add", "create", "implement"})
 }
 
 // formatAssetName converts an asset identifier like "cabin-markup" to a proper asset name like "Cabin Markup"
@@ -597,20 +577,15 @@ func (c *ComprehensiveClassificationChain) generateWorkTypeReason(task *taskdoma
 
 // containsResearchKeywords checks if task contains research-related keywords
 func (c *ComprehensiveClassificationChain) containsResearchKeywords(task *taskdomain.Task) bool {
-	content := task.Summary + " " + task.Description
 	keywords := []string{"spike", "research", "discovery", "investigation", "poc", "proof-of-concept"}
 
-	for _, keyword := range keywords {
-		if contains(content, keyword) {
-			return true
-		}
+	if containsAny(task.Summary+" "+task.Description, keywords) {
+		return true
 	}
 
 	for _, label := range task.Labels {
-		for _, keyword := range keywords {
-			if contains(label, keyword) {
-				return true
-			}
+		if containsAny(label, keywords) {
+			return true
 		}
 	}
 
@@ -619,70 +594,32 @@ func (c *ComprehensiveClassificationChain) containsResearchKeywords(task *taskdo
 
 // containsBugKeywords checks if task contains bug-related keywords
 func (c *ComprehensiveClassificationChain) containsBugKeywords(task *taskdomain.Task) bool {
-	content := task.Summary + " " + task.Description
-	keywords := []string{"bug", "fix", "hotfix", "error", "issue", "defect"}
-
-	for _, keyword := range keywords {
-		if contains(content, keyword) {
-			return true
-		}
+	if containsAny(task.Summary+" "+task.Description, []string{"bug", "fix", "hotfix", "error", "issue", "defect"}) {
+		return true
 	}
-
 	return task.Type == taskdomain.TaskTypeBug
 }
 
 // containsAPIKeywords checks if task contains API-related keywords
 func (c *ComprehensiveClassificationChain) containsAPIKeywords(task *taskdomain.Task) bool {
-	content := task.Summary + " " + task.Description
-	keywords := []string{"api", "endpoint", "service", "new", "add", "create", "implement"}
-
-	for _, keyword := range keywords {
-		if contains(content, keyword) {
-			return true
-		}
-	}
-
-	return false
+	return containsAny(task.Summary+" "+task.Description, []string{"api", "endpoint", "service", "new", "add", "create", "implement"})
 }
 
-// contains performs case-insensitive substring matching
-func contains(content, keyword string) bool {
-	contentLower := ""
-	keywordLower := ""
-
-	for _, r := range content {
-		if r >= 'A' && r <= 'Z' {
-			contentLower += string(r + 32)
-		} else {
-			contentLower += string(r)
-		}
-	}
-
-	for _, r := range keyword {
-		if r >= 'A' && r <= 'Z' {
-			keywordLower += string(r + 32)
-		} else {
-			keywordLower += string(r)
-		}
-	}
-
-	// Simple substring search
-	if len(keywordLower) > len(contentLower) {
-		return false
-	}
-
-	for i := 0; i <= len(contentLower)-len(keywordLower); i++ {
-		match := true
-		for j := 0; j < len(keywordLower); j++ {
-			if contentLower[i+j] != keywordLower[j] {
-				match = false
-				break
-			}
-		}
-		if match {
+// containsAny lowers content once and reports whether any keyword
+// (also lowered, on the fly) appears as a substring. Replaces a
+// hand-rolled contains() that lowered both strings via N allocations
+// each inside a rune loop before doing a manual substring search --
+// with the parallel classifier loop hammering this per task, that
+// allocation churn dominated CPU. strings.ToLower / strings.Contains
+// do the same job with a single sized allocation per lowering and a
+// tuned substring search, and they handle full Unicode rather than
+// just ASCII A–Z.
+func containsAny(content string, keywords []string) bool {
+	loweredContent := strings.ToLower(content)
+	for _, k := range keywords {
+		if strings.Contains(loweredContent, strings.ToLower(k)) {
 			return true
 		}
 	}
-
 	return false
 }

--- a/internal/tasks/infrastructure/classifier/contains_bench_test.go
+++ b/internal/tasks/infrastructure/classifier/contains_bench_test.go
@@ -1,0 +1,46 @@
+package classifier
+
+import (
+	"testing"
+
+	taskdomain "github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain"
+)
+
+// Benchmark inputs sized roughly like a real task summary plus
+// description so the numbers reflect real classification load, not a
+// 5-character toy string. Realistic content typically holds ~200-500
+// bytes; we pick 256 plus a known suffix so the keyword hits late.
+var (
+	benchContent = func() string {
+		const filler = "Reviewed the data pipeline integration with our new service layer; " +
+			"verified the latency budget; the SRE rotation owner signed off on Friday. " +
+			"There were several edge cases around retry semantics and idempotency keys."
+		return filler + " Implement new API endpoint"
+	}()
+	benchKeywords = []string{"api", "endpoint", "service", "new", "add", "create", "implement"}
+)
+
+func BenchmarkContainsAny(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		if !containsAny(benchContent, benchKeywords) {
+			b.Fatal("expected match")
+		}
+	}
+}
+
+// BenchmarkContainsAPIKeywords measures the realistic per-task hot
+// path: a task whose summary+description hits the API-keyword case,
+// classified once. Useful for tracking regression when the keyword set
+// or the surrounding function shape changes.
+func BenchmarkContainsAPIKeywords(b *testing.B) {
+	chain := &ComprehensiveClassificationChain{}
+	task := &taskdomain.Task{
+		Summary:     "Implement new API endpoint for the markup service",
+		Description: benchContent,
+	}
+	for i := 0; i < b.N; i++ {
+		if !chain.containsAPIKeywords(task) {
+			b.Fatal("expected match")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The classifier had a hand-rolled `contains(content, keyword string) bool` that lowered both strings via repeated string concatenation inside a rune loop — O(n) allocations per call to build the lowered content alone — then did a manual substring search. Six `containsXxxKeywords` helpers called it in tight loops, each iterating over a small keyword set against the same task content and re-lowering that content on every iteration.

After #72 parallelised the per-task classification loop, this became the hottest per-task hot path: every task fired three `containsXxxKeywords` helpers × ~7 keywords each × N-character content lowered char-by-char. The allocation churn dominated CPU.

## The change

- Drop the hand-rolled `contains()` entirely.
- Add a single `containsAny(content string, keywords []string) bool` helper that calls `strings.ToLower(content)` **once** then loops `strings.Contains` per keyword.
- Each of the six `containsXxxKeywords` collapses to one (or two, for the label variants) `containsAny` call.

## Benchmark

`darwin/arm64` (Apple M4), realistic 256-byte content + 7-keyword set:

```
BenchmarkContainsAny-10        3.17M ops    392.2 ns/op    256 B/op    1 alloc/op
```

One allocation per call (the sized buffer behind `strings.ToLower`) versus N allocations per character of content under the old shape. `BenchmarkContainsAPIKeywords` exercises the realistic per-task path and is parked alongside as a regression sentinel.

## Bonus correctness

`strings.ToLower` handles full Unicode; the hand-rolled A–Z fold only worked on ASCII. So this is also **strictly more correct** on tasks that contain non-ASCII summaries or labels — e.g., `"PAYÉ"` → `"payé"`.

## Test plan

- [x] `go test -race ./internal/tasks/infrastructure/classifier/...` — green.
- [x] Full project suite green.
- [x] Both new benchmarks run cleanly.