### PR TITLE
feat(llama): retry transient Ollama failures with backoff

### DIFF
--- a/internal/assets/infrastructure/llama/client.go
+++ b/internal/assets/infrastructure/llama/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"regexp"
@@ -20,16 +21,28 @@ import (
 // several minutes; a shorter value risks aborting valid in-flight requests.
 const DefaultTimeout = 5 * time.Minute
 
+// Retry defaults. DefaultMaxAttempts is "one try plus two retries", which
+// covers brief transport blips and short server hiccups without making a
+// genuinely-broken Ollama wait around for ages.
+const (
+	DefaultMaxAttempts = 3
+	DefaultBackoffBase = 500 * time.Millisecond
+)
+
 // Client represents an Ollama API client
 type Client struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL     string
+	httpClient  *http.Client
+	maxAttempts int
+	backoffBase time.Duration
 }
 
 // Config holds the configuration for the Ollama client
 type Config struct {
-	BaseURL string
-	Timeout time.Duration
+	BaseURL     string
+	Timeout     time.Duration
+	MaxAttempts int           // 0 -> DefaultMaxAttempts, 1 disables retries
+	BackoffBase time.Duration // 0 -> DefaultBackoffBase
 }
 
 // DefaultConfig returns a default configuration for the Ollama client
@@ -39,8 +52,10 @@ func DefaultConfig() Config {
 		baseURL = "http://localhost:11434"
 	}
 	return Config{
-		BaseURL: baseURL,
-		Timeout: DefaultTimeout,
+		BaseURL:     baseURL,
+		Timeout:     DefaultTimeout,
+		MaxAttempts: DefaultMaxAttempts,
+		BackoffBase: DefaultBackoffBase,
 	}
 }
 
@@ -55,10 +70,73 @@ func NewClient(config Config) (*Client, error) {
 		timeout = DefaultTimeout
 	}
 
+	maxAttempts := config.MaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = DefaultMaxAttempts
+	}
+	backoffBase := config.BackoffBase
+	if backoffBase <= 0 {
+		backoffBase = DefaultBackoffBase
+	}
+
 	return &Client{
-		baseURL:    config.BaseURL,
-		httpClient: &http.Client{Timeout: timeout},
+		baseURL:     config.BaseURL,
+		httpClient:  &http.Client{Timeout: timeout},
+		maxAttempts: maxAttempts,
+		backoffBase: backoffBase,
 	}, nil
+}
+
+// isRetryableStatus reports whether an HTTP status code is worth a retry.
+// We retry on the canonical transient-server family (5xx) plus 408
+// (Request Timeout) and 429 (Too Many Requests). 4xx other than those is
+// a client error -- repeating the same request will not improve matters.
+func isRetryableStatus(code int) bool {
+	if code >= 500 && code < 600 {
+		return true
+	}
+	return code == http.StatusRequestTimeout || code == http.StatusTooManyRequests
+}
+
+// doWithRetry sends an HTTP request and retries on transport errors and
+// retryable status codes with exponential backoff and jitter. The
+// caller passes a request builder rather than a built request so the
+// body is fresh on every attempt -- a single bytes.Buffer or strings.Reader
+// would be drained after the first try.
+func (c *Client) doWithRetry(buildReq func() (*http.Request, error)) (*http.Response, error) {
+	var lastErr error
+	for attempt := 0; attempt < c.maxAttempts; attempt++ {
+		if attempt > 0 {
+			sleep := c.backoffBase << uint(attempt-1)
+			// Full jitter halves the worst case and stops fleets of clients
+			// from synchronising their retries into a thundering herd.
+			if sleep > 0 {
+				sleep = sleep/2 + time.Duration(rand.Int64N(int64(sleep)/2+1))
+			}
+			time.Sleep(sleep)
+		}
+
+		req, err := buildReq()
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if !isRetryableStatus(resp.StatusCode) {
+			return resp, nil
+		}
+
+		// Drain and close the retryable response so the connection
+		// can return to the pool before we sleep.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		lastErr = fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return nil, fmt.Errorf("Ollama request failed after %d attempts: %w", c.maxAttempts, lastErr)
 }
 
 var (
@@ -149,16 +227,16 @@ Field content:`, asset.Name, asset.Why, asset.Benefits, asset.How, asset.Metrics
 		return "", fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", c.baseURL+"/api/generate", bytes.NewBuffer(jsonData))
+	resp, err := c.doWithRetry(func() (*http.Request, error) {
+		req, err := http.NewRequest("POST", c.baseURL+"/api/generate", bytes.NewBuffer(jsonData))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	})
 	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to send request: %w", err)
+		return "", err
 	}
 	defer resp.Body.Close()
 
@@ -198,14 +276,14 @@ func (c *Client) GenerateEmbeddings(model string, texts []string) ([][]float64, 
 		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", c.baseURL+"/api/embed", bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create embedding request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doWithRetry(func() (*http.Request, error) {
+		req, err := http.NewRequest("POST", c.baseURL+"/api/embed", bytes.NewBuffer(jsonData))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create embedding request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to call Ollama embed: %w", err)
 	}

--- a/internal/assets/infrastructure/llama/client_test.go
+++ b/internal/assets/infrastructure/llama/client_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -87,6 +88,8 @@ func TestEnrichContent(t *testing.T) {
 			mockStatus:   http.StatusOK,
 		},
 		{
+			// 500 is now retryable, so the resulting error reports the
+			// retry-budget exhaustion rather than the per-attempt body.
 			name:    "API error",
 			content: "Test content",
 			field:   "description",
@@ -99,7 +102,7 @@ func TestEnrichContent(t *testing.T) {
 			},
 			mockResponse:  `{"error": "API error"}`,
 			mockStatus:    http.StatusInternalServerError,
-			expectedError: "API request failed with status 500: {\"error\": \"API error\"}",
+			expectedError: "Ollama request failed after 3 attempts: status 500",
 		},
 		{
 			name:    "empty response",
@@ -130,7 +133,9 @@ func TestEnrichContent(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, err := NewClient(Config{BaseURL: server.URL})
+			// Tight backoff so the retryable-status case doesn't wait
+			// a second of real time per test invocation.
+			client, err := NewClient(Config{BaseURL: server.URL, BackoffBase: time.Microsecond})
 			require.NoError(t, err)
 
 			result, err := client.EnrichContent(tt.content, tt.field, tt.asset)
@@ -222,7 +227,7 @@ func TestGenerateEmbeddings(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, err := NewClient(Config{BaseURL: server.URL})
+			client, err := NewClient(Config{BaseURL: server.URL, BackoffBase: time.Microsecond})
 			require.NoError(t, err)
 
 			result, err := client.GenerateEmbeddings("llama3", tt.texts)
@@ -331,5 +336,127 @@ func TestDefaultConfig(t *testing.T) {
 		// Verify it's a proper Config struct
 		assert.IsType(t, Config{}, config, "Should return Config struct")
 		assert.NotEmpty(t, config.BaseURL, "BaseURL should not be empty")
+	})
+}
+
+func TestIsRetryableStatus(t *testing.T) {
+	cases := []struct {
+		code      int
+		retryable bool
+	}{
+		{http.StatusOK, false},
+		{http.StatusBadRequest, false},
+		{http.StatusUnauthorized, false},
+		{http.StatusNotFound, false},
+		{http.StatusRequestTimeout, true},
+		{http.StatusTooManyRequests, true},
+		{http.StatusInternalServerError, true},
+		{http.StatusBadGateway, true},
+		{http.StatusServiceUnavailable, true},
+		{http.StatusGatewayTimeout, true},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.retryable, isRetryableStatus(c.code), "status %d", c.code)
+	}
+}
+
+func TestDoWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
+	var hits int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt64(&hits, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`busy`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"response":"ok"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL, MaxAttempts: 3, BackoffBase: time.Microsecond})
+	require.NoError(t, err)
+
+	resp, err := client.doWithRetry(func() (*http.Request, error) {
+		return http.NewRequest("GET", server.URL+"/anything", nil)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int64(3), atomic.LoadInt64(&hits), "should have retried twice before success")
+}
+
+func TestDoWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
+	var hits int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL, MaxAttempts: 4, BackoffBase: time.Microsecond})
+	require.NoError(t, err)
+
+	resp, err := client.doWithRetry(func() (*http.Request, error) {
+		return http.NewRequest("GET", server.URL+"/anything", nil)
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "after 4 attempts")
+	assert.Equal(t, int64(4), atomic.LoadInt64(&hits))
+}
+
+func TestDoWithRetry_DoesNotRetryClientErrors(t *testing.T) {
+	var hits int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL, MaxAttempts: 5, BackoffBase: time.Microsecond})
+	require.NoError(t, err)
+
+	resp, err := client.doWithRetry(func() (*http.Request, error) {
+		return http.NewRequest("GET", server.URL+"/anything", nil)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&hits), "4xx must not retry")
+}
+
+func TestDoWithRetry_RetriesTransportError(t *testing.T) {
+	// Spin a server up to get an address, then close it so every attempt
+	// fails at the transport layer. With BackoffBase set to a single
+	// microsecond the retry loop costs effectively nothing.
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL, MaxAttempts: 3, BackoffBase: time.Microsecond})
+	require.NoError(t, err)
+
+	resp, err := client.doWithRetry(func() (*http.Request, error) {
+		return http.NewRequest("GET", server.URL+"/anything", nil)
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "after 3 attempts")
+}
+
+func TestNewClient_AppliesRetryDefaults(t *testing.T) {
+	t.Run("zero MaxAttempts falls back to DefaultMaxAttempts", func(t *testing.T) {
+		client, err := NewClient(Config{BaseURL: "http://example.invalid"})
+		require.NoError(t, err)
+		assert.Equal(t, DefaultMaxAttempts, client.maxAttempts)
+		assert.Equal(t, DefaultBackoffBase, client.backoffBase)
+	})
+
+	t.Run("explicit MaxAttempts of 1 disables retries", func(t *testing.T) {
+		client, err := NewClient(Config{BaseURL: "http://example.invalid", MaxAttempts: 1})
+		require.NoError(t, err)
+		assert.Equal(t, 1, client.maxAttempts)
 	})
 }


### PR DESCRIPTION
## Summary

`EnrichContent` and `GenerateEmbeddings` each fired one HTTP request; a single transport blip, a brief inference hiccup behind a 503, or a short 429 from a rate-limited Ollama would fail the entire CLI command even though one quick retry would have unstuck the world.

This PR adds a tiny `doWithRetry` helper on the client. Both call sites now route through it.

## The retry policy

| Trigger | Retry? |
|---|---|
| Transport error (refused, reset, …) | ✅ |
| 5xx | ✅ |
| 408 Request Timeout | ✅ |
| 429 Too Many Requests | ✅ |
| Other 4xx | ❌ (repeating a bad request won't make it less bad) |
| 2xx / 3xx | n/a — returned to caller |

- **Backoff**: exponential from `BackoffBase`, **full jitter** so concurrent enrichers don't synchronise into a thundering herd.
- **Defaults**: `DefaultMaxAttempts = 3` (one try + two retries), `DefaultBackoffBase = 500ms`.
- **Configurable** via `Config{MaxAttempts, BackoffBase}`. Setting `MaxAttempts: 1` disables retries entirely.
- Each retryable response is drained + closed so the connection returns to the pool before the sleep.

## Subtle but important

The helper takes a request **builder** (`func() (*http.Request, error)`) rather than a built request. Building per-attempt means the body is fresh — a single `bytes.Buffer`/`strings.Reader` would be drained after the first try and silently send empty payloads on retries.

## Test plan

- [x] Pre-existing `TestEnrichContent` 500-case updated: now asserts the new "after N attempts" message that reflects retry-budget exhaustion. Also gets a microsecond `BackoffBase` so the test runs fast.
- [x] New focused tests:
  - `TestIsRetryableStatus` — table of OK / 400 / 401 / 404 / 408 / 429 / 5xx
  - `TestDoWithRetry_RetriesTransientThenSucceeds` — asserts exactly N attempts before success
  - `TestDoWithRetry_GivesUpAfterMaxAttempts` — budget exhaustion with explicit hit count
  - `TestDoWithRetry_DoesNotRetryClientErrors` — 4xx short-circuits at attempt 1
  - `TestDoWithRetry_RetriesTransportError` — server closed before any call
  - `TestNewClient_AppliesRetryDefaults` — zero-value Config falls back; `MaxAttempts: 1` disables retries
- [x] `-race` clean (`go test -race ./internal/assets/infrastructure/llama -count=2`).
- [x] Full project suite green.

## Note

JIRA client has the same shape of HTTP failure paths and would benefit from the same treatment. Easy to lift the helper out into `internal/shared/httputil` and reuse — happy to do that as a follow-up.