### PR TITLE
refactor(httputil): share retry helper between Ollama and JIRA

### DIFF
--- a/internal/assets/infrastructure/llama/client.go
+++ b/internal/assets/infrastructure/llama/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math/rand/v2"
 	"net/http"
 	"os"
 	"regexp"
@@ -14,6 +13,7 @@ import (
 	"time"
 
 	"github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
+	"github.com/helmedeiros/digital-asset-capitalization/internal/shared/httputil"
 )
 
 // DefaultTimeout is the default HTTP timeout for Ollama requests. It is
@@ -21,28 +21,19 @@ import (
 // several minutes; a shorter value risks aborting valid in-flight requests.
 const DefaultTimeout = 5 * time.Minute
 
-// Retry defaults. DefaultMaxAttempts is "one try plus two retries", which
-// covers brief transport blips and short server hiccups without making a
-// genuinely-broken Ollama wait around for ages.
-const (
-	DefaultMaxAttempts = 3
-	DefaultBackoffBase = 500 * time.Millisecond
-)
-
 // Client represents an Ollama API client
 type Client struct {
 	baseURL     string
 	httpClient  *http.Client
-	maxAttempts int
-	backoffBase time.Duration
+	retryPolicy httputil.RetryPolicy
 }
 
 // Config holds the configuration for the Ollama client
 type Config struct {
 	BaseURL     string
 	Timeout     time.Duration
-	MaxAttempts int           // 0 -> DefaultMaxAttempts, 1 disables retries
-	BackoffBase time.Duration // 0 -> DefaultBackoffBase
+	MaxAttempts int           // 0 -> httputil.DefaultMaxAttempts, 1 disables retries
+	BackoffBase time.Duration // 0 -> httputil.DefaultBackoffBase
 }
 
 // DefaultConfig returns a default configuration for the Ollama client
@@ -54,8 +45,8 @@ func DefaultConfig() Config {
 	return Config{
 		BaseURL:     baseURL,
 		Timeout:     DefaultTimeout,
-		MaxAttempts: DefaultMaxAttempts,
-		BackoffBase: DefaultBackoffBase,
+		MaxAttempts: httputil.DefaultMaxAttempts,
+		BackoffBase: httputil.DefaultBackoffBase,
 	}
 }
 
@@ -70,73 +61,14 @@ func NewClient(config Config) (*Client, error) {
 		timeout = DefaultTimeout
 	}
 
-	maxAttempts := config.MaxAttempts
-	if maxAttempts <= 0 {
-		maxAttempts = DefaultMaxAttempts
-	}
-	backoffBase := config.BackoffBase
-	if backoffBase <= 0 {
-		backoffBase = DefaultBackoffBase
-	}
-
 	return &Client{
-		baseURL:     config.BaseURL,
-		httpClient:  &http.Client{Timeout: timeout},
-		maxAttempts: maxAttempts,
-		backoffBase: backoffBase,
+		baseURL:    config.BaseURL,
+		httpClient: &http.Client{Timeout: timeout},
+		retryPolicy: httputil.RetryPolicy{
+			MaxAttempts: config.MaxAttempts,
+			BackoffBase: config.BackoffBase,
+		},
 	}, nil
-}
-
-// isRetryableStatus reports whether an HTTP status code is worth a retry.
-// We retry on the canonical transient-server family (5xx) plus 408
-// (Request Timeout) and 429 (Too Many Requests). 4xx other than those is
-// a client error -- repeating the same request will not improve matters.
-func isRetryableStatus(code int) bool {
-	if code >= 500 && code < 600 {
-		return true
-	}
-	return code == http.StatusRequestTimeout || code == http.StatusTooManyRequests
-}
-
-// doWithRetry sends an HTTP request and retries on transport errors and
-// retryable status codes with exponential backoff and jitter. The
-// caller passes a request builder rather than a built request so the
-// body is fresh on every attempt -- a single bytes.Buffer or strings.Reader
-// would be drained after the first try.
-func (c *Client) doWithRetry(buildReq func() (*http.Request, error)) (*http.Response, error) {
-	var lastErr error
-	for attempt := 0; attempt < c.maxAttempts; attempt++ {
-		if attempt > 0 {
-			sleep := c.backoffBase << uint(attempt-1)
-			// Full jitter halves the worst case and stops fleets of clients
-			// from synchronising their retries into a thundering herd.
-			if sleep > 0 {
-				sleep = sleep/2 + time.Duration(rand.Int64N(int64(sleep)/2+1))
-			}
-			time.Sleep(sleep)
-		}
-
-		req, err := buildReq()
-		if err != nil {
-			return nil, err
-		}
-
-		resp, err := c.httpClient.Do(req)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		if !isRetryableStatus(resp.StatusCode) {
-			return resp, nil
-		}
-
-		// Drain and close the retryable response so the connection
-		// can return to the pool before we sleep.
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-		lastErr = fmt.Errorf("status %d", resp.StatusCode)
-	}
-	return nil, fmt.Errorf("Ollama request failed after %d attempts: %w", c.maxAttempts, lastErr)
 }
 
 var (
@@ -227,7 +159,7 @@ Field content:`, asset.Name, asset.Why, asset.Benefits, asset.How, asset.Metrics
 		return "", fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	resp, err := c.doWithRetry(func() (*http.Request, error) {
+	resp, err := httputil.DoWithRetry(c.httpClient, c.retryPolicy, "Ollama request", func() (*http.Request, error) {
 		req, err := http.NewRequest("POST", c.baseURL+"/api/generate", bytes.NewBuffer(jsonData))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create request: %w", err)
@@ -276,7 +208,7 @@ func (c *Client) GenerateEmbeddings(model string, texts []string) ([][]float64, 
 		return nil, fmt.Errorf("failed to marshal embedding request: %w", err)
 	}
 
-	resp, err := c.doWithRetry(func() (*http.Request, error) {
+	resp, err := httputil.DoWithRetry(c.httpClient, c.retryPolicy, "Ollama request", func() (*http.Request, error) {
 		req, err := http.NewRequest("POST", c.baseURL+"/api/embed", bytes.NewBuffer(jsonData))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create embedding request: %w", err)

--- a/internal/assets/infrastructure/llama/client_test.go
+++ b/internal/assets/infrastructure/llama/client_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -339,124 +338,27 @@ func TestDefaultConfig(t *testing.T) {
 	})
 }
 
-func TestIsRetryableStatus(t *testing.T) {
-	cases := []struct {
-		code      int
-		retryable bool
-	}{
-		{http.StatusOK, false},
-		{http.StatusBadRequest, false},
-		{http.StatusUnauthorized, false},
-		{http.StatusNotFound, false},
-		{http.StatusRequestTimeout, true},
-		{http.StatusTooManyRequests, true},
-		{http.StatusInternalServerError, true},
-		{http.StatusBadGateway, true},
-		{http.StatusServiceUnavailable, true},
-		{http.StatusGatewayTimeout, true},
-	}
-	for _, c := range cases {
-		assert.Equal(t, c.retryable, isRetryableStatus(c.code), "status %d", c.code)
-	}
-}
-
-func TestDoWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
-	var hits int64
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		n := atomic.AddInt64(&hits, 1)
-		if n < 3 {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte(`busy`))
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"response":"ok"}`))
-	}))
-	defer server.Close()
-
-	client, err := NewClient(Config{BaseURL: server.URL, MaxAttempts: 3, BackoffBase: time.Microsecond})
-	require.NoError(t, err)
-
-	resp, err := client.doWithRetry(func() (*http.Request, error) {
-		return http.NewRequest("GET", server.URL+"/anything", nil)
-	})
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	defer resp.Body.Close()
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, int64(3), atomic.LoadInt64(&hits), "should have retried twice before success")
-}
-
-func TestDoWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
-	var hits int64
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt64(&hits, 1)
-		w.WriteHeader(http.StatusBadGateway)
-	}))
-	defer server.Close()
-
-	client, err := NewClient(Config{BaseURL: server.URL, MaxAttempts: 4, BackoffBase: time.Microsecond})
-	require.NoError(t, err)
-
-	resp, err := client.doWithRetry(func() (*http.Request, error) {
-		return http.NewRequest("GET", server.URL+"/anything", nil)
-	})
-	require.Error(t, err)
-	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), "after 4 attempts")
-	assert.Equal(t, int64(4), atomic.LoadInt64(&hits))
-}
-
-func TestDoWithRetry_DoesNotRetryClientErrors(t *testing.T) {
-	var hits int64
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt64(&hits, 1)
-		w.WriteHeader(http.StatusBadRequest)
-	}))
-	defer server.Close()
-
-	client, err := NewClient(Config{BaseURL: server.URL, MaxAttempts: 5, BackoffBase: time.Microsecond})
-	require.NoError(t, err)
-
-	resp, err := client.doWithRetry(func() (*http.Request, error) {
-		return http.NewRequest("GET", server.URL+"/anything", nil)
-	})
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	defer resp.Body.Close()
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, int64(1), atomic.LoadInt64(&hits), "4xx must not retry")
-}
-
-func TestDoWithRetry_RetriesTransportError(t *testing.T) {
-	// Spin a server up to get an address, then close it so every attempt
-	// fails at the transport layer. With BackoffBase set to a single
-	// microsecond the retry loop costs effectively nothing.
-	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	server.Close()
-
-	client, err := NewClient(Config{BaseURL: server.URL, MaxAttempts: 3, BackoffBase: time.Microsecond})
-	require.NoError(t, err)
-
-	resp, err := client.doWithRetry(func() (*http.Request, error) {
-		return http.NewRequest("GET", server.URL+"/anything", nil)
-	})
-	require.Error(t, err)
-	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), "after 3 attempts")
-}
-
-func TestNewClient_AppliesRetryDefaults(t *testing.T) {
-	t.Run("zero MaxAttempts falls back to DefaultMaxAttempts", func(t *testing.T) {
+// Retry policy semantics are covered exhaustively in
+// internal/shared/httputil. The TestEnrichContent / TestGenerateEmbeddings
+// tables above exercise that the Ollama client routes both call sites
+// through the shared helper (the 500 case asserts the post-retry
+// "after N attempts" error shape).
+func TestNewClient_PropagatesRetryConfigToPolicy(t *testing.T) {
+	t.Run("zero MaxAttempts leaves the policy zero so DefaultMaxAttempts applies at use", func(t *testing.T) {
 		client, err := NewClient(Config{BaseURL: "http://example.invalid"})
 		require.NoError(t, err)
-		assert.Equal(t, DefaultMaxAttempts, client.maxAttempts)
-		assert.Equal(t, DefaultBackoffBase, client.backoffBase)
+		assert.Equal(t, 0, client.retryPolicy.MaxAttempts)
+		assert.Equal(t, time.Duration(0), client.retryPolicy.BackoffBase)
 	})
 
-	t.Run("explicit MaxAttempts of 1 disables retries", func(t *testing.T) {
-		client, err := NewClient(Config{BaseURL: "http://example.invalid", MaxAttempts: 1})
+	t.Run("explicit values flow into the policy unchanged", func(t *testing.T) {
+		client, err := NewClient(Config{
+			BaseURL:     "http://example.invalid",
+			MaxAttempts: 1,
+			BackoffBase: 7 * time.Millisecond,
+		})
 		require.NoError(t, err)
-		assert.Equal(t, 1, client.maxAttempts)
+		assert.Equal(t, 1, client.retryPolicy.MaxAttempts)
+		assert.Equal(t, 7*time.Millisecond, client.retryPolicy.BackoffBase)
 	})
 }

--- a/internal/shared/httputil/retry.go
+++ b/internal/shared/httputil/retry.go
@@ -1,0 +1,110 @@
+// Package httputil provides shared HTTP helpers used by infrastructure
+// clients (currently the Ollama and JIRA clients). Keeping them here
+// avoids two copies of the same retry logic drifting in different
+// directions.
+package httputil
+
+import (
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"time"
+)
+
+// Retry defaults. DefaultMaxAttempts means "one try plus two retries",
+// which covers brief transport blips and short server hiccups without
+// making a genuinely-broken upstream wait around for ages.
+const (
+	DefaultMaxAttempts = 3
+	DefaultBackoffBase = 500 * time.Millisecond
+)
+
+// HTTPClient is the minimum interface satisfied by *http.Client and by
+// the test fakes used by the JIRA client. Taking the interface here
+// lets the helper work with either without dragging in concrete types.
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// RetryPolicy bounds DoWithRetry's behaviour. Zero values fall back to
+// the package defaults so callers can pass RetryPolicy{} when they
+// don't want to tune.
+type RetryPolicy struct {
+	MaxAttempts int           // 0 -> DefaultMaxAttempts; 1 disables retries
+	BackoffBase time.Duration // 0 -> DefaultBackoffBase
+}
+
+// resolved returns a copy with zero fields filled in from the defaults.
+func (p RetryPolicy) resolved() RetryPolicy {
+	if p.MaxAttempts <= 0 {
+		p.MaxAttempts = DefaultMaxAttempts
+	}
+	if p.BackoffBase <= 0 {
+		p.BackoffBase = DefaultBackoffBase
+	}
+	return p
+}
+
+// IsRetryableStatus reports whether to retry on the given HTTP status
+// code. We retry on the canonical transient-server family (5xx) plus
+// 408 (Request Timeout) and 429 (Too Many Requests). 4xx other than
+// those is a client error -- repeating the same request will not
+// improve matters.
+func IsRetryableStatus(code int) bool {
+	if code >= 500 && code < 600 {
+		return true
+	}
+	return code == http.StatusRequestTimeout || code == http.StatusTooManyRequests
+}
+
+// DoWithRetry sends an HTTP request and retries on transport errors
+// and retryable status codes with exponential backoff and full jitter.
+// The caller passes a request *builder* rather than a built request so
+// the body is fresh on every attempt -- a single bytes.Buffer or
+// strings.Reader would be drained after the first try and silently
+// send empty payloads on retries.
+//
+// errLabel prefixes the final wrapped error so callers can identify
+// which upstream gave up; e.g. "Ollama request" or "JIRA request".
+func DoWithRetry(client HTTPClient, policy RetryPolicy, errLabel string, buildReq func() (*http.Request, error)) (*http.Response, error) {
+	p := policy.resolved()
+
+	var lastErr error
+	for attempt := 0; attempt < p.MaxAttempts; attempt++ {
+		if attempt > 0 {
+			sleep := p.BackoffBase << uint(attempt-1)
+			// Full jitter halves the worst case and stops fleets of
+			// concurrent clients from synchronising into a thundering herd.
+			if sleep > 0 {
+				sleep = sleep/2 + time.Duration(rand.Int64N(int64(sleep)/2+1))
+			}
+			time.Sleep(sleep)
+		}
+
+		req, err := buildReq()
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if !IsRetryableStatus(resp.StatusCode) {
+			return resp, nil
+		}
+
+		// Drain and close the retryable response so the connection can
+		// return to the pool before we sleep.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		lastErr = fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	if errLabel == "" {
+		errLabel = "request"
+	}
+	return nil, fmt.Errorf("%s failed after %d attempts: %w", errLabel, p.MaxAttempts, lastErr)
+}

--- a/internal/shared/httputil/retry_test.go
+++ b/internal/shared/httputil/retry_test.go
@@ -1,0 +1,159 @@
+package httputil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRetryableStatus(t *testing.T) {
+	cases := []struct {
+		code      int
+		retryable bool
+	}{
+		{http.StatusOK, false},
+		{http.StatusBadRequest, false},
+		{http.StatusUnauthorized, false},
+		{http.StatusForbidden, false},
+		{http.StatusNotFound, false},
+		{http.StatusRequestTimeout, true},
+		{http.StatusTooManyRequests, true},
+		{http.StatusInternalServerError, true},
+		{http.StatusBadGateway, true},
+		{http.StatusServiceUnavailable, true},
+		{http.StatusGatewayTimeout, true},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.retryable, IsRetryableStatus(c.code), "status %d", c.code)
+	}
+}
+
+func TestRetryPolicy_ResolvedFallsBackToDefaults(t *testing.T) {
+	p := RetryPolicy{}.resolved()
+	assert.Equal(t, DefaultMaxAttempts, p.MaxAttempts)
+	assert.Equal(t, DefaultBackoffBase, p.BackoffBase)
+
+	p = RetryPolicy{MaxAttempts: 5, BackoffBase: 7 * time.Millisecond}.resolved()
+	assert.Equal(t, 5, p.MaxAttempts)
+	assert.Equal(t, 7*time.Millisecond, p.BackoffBase)
+}
+
+func TestDoWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
+	var hits int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt64(&hits, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`busy`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	defer server.Close()
+
+	resp, err := DoWithRetry(http.DefaultClient,
+		RetryPolicy{MaxAttempts: 3, BackoffBase: time.Microsecond},
+		"upstream",
+		func() (*http.Request, error) {
+			return http.NewRequest("GET", server.URL+"/anything", nil)
+		})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int64(3), atomic.LoadInt64(&hits))
+}
+
+func TestDoWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
+	var hits int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	resp, err := DoWithRetry(http.DefaultClient,
+		RetryPolicy{MaxAttempts: 4, BackoffBase: time.Microsecond},
+		"upstream",
+		func() (*http.Request, error) {
+			return http.NewRequest("GET", server.URL+"/anything", nil)
+		})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "upstream failed after 4 attempts")
+	assert.Equal(t, int64(4), atomic.LoadInt64(&hits))
+}
+
+func TestDoWithRetry_DoesNotRetryClientErrors(t *testing.T) {
+	var hits int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	resp, err := DoWithRetry(http.DefaultClient,
+		RetryPolicy{MaxAttempts: 5, BackoffBase: time.Microsecond},
+		"upstream",
+		func() (*http.Request, error) {
+			return http.NewRequest("GET", server.URL+"/anything", nil)
+		})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&hits), "4xx must not retry")
+}
+
+func TestDoWithRetry_RetriesTransportError(t *testing.T) {
+	// Spin a server to get an address, then close it so every attempt
+	// fails at the transport layer.
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	server.Close()
+
+	resp, err := DoWithRetry(http.DefaultClient,
+		RetryPolicy{MaxAttempts: 3, BackoffBase: time.Microsecond},
+		"upstream",
+		func() (*http.Request, error) {
+			return http.NewRequest("GET", server.URL+"/anything", nil)
+		})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "upstream failed after 3 attempts")
+}
+
+func TestDoWithRetry_EmptyErrLabelFallsBackToRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	_, err := DoWithRetry(http.DefaultClient,
+		RetryPolicy{MaxAttempts: 2, BackoffBase: time.Microsecond},
+		"",
+		func() (*http.Request, error) {
+			return http.NewRequest("GET", server.URL+"/anything", nil)
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request failed after 2 attempts")
+}
+
+func TestDoWithRetry_BuildRequestErrorPropagates(t *testing.T) {
+	resp, err := DoWithRetry(http.DefaultClient,
+		RetryPolicy{MaxAttempts: 3, BackoffBase: time.Microsecond},
+		"upstream",
+		func() (*http.Request, error) {
+			return http.NewRequest("GET", "http://example.invalid\x00", nil)
+		})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	// We want the *request build* error, not a wrapped retry error -- if
+	// the caller can't build a request we shouldn't lie about retries.
+	assert.NotContains(t, err.Error(), "upstream failed after")
+}

--- a/internal/tasks/infrastructure/jira/client.go
+++ b/internal/tasks/infrastructure/jira/client.go
@@ -12,10 +12,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/helmedeiros/digital-asset-capitalization/internal/shared/httputil"
+	sharedjira "github.com/helmedeiros/digital-asset-capitalization/internal/shared/jira"
 	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain"
 	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/infrastructure/jira/api"
-
-	sharedjira "github.com/helmedeiros/digital-asset-capitalization/internal/shared/jira"
 )
 
 // Client defines the interface for Jira API interactions
@@ -43,8 +43,9 @@ var NewClient ClientFactory = newClient
 
 // client implements the Client interface
 type client struct {
-	httpClient HTTPClient
-	config     *Config
+	httpClient  HTTPClient
+	config      *Config
+	retryPolicy httputil.RetryPolicy
 
 	// customFieldIDs is lazily populated via resolveFieldIDsOnce on first
 	// use. After the Once.Do fires, customFieldIDs is read-only for the
@@ -65,6 +66,13 @@ func newClient(config *Config) (Client, error) {
 			Timeout: 30 * time.Second,
 		},
 		config: config,
+		// Honoured per-call via httputil.DoWithRetry so transient blips,
+		// brief 5xx hiccups, and 429 rate-limit replies don't fail a whole
+		// sprint sync. Zero-valued fields fall back to httputil defaults.
+		retryPolicy: httputil.RetryPolicy{
+			MaxAttempts: config.MaxAttempts,
+			BackoffBase: config.BackoffBase,
+		},
 	}, nil
 }
 
@@ -505,18 +513,15 @@ func (c *client) search(ctx context.Context, jql string) (*api.SearchResult, err
 		c.config.GetBaseURL(),
 		url.QueryEscape(jql))
 
-	// Create request
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Add authentication headers
-	req.Header.Set("Authorization", c.config.GetAuthHeader())
-	req.Header.Set("Accept", "application/json")
-
-	// Execute request
-	resp, err := c.httpClient.Do(req)
+	resp, err := httputil.DoWithRetry(c.httpClient, c.retryPolicy, "JIRA search", func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("Authorization", c.config.GetAuthHeader())
+		req.Header.Set("Accept", "application/json")
+		return req, nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
@@ -578,18 +583,15 @@ func (c *client) FetchTaskByKey(ctx context.Context, key string) (*domain.Task, 
 	// Build the URL for fetching a single issue
 	issueURL := fmt.Sprintf("%s/rest/api/3/issue/%s?expand=changelog", c.config.BaseURL, key)
 
-	// Create the request
-	req, err := http.NewRequestWithContext(ctx, "GET", issueURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Add authentication
-	req.Header.Set("Authorization", c.config.GetAuthHeader())
-	req.Header.Set("Accept", "application/json")
-
-	// Execute the request
-	resp, err := c.httpClient.Do(req)
+	resp, err := httputil.DoWithRetry(c.httpClient, c.retryPolicy, "JIRA issue fetch", func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, "GET", issueURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("Authorization", c.config.GetAuthHeader())
+		req.Header.Set("Accept", "application/json")
+		return req, nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
@@ -758,18 +760,16 @@ func (c *client) UpdateLabels(ctx context.Context, issueKey string, addLabels, r
 		return fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
-	// Construct the request
-	req, err := http.NewRequestWithContext(ctx, "PUT", fmt.Sprintf("%s/rest/api/3/issue/%s", c.config.GetBaseURL(), issueKey), bytes.NewBuffer(jsonBody))
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Set headers
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", c.config.GetAuthHeader())
-
-	// Send request
-	resp, err := c.httpClient.Do(req)
+	resp, err := httputil.DoWithRetry(c.httpClient, c.retryPolicy, "JIRA label update", func() (*http.Request, error) {
+		// Rebuild bytes.Buffer per attempt so the body is fresh on retries.
+		req, err := http.NewRequestWithContext(ctx, "PUT", fmt.Sprintf("%s/rest/api/3/issue/%s", c.config.GetBaseURL(), issueKey), bytes.NewBuffer(jsonBody))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", c.config.GetAuthHeader())
+		return req, nil
+	})
 	if err != nil {
 		return fmt.Errorf("failed to send request: %w", err)
 	}

--- a/internal/tasks/infrastructure/jira/client_test.go
+++ b/internal/tasks/infrastructure/jira/client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/helmedeiros/digital-asset-capitalization/internal/shared/httputil"
 	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain"
 	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/infrastructure/jira/api"
 )
@@ -279,17 +280,20 @@ func TestClient_FetchTasks(t *testing.T) {
 		}))
 		defer server.Close()
 
+		// 500 is retryable; cap MaxAttempts at 1 so the test runs fast.
+		// Retry behaviour itself is covered in internal/shared/httputil.
 		config := &Config{
-			BaseURL: server.URL,
-			Email:   "test@example.com",
-			Token:   "test-token",
+			BaseURL:     server.URL,
+			Email:       "test@example.com",
+			Token:       "test-token",
+			MaxAttempts: 1,
 		}
 		client, err := NewClient(config)
 		require.NoError(t, err, "Should not return error")
 		tasks, err := client.FetchTasks(ctx, "TEST", "Sprint 1")
 		require.Error(t, err, "Should return error")
 		assert.Nil(t, tasks, "Tasks should be nil")
-		assert.Contains(t, err.Error(), "unexpected status code: 500", "Error message should indicate server error")
+		assert.Contains(t, err.Error(), "JIRA search failed after 1 attempts")
 	})
 
 	t.Run("invalid response", func(t *testing.T) {
@@ -981,7 +985,10 @@ func TestClient_FetchTaskByKey(t *testing.T) {
 				}
 			},
 			expectedError: true,
-			errorContains: "Jira API returned status 500",
+			// 500 is retryable; the test uses the table client below
+			// with MaxAttempts: 1 to skip the retry loop, so we report
+			// the new single-attempt error shape.
+			errorContains: "JIRA issue fetch failed after 1 attempts",
 		},
 		{
 			name: "invalid JSON response",
@@ -1012,10 +1019,12 @@ func TestClient_FetchTaskByKey(t *testing.T) {
 				Token:   "test-token",
 			}
 
-			// Create client
+			// Create client with MaxAttempts: 1 so retryable-status
+			// cases don't drag the suite through real backoff sleeps.
 			client := &client{
-				httpClient: mockHTTPClient,
-				config:     config,
+				httpClient:  mockHTTPClient,
+				config:      config,
+				retryPolicy: httputil.RetryPolicy{MaxAttempts: 1},
 			}
 
 			// Execute
@@ -1110,10 +1119,14 @@ func TestClient_UpdateLabels(t *testing.T) {
 		}))
 		defer server.Close()
 
+		// 500 is retryable; cap MaxAttempts at 1 so the test exercises
+		// a single-attempt failure path quickly. The retry path itself
+		// is covered exhaustively in internal/shared/httputil.
 		config := &Config{
-			BaseURL: server.URL,
-			Email:   "test@example.com",
-			Token:   "test-token",
+			BaseURL:     server.URL,
+			Email:       "test@example.com",
+			Token:       "test-token",
+			MaxAttempts: 1,
 		}
 
 		client, err := NewClient(config)
@@ -1124,7 +1137,7 @@ func TestClient_UpdateLabels(t *testing.T) {
 		)
 
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to update labels")
+		assert.Contains(t, err.Error(), "JIRA label update failed after 1 attempts")
 	})
 }
 

--- a/internal/tasks/infrastructure/jira/config.go
+++ b/internal/tasks/infrastructure/jira/config.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 )
 
 const (
@@ -19,6 +20,12 @@ type Config struct {
 	BaseURL string
 	Email   string
 	Token   string
+
+	// MaxAttempts and BackoffBase tune the retry policy applied to all
+	// outbound JIRA calls. Zero values fall back to the shared httputil
+	// defaults; MaxAttempts == 1 disables retries entirely.
+	MaxAttempts int
+	BackoffBase time.Duration
 }
 
 // ConfigFactory is a function type for creating new Jira configurations


### PR DESCRIPTION
## Summary

#78 added a `doWithRetry` helper inside the llama package so `EnrichContent` and `GenerateEmbeddings` could survive transient blips. The JIRA client had the same shape of HTTP failure paths — sprint search, single-issue fetch, label update — and the same need: a 502 from a load balancer or a 429 during a rate-limited bulk sync used to fail the whole CLI command even when one quick retry would have unstuck the world.

Rather than copy-paste the helper (two implementations would drift in different directions), this PR:

1. **Lifts** the retry logic into `internal/shared/httputil`.
2. **Routes both clients** through it.
3. **Adds retry knobs** to JIRA `Config` mirroring the Ollama ones.

## Shared package

`internal/shared/httputil`:

- `IsRetryableStatus(int) bool` — 5xx, 408, 429.
- `RetryPolicy{MaxAttempts, BackoffBase}` — zero values fall back to `DefaultMaxAttempts=3` and `DefaultBackoffBase=500ms`. `MaxAttempts:1` disables retries entirely.
- `DoWithRetry(client HTTPClient, policy RetryPolicy, errLabel string, buildReq func() (*http.Request, error)) (*http.Response, error)` — takes an `HTTPClient` interface (`*http.Client` and the JIRA package's mock both satisfy it), a request **builder** (so the body is fresh per attempt — a `bytes.Buffer` would drain after the first try), an `errLabel` for the final wrapped error (`"JIRA search"`, `"Ollama request"`), and applies exponential backoff with full jitter between attempts.

100% statement coverage, `-race -count=2` clean.

## Client wiring

Both clients now route every HTTP call through `DoWithRetry`:

| Client | Endpoints |
|---|---|
| llama | `POST /api/generate`, `POST /api/embed` |
| JIRA | `GET /rest/api/3/search/jql`, `GET /rest/api/3/issue/<key>`, `PUT /rest/api/3/issue/<key>` |

JIRA `Config` picks up `MaxAttempts` and `BackoffBase` fields that propagate into `client.retryPolicy` at construction — matching the existing Ollama `Config` shape so tests and operators can dial things down (or disable retries entirely with `MaxAttempts:1`) on a per-client basis.

## Test surgery

Three pre-existing JIRA tests asserted the per-attempt error string (`"unexpected status code: 500"`, `"Jira API returned status 500"`, `"failed to update labels"`) on the 500-response path. With retries, that path now reports the post-retry shape (`"JIRA <op> failed after N attempts"`). The tests now set `MaxAttempts:1` and assert the new single-attempt shape — they still exercise the same single-failure path, just without the noise of a real backoff loop. Retry semantics themselves are covered exhaustively in `internal/shared/httputil`.

The llama wrapper test stays as a thin propagation check: zero `Config` flows to a zero `RetryPolicy` so the defaults bind at use-time, explicit values flow through unchanged.

## Test plan

- [x] `go test -race ./internal/shared/httputil -count=2 -cover` — 100% coverage, race-clean.
- [x] `go test -race ./internal/tasks/infrastructure/jira -count=1` — green.
- [x] `go test -race ./internal/assets/infrastructure/llama -count=1` — green.
- [x] `go test -race ./...` — full project suite green.