### PR TITLE
ci: filter testutil packages out of the badge calculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,16 @@ jobs:
         # -race catches data races on every PR; multiple were already
         # found and fixed in recent work (#70, #71, #72, #73) that CI
         # was missing because tests were not race-instrumented.
+        # The badge is computed from a filtered profile that drops
+        # testutil packages (test helpers that look like production
+        # code to `go test -cover`) -- matching what
+        # scripts/coverage-gate.sh enforces locally, so the badge and
+        # the gate never disagree.
         run: |
           go test -v -race -coverprofile=coverage.out ./...
-          go tool cover -func=coverage.out | tee coverage.txt
-          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+          grep -v "testutil" coverage.out > coverage.filtered.out
+          go tool cover -func=coverage.filtered.out | tee coverage.txt
+          COVERAGE=$(go tool cover -func=coverage.filtered.out | grep total | awk '{print $3}' | sed 's/%//')
           echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
 
       - name: Upload coverage report


### PR DESCRIPTION
## Summary

The local coverage gate (`scripts/coverage-gate.sh`) drops `testutil` packages before computing the percentage — `internal/**/testutil/` helpers look like production code to `go test -cover`, and a 0%-covered helper file silently drags the displayed average down. The CI badge step ran the same `go test` invocation but piped the **unfiltered** profile straight to `go tool cover -func`, so the badge under-reported real coverage.

This PR applies the same filter in CI so the badge matches what the gate enforces.

## Concrete effect on the badge

| Source | % |
|---|---|
| **CI badge before** (unfiltered) | 71.8% |
| **CI badge after** (filtered, matches gate) | **72.5%** |

The spread (0.7 pp) is the testutil helpers reading as 0% / 48.8% "production" code. Code in the project is unaffected — this is purely surfacing what the gate already accepts.

## Test plan

- [x] Verified locally: same `go test ./...` produces 71.8% unfiltered vs 72.5% filtered.
- [x] No code change in the project; only the CI workflow's percentage extraction.