### PR TITLE
test(ui/colors): cover the remaining ANSI text-style wrappers

### DIFF
--- a/internal/console/infrastructure/ui/colors_test.go
+++ b/internal/console/infrastructure/ui/colors_test.go
@@ -133,3 +133,98 @@ func TestStyled(t *testing.T) {
 		t.Error("Expected styled text to end with reset")
 	}
 }
+
+// assertWrapsWithReset checks that a colour/style helper preserved the
+// raw text in its output and terminated the styled span with Reset.
+// All the helpers below share that contract; deduplicating the
+// assertion keeps each subtest a single readable line.
+func assertWrapsWithReset(t *testing.T, got, raw string) {
+	t.Helper()
+	if !strings.Contains(got, raw) {
+		t.Errorf("expected output to contain raw text %q, got %q", raw, got)
+	}
+	if !strings.HasSuffix(got, Reset) {
+		t.Errorf("expected output to end with Reset, got %q", got)
+	}
+}
+
+func TestDimText(t *testing.T) {
+	got := DimText("hello")
+	assertWrapsWithReset(t, got, "hello")
+	if !strings.HasPrefix(got, Dim) {
+		t.Errorf("expected output to start with Dim, got %q", got)
+	}
+}
+
+func TestItalicText(t *testing.T) {
+	got := ItalicText("hi")
+	assertWrapsWithReset(t, got, "hi")
+	if !strings.HasPrefix(got, Italic) {
+		t.Errorf("expected output to start with Italic, got %q", got)
+	}
+}
+
+func TestSemanticTextWrappers(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func(string) string
+	}{
+		{"MutedText", MutedText},
+		{"PrimaryText", PrimaryText},
+		{"Code", Code},
+		{"Link", Link},
+		{"Subheader", Subheader},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assertWrapsWithReset(t, c.fn("payload"), "payload")
+		})
+	}
+}
+
+func TestPromptText_AppliesBoldAndColor(t *testing.T) {
+	got := PromptText("> ")
+	// PromptText is Colorize(BoldText(text)) so the raw text and a
+	// Bold marker must both survive into the output.
+	if !strings.Contains(got, "> ") {
+		t.Errorf("expected raw text in output, got %q", got)
+	}
+	if !strings.Contains(got, Bold) {
+		t.Errorf("expected output to contain Bold, got %q", got)
+	}
+}
+
+func TestHeader_AppliesBoldOverPrimary(t *testing.T) {
+	got := Header("Title")
+	if !strings.Contains(got, "Title") {
+		t.Errorf("expected raw text in output, got %q", got)
+	}
+	if !strings.Contains(got, Bold) {
+		t.Errorf("expected Header to apply Bold, got %q", got)
+	}
+}
+
+func TestHighlight_WrapsWithBackgroundAndForeground(t *testing.T) {
+	got := Highlight("warn")
+	// Highlight is Styled(text, BgYellow, Black) so both style strings
+	// must appear before the text and a Reset must close the run.
+	if !strings.Contains(got, "warn") {
+		t.Errorf("expected raw text in output, got %q", got)
+	}
+	if !strings.HasSuffix(got, Reset) {
+		t.Errorf("expected output to end with Reset, got %q", got)
+	}
+	if !strings.Contains(got, BgYellow) || !strings.Contains(got, Black) {
+		t.Errorf("expected output to contain both BgYellow and Black style runs, got %q", got)
+	}
+}
+
+func TestGradient_StubFallsBackToStartColor(t *testing.T) {
+	// The documented behaviour is "for now, just use start color".
+	// Pin that so a future real gradient implementation surfaces in tests.
+	got := Gradient("g", ColorSuccess, ColorError)
+	assertWrapsWithReset(t, got, "g")
+	if !strings.HasPrefix(got, string(ColorSuccess)) {
+		t.Errorf("expected Gradient to begin with the start colour, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

A cluster of small zero-covered ANSI wrappers in `console/infrastructure/ui/colors.go`: `DimText`, `ItalicText`, `MutedText`, `PrimaryText`, `Subheader`, `Code`, `Link`, `PromptText`, `Header`, `Highlight`, `Gradient`. Each is a one-liner over `Colorize` / `Styled`, so the contract is uniform: the raw text survives into the output and the styled span terminates with `Reset`.

Test-only.

## Shape

- `assertWrapsWithReset` helper deduplicates the "raw text present + ends with Reset" check.
- The five identical semantic-text helpers (`MutedText`, `PrimaryText`, `Code`, `Link`, `Subheader`) table-drive through a single subtest.
- The compound wrappers get named tests: `PromptText` hits both `Bold` *and* a colour; `Header` is `Bold` over `Primary`; `Highlight` is multi-style (`BgYellow` *and* `Black` both appear).
- `Gradient` gets an **explicit pin** on its current "just return the start colour" stub. The doc says `"simplified"` / `"for now"` — if someone ever wires a real gradient, this test fires and forces them to update the contract.

## Coverage delta

```
console/infrastructure/ui   81.8%  →  82.5%
```

Modest because the package was already past target — but it closes the last cluster of completely-uncovered string formatters.

## Test plan

- [x] `go test -race ./internal/console/infrastructure/ui -count=2` — clean
- [x] Full project suite green