### PR TITLE
test(console): cover small zero-coverage helpers

### DIFF
--- a/internal/console/domain/ports/ai_interpreter_test.go
+++ b/internal/console/domain/ports/ai_interpreter_test.go
@@ -1,0 +1,27 @@
+package ports
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInterpretationError(t *testing.T) {
+	err := NewInterpretationError("show me everything", "ambiguous", []string{"assets list", "tasks list"})
+	require.NotNil(t, err)
+	assert.Equal(t, "show me everything", err.Input)
+	assert.Equal(t, "ambiguous", err.Reason)
+	assert.Equal(t, []string{"assets list", "tasks list"}, err.Options)
+}
+
+func TestInterpretationError_Error(t *testing.T) {
+	err := NewInterpretationError("anything", "the reason text", nil)
+	assert.Equal(t, "the reason text", err.Error())
+
+	// Also satisfies the standard error interface so errors.As works.
+	var ie *InterpretationError
+	require.True(t, errors.As(err, &ie))
+	assert.Same(t, err, ie)
+}

--- a/internal/console/infrastructure/ui/prompt_test.go
+++ b/internal/console/infrastructure/ui/prompt_test.go
@@ -271,3 +271,26 @@ func TestClearScreen(t *testing.T) {
 	result := ps.ClearScreen()
 	assert.Equal(t, "\033[2J\033[H", result)
 }
+
+func TestRenderFullSession(t *testing.T) {
+	ps := NewPromptSession(80)
+
+	t.Run("empty history yields empty string", func(t *testing.T) {
+		assert.Equal(t, "", ps.RenderFullSession())
+	})
+
+	t.Run("populated history renders each entry's input", func(t *testing.T) {
+		ps.AddEntry("first input", "first output", 100*time.Millisecond, true)
+		ps.AddEntry("second input", "second output", 200*time.Millisecond, false)
+		got := ps.RenderFullSession()
+		assert.Contains(t, got, "first input")
+		assert.Contains(t, got, "second input")
+	})
+}
+
+func TestRenderCurrentPrompt(t *testing.T) {
+	ps := NewPromptSession(80)
+	got := ps.RenderCurrentPrompt()
+	assert.NotEmpty(t, got)
+	assert.True(t, strings.HasPrefix(got, "\n"), "RenderCurrentPrompt should lead with a newline separator")
+}


### PR DESCRIPTION
Three small zero-covered helpers:

- `ports.NewInterpretationError` + `Error()` — establishes the package's first test file.
- `PromptSession.RenderFullSession` — empty/populated history branches.
- `PromptSession.RenderCurrentPrompt` — newline-prefix contract.

Tiny accessor coverage; supports the broader push toward 80% project total.