### PR TITLE
test(sprint): cover NewStatusService delegation edge

### DIFF
--- a/internal/sprint/application/service/status_service_test.go
+++ b/internal/sprint/application/service/status_service_test.go
@@ -271,3 +271,19 @@ func TestLoadTeamConfigs(t *testing.T) {
 		assert.Nil(t, configs)
 	})
 }
+
+func TestNewStatusService(t *testing.T) {
+	// NewStatusService delegates to NewStatusServiceWithPath("") which
+	// looks up the user's home directory. We don't care which path it
+	// finally settles on -- only that the delegation works without
+	// panicking and either succeeds (file existed) or errors
+	// gracefully. The path-construction code lives entirely in
+	// NewStatusServiceWithPath, so this test fires only the delegation
+	// edge.
+	svc, err := NewStatusService()
+	if err != nil {
+		assert.Nil(t, svc)
+		return
+	}
+	require.NotNil(t, svc)
+}


### PR DESCRIPTION
One-liner constructor that delegates to NewStatusServiceWithPath(""). Smoke test pins the delegation works regardless of whether the filesystem lookup succeeds.