### PR TITLE
test(ui): cover Table.alignText branches (50% → 100%)

### DIFF
--- a/internal/console/infrastructure/ui/formatters_extra_test.go
+++ b/internal/console/infrastructure/ui/formatters_extra_test.go
@@ -256,3 +256,25 @@ func TestDefaultFormatter_AllTypeBranches(t *testing.T) {
 		require.NotEmpty(t, got)
 	})
 }
+
+func TestTable_AlignText(t *testing.T) {
+	tbl := &Table{}
+
+	t.Run("text wider than width is returned unchanged", func(t *testing.T) {
+		assert.Equal(t, "xxxxxxxx", tbl.alignText("xxxxxxxx", 4, "left"))
+	})
+
+	t.Run("right alignment prepends padding", func(t *testing.T) {
+		assert.Equal(t, "   abc", tbl.alignText("abc", 6, "right"))
+	})
+
+	t.Run("center alignment splits padding (extra goes to the right)", func(t *testing.T) {
+		// 6 - 3 = 3 -> 1 left, 2 right.
+		assert.Equal(t, " abc  ", tbl.alignText("abc", 6, "center"))
+	})
+
+	t.Run("left alignment (default) appends padding", func(t *testing.T) {
+		assert.Equal(t, "abc   ", tbl.alignText("abc", 6, "left"))
+		assert.Equal(t, "abc   ", tbl.alignText("abc", 6, ""), "unknown align defaults to left")
+	})
+}


### PR DESCRIPTION
alignText switches on align string: wider-than-width returned unchanged, right prepends padding, center splits padding with the extra going to the right, left (and any unknown align) appends padding.