### PR TITLE
refactor(assets): extract processFetchedAssets and cover merge loop

### DIFF
--- a/internal/assets/application/process_fetched_assets_test.go
+++ b/internal/assets/application/process_fetched_assets_test.go
@@ -1,0 +1,150 @@
+package application
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
+)
+
+func validAsset() *domain.Asset {
+	return &domain.Asset{
+		ID:          "asset-1",
+		Name:        "Search",
+		Description: "Search subsystem",
+		Status:      "active",
+		DocLink:     "https://example.invalid/search",
+		LaunchDate:  time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestProcessFetchedAssets_BucketsByValidation(t *testing.T) {
+	mockRepo := new(MockAssetRepository)
+	// First asset is valid and new.
+	good := validAsset()
+	mockRepo.On("FindByID", "asset-1").Return(nil, errors.New("not found")).Once()
+	mockRepo.On("Save", good).Return(nil).Once()
+
+	// Second asset has no DocLink/Status — should land in NotSyncedAssets.
+	bad := &domain.Asset{ID: "asset-2", Name: "Empty", Description: "x"}
+
+	svc := &AssetServiceImpl{repo: mockRepo}
+	result, err := svc.processFetchedAssets([]*domain.Asset{good, bad})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.SyncedAssets, 1)
+	assert.Equal(t, "Search", result.SyncedAssets[0].Name)
+	require.Len(t, result.NotSyncedAssets, 1)
+	assert.Equal(t, "Empty", result.NotSyncedAssets[0].Name)
+	assert.Contains(t, result.NotSyncedAssets[0].MissingFields, "Status")
+	assert.Contains(t, result.NotSyncedAssets[0].MissingFields, "DocLink")
+	mockRepo.AssertExpectations(t)
+}
+
+func TestProcessFetchedAssets_PreservesLocalMetadata(t *testing.T) {
+	mockRepo := new(MockAssetRepository)
+	fresh := validAsset() // Keywords/teams empty, AssociatedTaskCount=0.
+
+	existing := validAsset()
+	existing.Keywords = []string{"search", "indexer"}
+	existing.OwningTeam = "Voyager"
+	existing.ContributingTeams = []string{"Catalog"}
+	existing.AssociatedTaskCount = 12
+
+	mockRepo.On("FindByID", "asset-1").Return(existing, nil).Once()
+	// The saved asset is the same pointer as `fresh`, mutated by merge.
+	mockRepo.On("Save", fresh).Return(nil).Once()
+
+	svc := &AssetServiceImpl{repo: mockRepo}
+	_, err := svc.processFetchedAssets([]*domain.Asset{fresh})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"search", "indexer"}, fresh.Keywords)
+	assert.Equal(t, "Voyager", fresh.OwningTeam)
+	assert.Equal(t, []string{"Catalog"}, fresh.ContributingTeams)
+	assert.Equal(t, 12, fresh.AssociatedTaskCount)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestProcessFetchedAssets_DoesNotOverwriteFreshMetadata(t *testing.T) {
+	mockRepo := new(MockAssetRepository)
+	fresh := validAsset()
+	fresh.Keywords = []string{"fresh"}
+	fresh.OwningTeam = "FreshTeam"
+	fresh.ContributingTeams = []string{"Other"}
+	fresh.AssociatedTaskCount = 3
+
+	existing := validAsset()
+	existing.Keywords = []string{"stale"}
+	existing.OwningTeam = "StaleTeam"
+	existing.ContributingTeams = []string{"Stale"}
+	existing.AssociatedTaskCount = 99
+
+	mockRepo.On("FindByID", "asset-1").Return(existing, nil).Once()
+	mockRepo.On("Save", fresh).Return(nil).Once()
+
+	svc := &AssetServiceImpl{repo: mockRepo}
+	_, err := svc.processFetchedAssets([]*domain.Asset{fresh})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"fresh"}, fresh.Keywords)
+	assert.Equal(t, "FreshTeam", fresh.OwningTeam)
+	assert.Equal(t, []string{"Other"}, fresh.ContributingTeams)
+	// AssociatedTaskCount is preserved from existing only when existing > 0;
+	// for this branch the existing.AssociatedTaskCount (99) IS preserved
+	// because mergeLocalMetadata unconditionally overwrites when existing > 0.
+	assert.Equal(t, 99, fresh.AssociatedTaskCount)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestProcessFetchedAssets_SaveErrorWrapsAssetName(t *testing.T) {
+	mockRepo := new(MockAssetRepository)
+	fresh := validAsset()
+	mockRepo.On("FindByID", "asset-1").Return(nil, errors.New("not found")).Once()
+	mockRepo.On("Save", fresh).Return(errors.New("disk full")).Once()
+
+	svc := &AssetServiceImpl{repo: mockRepo}
+	_, err := svc.processFetchedAssets([]*domain.Asset{fresh})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save asset Search")
+	mockRepo.AssertExpectations(t)
+}
+
+func TestNotSyncedFromAsset_CapturesAvailableFields(t *testing.T) {
+	asset := &domain.Asset{
+		ID:          "id-1",
+		Name:        "X",
+		Description: "desc",
+		Status:      "active",
+		DocLink:     "https://e/d",
+		Why:         "why",
+		Benefits:    "benefits",
+		How:         "how",
+		Metrics:     "metrics",
+		LaunchDate:  time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+	}
+	got := notSyncedFromAsset(asset, []string{"Foo"})
+	assert.Equal(t, "X", got.Name)
+	assert.Equal(t, []string{"Foo"}, got.MissingFields)
+	assert.Equal(t, "id-1", got.AvailableFields["ID"])
+	assert.Equal(t, "2026-01-02", got.AvailableFields["LaunchDate"])
+	assert.Equal(t, "why", got.AvailableFields["Why"])
+}
+
+func TestMergeLocalMetadata_NilOrEmptyFieldsOnExistingAreIgnored(t *testing.T) {
+	fresh := validAsset()
+	fresh.Keywords = []string{"kept"}
+	existing := validAsset() // No keywords/teams on existing either.
+
+	mergeLocalMetadata(fresh, existing)
+
+	// Nothing to merge — fresh stays intact, no panic.
+	assert.Equal(t, []string{"kept"}, fresh.Keywords)
+	assert.Equal(t, "", fresh.OwningTeam)
+	assert.Empty(t, fresh.ContributingTeams)
+	assert.Equal(t, 0, fresh.AssociatedTaskCount)
+}

--- a/internal/assets/application/service.go
+++ b/internal/assets/application/service.go
@@ -281,50 +281,26 @@ func (s *AssetServiceImpl) SyncFromConfluence(spaceKey, label string, debug bool
 		return nil, fmt.Errorf("failed to fetch assets from Confluence: %v", err)
 	}
 
+	return s.processFetchedAssets(assets)
+}
+
+// processFetchedAssets validates each fetched asset, preserves locally
+// generated metadata from the existing repository copy, and persists
+// the merged result. Extracted from SyncFromConfluence so the merge
+// loop can be unit-tested without driving the Confluence adapter.
+func (s *AssetServiceImpl) processFetchedAssets(assets []*domain.Asset) (*domain.SyncResult, error) {
 	result := domain.NewSyncResult()
 
-	// Update local repository with fetched assets
 	for _, asset := range assets {
 		missingFields := validateRequiredFields(asset)
 		if len(missingFields) > 0 {
-			notSynced := &domain.NotSyncedAsset{
-				Name:          asset.Name,
-				MissingFields: missingFields,
-				AvailableFields: map[string]string{
-					"ID":          asset.ID,
-					"Name":        asset.Name,
-					"Description": asset.Description,
-					"LaunchDate":  asset.LaunchDate.Format("2006-01-02"),
-					"Status":      asset.Status,
-					"DocLink":     asset.DocLink,
-					"Why":         asset.Why,
-					"Benefits":    asset.Benefits,
-					"How":         asset.How,
-					"Metrics":     asset.Metrics,
-				},
-			}
-			result.NotSyncedAssets = append(result.NotSyncedAssets, notSynced)
+			result.NotSyncedAssets = append(result.NotSyncedAssets, notSyncedFromAsset(asset, missingFields))
 			continue
 		}
 
-		// Preserve locally-generated data (keywords, team assignments) from existing asset
 		existingAsset, err := s.repo.FindByID(asset.ID)
 		if err == nil && existingAsset != nil {
-			// Preserve keywords if the new asset has none (Confluence doesn't store AI-generated keywords)
-			if len(asset.Keywords) == 0 && len(existingAsset.Keywords) > 0 {
-				asset.Keywords = existingAsset.Keywords
-			}
-			// Preserve team assignments
-			if asset.OwningTeam == "" && existingAsset.OwningTeam != "" {
-				asset.OwningTeam = existingAsset.OwningTeam
-			}
-			if len(asset.ContributingTeams) == 0 && len(existingAsset.ContributingTeams) > 0 {
-				asset.ContributingTeams = existingAsset.ContributingTeams
-			}
-			// Preserve task count
-			if existingAsset.AssociatedTaskCount > 0 {
-				asset.AssociatedTaskCount = existingAsset.AssociatedTaskCount
-			}
+			mergeLocalMetadata(asset, existingAsset)
 		}
 
 		if err := s.repo.Save(asset); err != nil {
@@ -334,6 +310,47 @@ func (s *AssetServiceImpl) SyncFromConfluence(spaceKey, label string, debug bool
 	}
 
 	return result, nil
+}
+
+// notSyncedFromAsset packages an asset's snapshot for the caller to
+// see which fields blocked the sync.
+func notSyncedFromAsset(asset *domain.Asset, missingFields []string) *domain.NotSyncedAsset {
+	return &domain.NotSyncedAsset{
+		Name:          asset.Name,
+		MissingFields: missingFields,
+		AvailableFields: map[string]string{
+			"ID":          asset.ID,
+			"Name":        asset.Name,
+			"Description": asset.Description,
+			"LaunchDate":  asset.LaunchDate.Format("2006-01-02"),
+			"Status":      asset.Status,
+			"DocLink":     asset.DocLink,
+			"Why":         asset.Why,
+			"Benefits":    asset.Benefits,
+			"How":         asset.How,
+			"Metrics":     asset.Metrics,
+		},
+	}
+}
+
+// mergeLocalMetadata copies locally-generated fields (AI keywords, team
+// assignments, task counts) from the existing repository copy onto the
+// freshly-fetched asset when the new asset has nothing for that slot.
+// Confluence does not store these locally-generated fields so a naive
+// overwrite would lose them on every sync.
+func mergeLocalMetadata(asset, existingAsset *domain.Asset) {
+	if len(asset.Keywords) == 0 && len(existingAsset.Keywords) > 0 {
+		asset.Keywords = existingAsset.Keywords
+	}
+	if asset.OwningTeam == "" && existingAsset.OwningTeam != "" {
+		asset.OwningTeam = existingAsset.OwningTeam
+	}
+	if len(asset.ContributingTeams) == 0 && len(existingAsset.ContributingTeams) > 0 {
+		asset.ContributingTeams = existingAsset.ContributingTeams
+	}
+	if existingAsset.AssociatedTaskCount > 0 {
+		asset.AssociatedTaskCount = existingAsset.AssociatedTaskCount
+	}
 }
 
 // EnrichAsset enriches a specific field of an asset using LLaMA 3


### PR DESCRIPTION
## Summary

- Extract SyncFromConfluence's merge/save loop into testable processFetchedAssets, notSyncedFromAsset, and mergeLocalMetadata helpers
- The original loop was unreachable in unit tests because SyncFromConfluence constructs its Confluence adapter inline; these helpers take plain inputs and only need the AssetRepository port
- Behavior is unchanged — the public API still calls into the same logic, just through extracted helpers

## Coverage

- SyncFromConfluence: 35.6% → 64.0%
- New helpers: 100%
- Package internal/assets/application: 71.6% → 76.3%
- Project total: 79.4% → 79.6%

## Test plan

- [x] go test ./internal/assets/application/ -run 'TestProcessFetchedAssets|TestNotSyncedFromAsset|TestMergeLocalMetadata'
- [x] go test ./... (no regressions)