### PR TITLE
test(classifier): cover batch LLM, embedding adapter, and history constructor

### DIFF
--- a/internal/tasks/infrastructure/classifier/embedding_classifier_constructor_test.go
+++ b/internal/tasks/infrastructure/classifier/embedding_classifier_constructor_test.go
@@ -1,0 +1,33 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEmbeddingAssetClassifierWithHistory_WiresAllFields(t *testing.T) {
+	historical := map[string][]string{"cap-asset-search": {"Search ranking task"}}
+	epicNames := map[string]string{"COP-2": "Improve checkout"}
+	epicHints := map[string]string{"COP-19": "cap-asset-carrier-optimization"}
+
+	classifier := NewEmbeddingAssetClassifierWithHistory(nil, nil, nil, historical, epicNames, epicHints)
+	require.NotNil(t, classifier)
+
+	concrete, ok := classifier.(*EmbeddingAssetClassifier)
+	require.True(t, ok, "constructor should return *EmbeddingAssetClassifier")
+	assert.Equal(t, historical, concrete.historicalTasks)
+	assert.Equal(t, epicNames, concrete.epicNames)
+	assert.Equal(t, epicHints, concrete.epicAssetHint)
+}
+
+func TestNewEmbeddingAssetClassifierWithHistory_NilMapsAreFine(t *testing.T) {
+	classifier := NewEmbeddingAssetClassifierWithHistory(nil, nil, nil, nil, nil, nil)
+	require.NotNil(t, classifier)
+	concrete, ok := classifier.(*EmbeddingAssetClassifier)
+	require.True(t, ok)
+	assert.Nil(t, concrete.historicalTasks)
+	assert.Nil(t, concrete.epicNames)
+	assert.Nil(t, concrete.epicAssetHint)
+}

--- a/internal/tasks/infrastructure/classifier/ollama_embedding_adapter_test.go
+++ b/internal/tasks/infrastructure/classifier/ollama_embedding_adapter_test.go
@@ -1,0 +1,36 @@
+package classifier
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helmedeiros/digital-asset-capitalization/internal/assets/infrastructure/llama"
+)
+
+// TestOllamaEmbeddingAdapter_Embed_PassesThrough drives the
+// previously-uncovered Embed method by pointing a real llama.Client
+// at an httptest server. The adapter is a thin pass-through to
+// GenerateEmbeddings so a single happy path is enough.
+func TestOllamaEmbeddingAdapter_Embed_PassesThrough(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/embed", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"embeddings": [[0.1, 0.2], [0.3, 0.4]]}`))
+	}))
+	defer server.Close()
+
+	client, err := llama.NewClient(llama.Config{BaseURL: server.URL, BackoffBase: time.Microsecond})
+	require.NoError(t, err)
+
+	adapter := NewOllamaEmbeddingAdapter(client, "nomic-embed-text")
+	got, err := adapter.Embed([]string{"alpha", "beta"})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.InDelta(t, 0.1, got[0][0], 0.0001)
+	assert.InDelta(t, 0.4, got[1][1], 0.0001)
+}

--- a/internal/tasks/infrastructure/classifier/run_batch_llm_classification_test.go
+++ b/internal/tasks/infrastructure/classifier/run_batch_llm_classification_test.go
@@ -1,0 +1,69 @@
+package classifier
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	assetdomain "github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
+	taskdomain "github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain"
+	"github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain/ports"
+)
+
+// batchStubAssetClassifier is a hand-rolled stub for the batch
+// classification path. The single-task stubAssetClassifier in
+// inherit_from_parent_test.go returns nil from ClassifyTasksAssets,
+// which doesn't exercise runBatchLLMClassification's match loop.
+type batchStubAssetClassifier struct {
+	batchResults []*ports.AssetClassificationResult
+	batchErr     error
+}
+
+func (b *batchStubAssetClassifier) ClassifyTaskAsset(*taskdomain.Task) (*ports.AssetClassificationResult, error) {
+	return nil, nil
+}
+func (b *batchStubAssetClassifier) ClassifyTasksAssets([]*taskdomain.Task) ([]*ports.AssetClassificationResult, error) {
+	return b.batchResults, b.batchErr
+}
+
+func TestRunBatchLLMClassification_AttachesByTaskKey(t *testing.T) {
+	tasks := []*taskdomain.Task{{Key: "FN-1"}, {Key: "FN-2"}, {Key: "FN-3"}}
+	results := []*ports.ComprehensiveClassificationResult{
+		{Task: tasks[0]},
+		{Task: tasks[1]},
+		{Task: tasks[2]},
+	}
+
+	// Returns a result for FN-1 and FN-3 (FN-2 missing) plus a stray nil
+	// entry to prove the nil filter in the lookup loop is exercised.
+	chain := &ComprehensiveClassificationChainWithInheritance{
+		llmClassifier: &batchStubAssetClassifier{
+			batchResults: []*ports.AssetClassificationResult{
+				{Task: tasks[0], Asset: &assetdomain.Asset{Name: "Search"}},
+				nil,
+				{Task: tasks[2], Asset: &assetdomain.Asset{Name: "Payments"}},
+				{Task: nil, Asset: &assetdomain.Asset{Name: "Should be skipped"}},
+			},
+		},
+	}
+
+	chain.runBatchLLMClassification(tasks, results)
+	require.NotNil(t, results[0].LLMAsset)
+	assert.Equal(t, "Search", results[0].LLMAsset.Asset.Name)
+	assert.Nil(t, results[1].LLMAsset, "FN-2 has no LLM result so it stays nil")
+	require.NotNil(t, results[2].LLMAsset)
+	assert.Equal(t, "Payments", results[2].LLMAsset.Asset.Name)
+}
+
+func TestRunBatchLLMClassification_ErrorIsLoggedAndResultsUntouched(t *testing.T) {
+	tasks := []*taskdomain.Task{{Key: "FN-1"}}
+	results := []*ports.ComprehensiveClassificationResult{{Task: tasks[0]}}
+
+	chain := &ComprehensiveClassificationChainWithInheritance{
+		llmClassifier: &batchStubAssetClassifier{batchErr: errors.New("model busy")},
+	}
+	chain.runBatchLLMClassification(tasks, results)
+	assert.Nil(t, results[0].LLMAsset, "errored classifier must leave results untouched")
+}


### PR DESCRIPTION
## Summary

Three group-4 classifier helpers were sitting at 0% coverage. Bring them to 100%:

- runBatchLLMClassification — batch stub returns mixed valid/nil/no-task results to drive the lookup filter, plus an error-path test pinning that results stay untouched
- OllamaEmbeddingAdapter.Embed — httptest server feeding a real llama.Client, same pattern the llama package already uses
- NewEmbeddingAssetClassifierWithHistory — constructor field wiring + nil-map path

## Coverage

- All three functions: 0% → 100%
- Package internal/tasks/infrastructure/classifier: 91.6% → 92.8%

## Test plan

- [x] go test ./internal/tasks/infrastructure/classifier/