### PR TITLE
test(console): cover renderStructuredOutput and extract sweepExpired

### DIFF
--- a/internal/console/infrastructure/store/memory_store.go
+++ b/internal/console/infrastructure/store/memory_store.go
@@ -231,20 +231,26 @@ func (s *MemoryStore) copyContext(original *domain.Context) *domain.Context {
 	return contextCopy
 }
 
-// cleanupRoutine runs periodically to clean up expired sessions
+// cleanupRoutine runs periodically to clean up expired sessions.
 func (s *MemoryStore) cleanupRoutine() {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 
 	for range ticker.C {
-		s.mu.Lock()
-		now := time.Now()
-		for sessionID, sessionContext := range s.contexts {
-			if now.Sub(sessionContext.LastActivity) > s.sessionTTL {
-				delete(s.contexts, sessionID)
-			}
+		s.sweepExpired(time.Now())
+	}
+}
+
+// sweepExpired removes contexts older than sessionTTL. Extracted from
+// cleanupRoutine so the sweep logic is unit-testable without driving
+// a 5-minute ticker.
+func (s *MemoryStore) sweepExpired(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for sessionID, sessionContext := range s.contexts {
+		if now.Sub(sessionContext.LastActivity) > s.sessionTTL {
+			delete(s.contexts, sessionID)
 		}
-		s.mu.Unlock()
 	}
 }
 

--- a/internal/console/infrastructure/store/sweep_expired_test.go
+++ b/internal/console/infrastructure/store/sweep_expired_test.go
@@ -1,0 +1,47 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helmedeiros/digital-asset-capitalization/internal/console/domain"
+)
+
+// TestSweepExpired_DropsOnlyExpiredSessions drives the sweep helper
+// that backs cleanupRoutine. cleanupRoutine itself is a 5-minute
+// ticker loop and is impractical to drive end-to-end; the extracted
+// sweepExpired carries the same delete logic.
+func TestSweepExpired_DropsOnlyExpiredSessions(t *testing.T) {
+	store := NewMemoryStore(Config{MaxSessions: 10, SessionTTL: time.Minute})
+
+	fresh := domain.NewContext("fresh")
+	stale := domain.NewContext("stale")
+	require.NoError(t, store.Save(context.Background(), fresh))
+	require.NoError(t, store.Save(context.Background(), stale))
+
+	// Backdate the stale entry's LastActivity past the TTL. Save deep-
+	// copies, so reach into the stored copy directly.
+	store.mu.Lock()
+	store.contexts["stale"].LastActivity = time.Now().Add(-2 * time.Minute)
+	store.mu.Unlock()
+
+	store.sweepExpired(time.Now())
+
+	store.mu.RLock()
+	_, freshExists := store.contexts["fresh"]
+	_, staleExists := store.contexts["stale"]
+	store.mu.RUnlock()
+	assert.True(t, freshExists, "fresh session must survive")
+	assert.False(t, staleExists, "stale session must be swept")
+}
+
+func TestSweepExpired_NoEntriesIsNoop(t *testing.T) {
+	store := NewMemoryStore(Config{MaxSessions: 10, SessionTTL: time.Minute})
+	// Must not panic on an empty map.
+	store.sweepExpired(time.Now())
+	assert.Equal(t, 0, store.GetStats().TotalSessions)
+}

--- a/internal/console/infrastructure/ui/render_structured_output_test.go
+++ b/internal/console/infrastructure/ui/render_structured_output_test.go
@@ -1,0 +1,46 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderStructuredOutput_BlankLinesArePreserved(t *testing.T) {
+	ps := NewPromptSession(80)
+	got := ps.renderStructuredOutput("\n   \n")
+	// Two empty/whitespace-only lines plus a trailing empty split.
+	assert.Equal(t, "\n\n\n", got)
+}
+
+func TestRenderStructuredOutput_KeyValueLineIsColorized(t *testing.T) {
+	ps := NewPromptSession(80)
+	got := ps.renderStructuredOutput("name: AssetCap")
+	// Key gets the primary-color prefix; value goes through formatValue.
+	assert.Contains(t, got, "name:")
+	assert.Contains(t, got, "AssetCap")
+}
+
+func TestRenderStructuredOutput_PlainURLLineSkipsKeyValueSplit(t *testing.T) {
+	ps := NewPromptSession(80)
+	got := ps.renderStructuredOutput("http://example.invalid/page")
+	// Lines starting with http even when they contain a colon should
+	// NOT be split as key:value — they fall through to the plain
+	// regular-line branch.
+	assert.Contains(t, got, "http://example.invalid/page")
+}
+
+func TestRenderStructuredOutput_LineWithSingleColonOnlySplitsOnce(t *testing.T) {
+	ps := NewPromptSession(80)
+	got := ps.renderStructuredOutput("title: a:b:c")
+	// SplitN with n=2 must leave the rest intact under the value.
+	assert.Contains(t, got, "a:b:c")
+}
+
+func TestRenderStructuredOutput_LineWithoutColonGoesThroughRegularBranch(t *testing.T) {
+	ps := NewPromptSession(80)
+	got := ps.renderStructuredOutput("just a heading")
+	// The line is preserved with its trailing newline.
+	assert.True(t, strings.Contains(got, "just a heading"))
+}


### PR DESCRIPTION
## Summary

Two console helpers reach higher coverage:

- renderStructuredOutput in console/ui: 0% → 100%. Tests cover blank lines, key:value split (regular and http-skip), single-colon left-only split semantics, plain passthrough.
- cleanupRoutine in console/store: 33.3% → 75%. The remaining 25% is the 5-minute ticker loop itself, which is impractical to test. Extracted the sweep body into sweepExpired(now time.Time) so the delete logic is now unit-testable (100%).

## Coverage

- renderStructuredOutput: 0% → 100%
- sweepExpired (new): 100%
- Package internal/console/infrastructure/store: 83.2% → 88.1%
- Package internal/console/infrastructure/ui: 95.8% → 96.4%

## Test plan

- [x] go test ./internal/console/infrastructure/store/ ./internal/console/infrastructure/ui/