### PR TITLE
test: fill trivial branches across five small helpers

### DIFF
--- a/internal/assets/infrastructure/confluence/capitalize_first_test.go
+++ b/internal/assets/infrastructure/confluence/capitalize_first_test.go
@@ -6,12 +6,12 @@ func TestCapitalizeFirst(t *testing.T) {
 	cases := []struct {
 		in, want string
 	}{
-		{"", ""},                                       // previously-uncovered empty short-circuit
-		{"a", "A"},                                     // single character
-		{"hello", "Hello"},                             // ordinary word
-		{"Hello", "Hello"},                             // already capitalized
-		{" leading space", " leading space"},          // first byte is a space; ToUpper is identity
-		{"1number", "1number"},                         // first byte is a digit
+		{"", ""},                             // previously-uncovered empty short-circuit
+		{"a", "A"},                           // single character
+		{"hello", "Hello"},                   // ordinary word
+		{"Hello", "Hello"},                   // already capitalized
+		{" leading space", " leading space"}, // first byte is a space; ToUpper is identity
+		{"1number", "1number"},               // first byte is a digit
 	}
 	for _, c := range cases {
 		if got := capitalizeFirst(c.in); got != c.want {

--- a/internal/assets/infrastructure/confluence/capitalize_first_test.go
+++ b/internal/assets/infrastructure/confluence/capitalize_first_test.go
@@ -1,0 +1,21 @@
+package confluence
+
+import "testing"
+
+func TestCapitalizeFirst(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},                                       // previously-uncovered empty short-circuit
+		{"a", "A"},                                     // single character
+		{"hello", "Hello"},                             // ordinary word
+		{"Hello", "Hello"},                             // already capitalized
+		{" leading space", " leading space"},          // first byte is a space; ToUpper is identity
+		{"1number", "1number"},                         // first byte is a digit
+	}
+	for _, c := range cases {
+		if got := capitalizeFirst(c.in); got != c.want {
+			t.Errorf("capitalizeFirst(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/config/domain/min_int_test.go
+++ b/internal/config/domain/min_int_test.go
@@ -1,0 +1,17 @@
+package domain
+
+import "testing"
+
+// TestMinInt_BothBranches covers the b<=a branch that wasn't
+// exercised by the existing jira_config tests.
+func TestMinInt_BothBranches(t *testing.T) {
+	if got := minInt(1, 2); got != 1 {
+		t.Errorf("minInt(1,2) = %d, want 1", got)
+	}
+	if got := minInt(5, 3); got != 3 {
+		t.Errorf("minInt(5,3) = %d, want 3", got)
+	}
+	if got := minInt(7, 7); got != 7 {
+		t.Errorf("minInt(7,7) tie should pick b, got %d", got)
+	}
+}

--- a/internal/console/application/usecase/validate_command_invalid_test.go
+++ b/internal/console/application/usecase/validate_command_invalid_test.go
@@ -1,0 +1,32 @@
+package usecase
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helmedeiros/digital-asset-capitalization/internal/console/domain"
+)
+
+// TestExecuteCommandUseCase_ValidateCommand_DomainInvalidShortCircuits
+// covers the previously-untested branch where command.Validate() itself
+// fails (missing ID), so the executor is never reached.
+func TestExecuteCommandUseCase_ValidateCommand_DomainInvalidShortCircuits(t *testing.T) {
+	mockExecutor := new(MockCommandExecutor)
+	// Intentionally no .On("ValidateCommand") — the test asserts the
+	// short-circuit prevents that call.
+	useCase := NewExecuteCommandUseCase(mockExecutor)
+
+	// Missing ID makes Command.Validate() fail with "command ID is required".
+	err := useCase.ValidateCommand(&domain.Command{
+		SessionID:   "s",
+		Raw:         "x",
+		Interpreted: "y",
+		Confidence:  0.9,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid command")
+	assert.Contains(t, err.Error(), "command ID is required")
+	mockExecutor.AssertNotCalled(t, "ValidateCommand")
+}

--- a/internal/console/domain/add_recent_task_test.go
+++ b/internal/console/domain/add_recent_task_test.go
@@ -1,0 +1,32 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddRecentTask_MoveToFrontAndCapAtFive drives addRecentTask
+// through its three branches: insert when new, move-to-front when
+// already present, and drop-tail when the list exceeds five.
+// It's exercised via the public UpdateTaskContext entry point.
+func TestAddRecentTask_MoveToFrontAndCapAtFive(t *testing.T) {
+	ctx := NewContext("session-1")
+
+	for _, key := range []string{"T-1", "T-2", "T-3", "T-4", "T-5"} {
+		ctx.UpdateTaskContext(key, nil)
+	}
+	// Newest entries push older ones toward the tail.
+	require.Equal(t, []string{"T-5", "T-4", "T-3", "T-2", "T-1"}, ctx.RecentTasks)
+
+	// Re-mentioning T-3 moves it to the front, doesn't grow the list.
+	ctx.UpdateTaskContext("T-3", nil)
+	assert.Equal(t, []string{"T-3", "T-5", "T-4", "T-2", "T-1"}, ctx.RecentTasks)
+	assert.Len(t, ctx.RecentTasks, 5)
+
+	// A sixth fresh entry evicts the tail.
+	ctx.UpdateTaskContext("T-6", nil)
+	assert.Equal(t, []string{"T-6", "T-3", "T-5", "T-4", "T-2"}, ctx.RecentTasks)
+	assert.Len(t, ctx.RecentTasks, 5)
+}

--- a/internal/console/infrastructure/ui/table_format_value_test.go
+++ b/internal/console/infrastructure/ui/table_format_value_test.go
@@ -1,0 +1,30 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTable_formatValue covers both branches of the Table.formatValue
+// helper. The existing test suite only exercised the table tests that
+// went through the column-formatter path; the nil-formatter fallback
+// to DefaultFormatter wasn't reached directly.
+func TestTable_formatValue(t *testing.T) {
+	tbl := &Table{}
+
+	t.Run("with formatter delegates and ignores DefaultFormatter", func(t *testing.T) {
+		called := false
+		got := tbl.formatValue("raw", func(v interface{}) string {
+			called = true
+			return "shaped:" + v.(string)
+		})
+		assert.True(t, called, "formatter must be called when non-nil")
+		assert.Equal(t, "shaped:raw", got)
+	})
+
+	t.Run("without formatter falls back to DefaultFormatter", func(t *testing.T) {
+		// DefaultFormatter renders strings unchanged.
+		assert.Equal(t, "raw", tbl.formatValue("raw", nil))
+	})
+}


### PR DESCRIPTION
## Summary

Batched five tiny one-branch fills into one PR — each was small enough that opening five separate PRs would have been more overhead than value.

- `config/domain.minInt`: b<=a branch + tie
- `assets/infrastructure/confluence.capitalizeFirst`: empty-string short-circuit
- `console/infrastructure/ui.Table.formatValue`: nil-formatter fallback
- `console/domain.addRecentTask`: drove through UpdateTaskContext for insert-new / move-to-front / drop-tail
- `console/application/usecase.ExecuteCommandUseCase.ValidateCommand`: domain-invalid short-circuit

## Coverage

All five helpers move from 66.7%-71.4% to 100%.

## Test plan

- [x] go test against each touched package