### PR TITLE
refactor(cmd): extract version and completion into their own file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Build the binary
 build:
 	@echo "Building assetcap binary..."
-	@go build -o assetcap cmd/main.go cmd/console.go cmd/deployment_commands.go
+	@go build -o assetcap ./cmd/
 	@echo "✅ Built assetcap binary"
 
 # Build and run assetcap with arguments

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,6 @@ import (
 	investmentservice "github.com/helmedeiros/digital-asset-capitalization/internal/investment/application/service"
 	investmentdomain "github.com/helmedeiros/digital-asset-capitalization/internal/investment/domain"
 	investmentinfra "github.com/helmedeiros/digital-asset-capitalization/internal/investment/infrastructure"
-	"github.com/helmedeiros/digital-asset-capitalization/internal/shell/completion"
 	sprintapp "github.com/helmedeiros/digital-asset-capitalization/internal/sprint/application"
 	sprintusecase "github.com/helmedeiros/digital-asset-capitalization/internal/sprint/application/usecase"
 	sprintinfra "github.com/helmedeiros/digital-asset-capitalization/internal/sprint/infrastructure"
@@ -176,46 +175,8 @@ COMMANDS:
 For more information about a command:
    assetcap [command] --help`,
 		Commands: []*cli.Command{
-			{
-				Name:  "version",
-				Usage: "Show version information",
-				Action: func(_ *cli.Context) error {
-					fmt.Printf("AssetCap %s\n", version)
-					fmt.Printf("Commit: %s\n", commit)
-					fmt.Printf("Built: %s\n", date)
-					return nil
-				},
-			},
-			{
-				Name:  "completion",
-				Usage: "Generate shell completion scripts",
-				Subcommands: []*cli.Command{
-					{
-						Name:  "bash",
-						Usage: "Generate bash completion script",
-						Action: func(_ *cli.Context) error {
-							fmt.Println(completion.GetBashCompletion())
-							return nil
-						},
-					},
-					{
-						Name:  "zsh",
-						Usage: "Generate zsh completion script",
-						Action: func(_ *cli.Context) error {
-							fmt.Println(completion.GetZshCompletion())
-							return nil
-						},
-					},
-					{
-						Name:  "fish",
-						Usage: "Generate fish completion script",
-						Action: func(_ *cli.Context) error {
-							fmt.Println(completion.GetFishCompletion())
-							return nil
-						},
-					},
-				},
-			},
+			a.createVersionCommand(),
+			a.createCompletionCommand(),
 			{
 				Name:  "sprint",
 				Usage: "Manage sprint-related operations",

--- a/cmd/version_completion_commands.go
+++ b/cmd/version_completion_commands.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/helmedeiros/digital-asset-capitalization/internal/shell/completion"
+)
+
+// createVersionCommand builds the `version` CLI command.
+//
+// It's a method on *App for symmetry with the other createXxxCommands
+// helpers, even though version doesn't currently read App state — that
+// way future fields (build flags, env-reported channels, etc.) have a
+// natural home.
+func (a *App) createVersionCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "version",
+		Usage: "Show version information",
+		Action: func(_ *cli.Context) error {
+			fmt.Printf("AssetCap %s\n", version)
+			fmt.Printf("Commit: %s\n", commit)
+			fmt.Printf("Built: %s\n", date)
+			return nil
+		},
+	}
+}
+
+// createCompletionCommand builds the `completion` CLI command with its
+// per-shell subcommands.
+func (a *App) createCompletionCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "completion",
+		Usage: "Generate shell completion scripts",
+		Subcommands: []*cli.Command{
+			{
+				Name:  "bash",
+				Usage: "Generate bash completion script",
+				Action: func(_ *cli.Context) error {
+					fmt.Println(completion.GetBashCompletion())
+					return nil
+				},
+			},
+			{
+				Name:  "zsh",
+				Usage: "Generate zsh completion script",
+				Action: func(_ *cli.Context) error {
+					fmt.Println(completion.GetZshCompletion())
+					return nil
+				},
+			},
+			{
+				Name:  "fish",
+				Usage: "Generate fish completion script",
+				Action: func(_ *cli.Context) error {
+					fmt.Println(completion.GetFishCompletion())
+					return nil
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

First step of splitting the 3,374-line \`cmd/main.go\` into per-command files. Follows the existing \`createDeploymentCommands\` / \`createConsoleCommand\` pattern: each command group becomes a method on \`*App\` that returns a \`*cli.Command\`.

This PR takes only the smallest and safest commands (\`version\` and \`completion\`) to prove the seam works before touching the larger groups (assets, tasks, config, sprint, investment).

## Collateral fixes
- Makefile \`build\` target listed individual \`.go\` files instead of the package, so adding any new file silently broke \`make build\`. Use \`./cmd/\`.
- Removed now-unused \`completion\` import from \`cmd/main.go\`.

## Scientific validation
Captured byte-level baselines from main and diffed against the refactored binary:
- \`assetcap version\` ✅ identical
- \`assetcap completion bash\` ✅ identical
- \`assetcap completion zsh\` ✅ identical
- \`assetcap completion fish\` ✅ identical
- \`assetcap --help\` ✅ identical
- \`assetcap assets --help\` ✅ identical
- \`assetcap completion --help\` ✅ identical

Plus: \`go test ./...\` passes (3,759 tests), \`golangci-lint run\` reports 0 issues.

## Test plan
- [x] go build ./...
- [x] go test ./...
- [x] golangci-lint run
- [x] Byte-level diff of every touched command's output against main