### PR TITLE
test: enable t.Parallel() on domain and application unit tests

### DIFF
--- a/internal/assets/application/asset_service_test.go
+++ b/internal/assets/application/asset_service_test.go
@@ -204,6 +204,7 @@ func (m *MockAssetService) UpdateConfluencePage(_ context.Context, assetName str
 }
 
 func TestAssetService(t *testing.T) {
+	t.Parallel()
 	service := NewMockAssetService()
 
 	t.Run("CreateAsset", func(t *testing.T) {

--- a/internal/assets/application/enrich_asset_fields_test.go
+++ b/internal/assets/application/enrich_asset_fields_test.go
@@ -17,6 +17,7 @@ import (
 // covered the "description" branch, leaving why/benefits/how/metrics
 // unexecuted in both the read- and write-switch.
 func TestEnrichAsset_AllFieldBranches(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		field  string
 		seed   string
@@ -68,6 +69,7 @@ func TestEnrichAsset_AllFieldBranches(t *testing.T) {
 // TestEnrichAsset_LlamaErrorWraps drives the EnrichContent failure
 // branch — the asset is loaded successfully but the LLM call errors.
 func TestEnrichAsset_LlamaErrorWraps(t *testing.T) {
+	t.Parallel()
 	asset := &domain.Asset{ID: "id-1", Name: "Search", Description: "x", Version: 1}
 	mockRepo := new(MockAssetRepository)
 	mockLlama := new(MockLlamaClient)
@@ -87,6 +89,7 @@ func TestEnrichAsset_LlamaErrorWraps(t *testing.T) {
 // failure branch — the asset and enrichment succeed but persistence
 // fails.
 func TestEnrichAsset_SaveErrorPropagates(t *testing.T) {
+	t.Parallel()
 	asset := &domain.Asset{ID: "id-1", Name: "Search", Description: "x", Version: 1}
 	mockRepo := new(MockAssetRepository)
 	mockLlama := new(MockLlamaClient)

--- a/internal/assets/application/process_fetched_assets_test.go
+++ b/internal/assets/application/process_fetched_assets_test.go
@@ -23,6 +23,7 @@ func validAsset() *domain.Asset {
 }
 
 func TestProcessFetchedAssets_BucketsByValidation(t *testing.T) {
+	t.Parallel()
 	mockRepo := new(MockAssetRepository)
 	// First asset is valid and new.
 	good := validAsset()
@@ -46,6 +47,7 @@ func TestProcessFetchedAssets_BucketsByValidation(t *testing.T) {
 }
 
 func TestProcessFetchedAssets_PreservesLocalMetadata(t *testing.T) {
+	t.Parallel()
 	mockRepo := new(MockAssetRepository)
 	fresh := validAsset() // Keywords/teams empty, AssociatedTaskCount=0.
 
@@ -71,6 +73,7 @@ func TestProcessFetchedAssets_PreservesLocalMetadata(t *testing.T) {
 }
 
 func TestProcessFetchedAssets_DoesNotOverwriteFreshMetadata(t *testing.T) {
+	t.Parallel()
 	mockRepo := new(MockAssetRepository)
 	fresh := validAsset()
 	fresh.Keywords = []string{"fresh"}
@@ -102,6 +105,7 @@ func TestProcessFetchedAssets_DoesNotOverwriteFreshMetadata(t *testing.T) {
 }
 
 func TestProcessFetchedAssets_SaveErrorWrapsAssetName(t *testing.T) {
+	t.Parallel()
 	mockRepo := new(MockAssetRepository)
 	fresh := validAsset()
 	mockRepo.On("FindByID", "asset-1").Return(nil, errors.New("not found")).Once()
@@ -115,6 +119,7 @@ func TestProcessFetchedAssets_SaveErrorWrapsAssetName(t *testing.T) {
 }
 
 func TestNotSyncedFromAsset_CapturesAvailableFields(t *testing.T) {
+	t.Parallel()
 	asset := &domain.Asset{
 		ID:          "id-1",
 		Name:        "X",
@@ -136,6 +141,7 @@ func TestNotSyncedFromAsset_CapturesAvailableFields(t *testing.T) {
 }
 
 func TestMergeLocalMetadata_NilOrEmptyFieldsOnExistingAreIgnored(t *testing.T) {
+	t.Parallel()
 	fresh := validAsset()
 	fresh.Keywords = []string{"kept"}
 	existing := validAsset() // No keywords/teams on existing either.

--- a/internal/assets/application/team_helpers_test.go
+++ b/internal/assets/application/team_helpers_test.go
@@ -68,6 +68,7 @@ func teamConfigWithNicknames(t *testing.T) *configdomain.TeamConfig {
 }
 
 func TestAssetServiceImpl_getConfluenceParentPageForTeam(t *testing.T) {
+	t.Parallel()
 	t.Run("empty team name short-circuits to empty string", func(t *testing.T) {
 		s := &AssetServiceImpl{}
 		assert.Equal(t, "", s.getConfluenceParentPageForTeam(""))
@@ -104,6 +105,7 @@ func TestAssetServiceImpl_getConfluenceParentPageForTeam(t *testing.T) {
 }
 
 func TestAssetServiceImpl_resolveTeamIdentifier(t *testing.T) {
+	t.Parallel()
 	t.Run("nil configService returns the identifier unchanged", func(t *testing.T) {
 		s := &AssetServiceImpl{}
 		assert.Equal(t, "fortuna", s.resolveTeamIdentifier("fortuna"))
@@ -135,6 +137,7 @@ func TestAssetServiceImpl_resolveTeamIdentifier(t *testing.T) {
 }
 
 func TestAssetServiceImpl_getTribeAndCompanyForTeam(t *testing.T) {
+	t.Parallel()
 	// Pin the getTribeForTeam / getCompanyForTeam branches at the same
 	// time -- they're structurally identical to getConfluenceParentPageForTeam
 	// and the existing test surface already partly covers them, but the

--- a/internal/assets/application/usecase/assign_team_test.go
+++ b/internal/assets/application/usecase/assign_team_test.go
@@ -50,12 +50,14 @@ func (m *MockAssetRepositoryForTeams) Delete(name string) error {
 }
 
 func TestAssignTeamUseCase_NewAssignTeamUseCase(t *testing.T) {
+	t.Parallel()
 	mockRepo := &MockAssetRepositoryForTeams{}
 	useCase := NewAssignTeamUseCase(mockRepo)
 	assert.NotNil(t, useCase)
 }
 
 func TestAssignTeamUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	t.Run("should assign owning team to asset successfully", func(t *testing.T) {
 		mockRepo := &MockAssetRepositoryForTeams{}
 		useCase := NewAssignTeamUseCase(mockRepo)
@@ -188,12 +190,14 @@ func TestAssignTeamUseCase_Execute(t *testing.T) {
 }
 
 func TestGetAssetTeamsUseCase_NewGetAssetTeamsUseCase(t *testing.T) {
+	t.Parallel()
 	mockRepo := &MockAssetRepositoryForTeams{}
 	useCase := NewGetAssetTeamsUseCase(mockRepo)
 	assert.NotNil(t, useCase)
 }
 
 func TestGetAssetTeamsUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	t.Run("should return all asset teams", func(t *testing.T) {
 		mockRepo := &MockAssetRepositoryForTeams{}
 		useCase := NewGetAssetTeamsUseCase(mockRepo)
@@ -259,12 +263,14 @@ func TestGetAssetTeamsUseCase_Execute(t *testing.T) {
 }
 
 func TestGetAssetTeamInfoUseCase_NewGetAssetTeamInfoUseCase(t *testing.T) {
+	t.Parallel()
 	mockRepo := &MockAssetRepositoryForTeams{}
 	useCase := NewGetAssetTeamInfoUseCase(mockRepo)
 	assert.NotNil(t, useCase)
 }
 
 func TestGetAssetTeamInfoUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	t.Run("should return team info for specific asset", func(t *testing.T) {
 		mockRepo := &MockAssetRepositoryForTeams{}
 		useCase := NewGetAssetTeamInfoUseCase(mockRepo)
@@ -309,12 +315,14 @@ func TestGetAssetTeamInfoUseCase_Execute(t *testing.T) {
 }
 
 func TestAddContributingTeamUseCase_NewAddContributingTeamUseCase(t *testing.T) {
+	t.Parallel()
 	mockRepo := &MockAssetRepositoryForTeams{}
 	useCase := NewAddContributingTeamUseCase(mockRepo)
 	assert.NotNil(t, useCase)
 }
 
 func TestAddContributingTeamUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	t.Run("should add contributing team successfully", func(t *testing.T) {
 		mockRepo := &MockAssetRepositoryForTeams{}
 		useCase := NewAddContributingTeamUseCase(mockRepo)
@@ -382,12 +390,14 @@ func TestAddContributingTeamUseCase_Execute(t *testing.T) {
 }
 
 func TestRemoveContributingTeamUseCase_NewRemoveContributingTeamUseCase(t *testing.T) {
+	t.Parallel()
 	mockRepo := &MockAssetRepositoryForTeams{}
 	useCase := NewRemoveContributingTeamUseCase(mockRepo)
 	assert.NotNil(t, useCase)
 }
 
 func TestRemoveContributingTeamUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	t.Run("should remove contributing team successfully", func(t *testing.T) {
 		mockRepo := &MockAssetRepositoryForTeams{}
 		useCase := NewRemoveContributingTeamUseCase(mockRepo)
@@ -459,6 +469,7 @@ func TestRemoveContributingTeamUseCase_Execute(t *testing.T) {
 }
 
 func TestParseTeamsInput(t *testing.T) {
+	t.Parallel()
 	t.Run("should parse comma-separated teams", func(t *testing.T) {
 		input := "team-alpha,team-beta,team-gamma"
 		teams := ParseTeamsInput(input)

--- a/internal/assets/application/usecase/bulk_enrich_fields_test.go
+++ b/internal/assets/application/usecase/bulk_enrich_fields_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestBulkEnrichFieldsUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		input          BulkEnrichFieldsInput

--- a/internal/assets/application/usecase/bulk_enrich_keywords_test.go
+++ b/internal/assets/application/usecase/bulk_enrich_keywords_test.go
@@ -67,6 +67,7 @@ func (m *TestMockLlamaClient) Close() error {
 }
 
 func TestBulkEnrichKeywordsUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		input          BulkEnrichKeywordsInput

--- a/internal/assets/application/usecase/create_asset_test.go
+++ b/internal/assets/application/usecase/create_asset_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestCreateAssetUseCase(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		assetName   string

--- a/internal/assets/application/usecase/decrement_task_count_test.go
+++ b/internal/assets/application/usecase/decrement_task_count_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestDecrementTaskCountUseCase(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		assetName string

--- a/internal/assets/application/usecase/delete_asset_test.go
+++ b/internal/assets/application/usecase/delete_asset_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestDeleteAssetUseCase(t *testing.T) {
+	t.Parallel()
 	// Create a mock repository
 	mockRepo := testutil.NewMockAssetRepository()
 	useCase := NewDeleteAssetUseCase(mockRepo)

--- a/internal/assets/application/usecase/get_asset_test.go
+++ b/internal/assets/application/usecase/get_asset_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestGetAssetUseCase(t *testing.T) {
+	t.Parallel()
 	// Create a mock repository
 	mockRepo := testutil.NewMockAssetRepository()
 	useCase := NewGetAssetUseCase(mockRepo)

--- a/internal/assets/application/usecase/increment_task_count_test.go
+++ b/internal/assets/application/usecase/increment_task_count_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestIncrementTaskCountUseCase(t *testing.T) {
+	t.Parallel()
 	// Create a mock repository
 	mockRepo := testutil.NewMockAssetRepository()
 	useCase := NewIncrementTaskCountUseCase(mockRepo)

--- a/internal/assets/application/usecase/list_assets_test.go
+++ b/internal/assets/application/usecase/list_assets_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestListAssetsUseCase(t *testing.T) {
+	t.Parallel()
 	// Create a mock repository
 	mockRepo := testutil.NewMockAssetRepository()
 	useCase := NewListAssetsUseCase(mockRepo)

--- a/internal/assets/application/usecase/publish_to_confluence_test.go
+++ b/internal/assets/application/usecase/publish_to_confluence_test.go
@@ -91,6 +91,7 @@ func (m *MockIDGenerator) GenerateID(name string) string {
 }
 
 func TestPublishToConfluenceUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	launchDate := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
 
@@ -356,6 +357,7 @@ func TestPublishToConfluenceUseCase_Execute(t *testing.T) {
 }
 
 func TestPublishToConfluenceUseCase_getAssetLabel(t *testing.T) {
+	t.Parallel()
 	mockIDGen := new(MockIDGenerator)
 	useCase := &PublishToConfluenceUseCase{
 		idGenerator: mockIDGen,

--- a/internal/assets/application/usecase/sync_and_enrich_test.go
+++ b/internal/assets/application/usecase/sync_and_enrich_test.go
@@ -26,6 +26,7 @@ func (m *MockAssetService) SyncFromConfluence(spaceKey, label string, debug bool
 }
 
 func TestSyncAndEnrichUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		input          SyncAndEnrichInput
@@ -216,6 +217,7 @@ func TestSyncAndEnrichUseCase_Execute(t *testing.T) {
 }
 
 func TestSyncAndEnrichUseCase_generateSummary(t *testing.T) {
+	t.Parallel()
 	useCase := &SyncAndEnrichUseCase{}
 
 	tests := []struct {

--- a/internal/assets/application/usecase/sync_contributors_from_jira_test.go
+++ b/internal/assets/application/usecase/sync_contributors_from_jira_test.go
@@ -84,6 +84,7 @@ func (m *MockAssetRepository) Delete(name string) error {
 }
 
 func TestSyncAssetContributorsFromJiraUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		input          SyncContributorsInput
@@ -306,6 +307,7 @@ func TestSyncAssetContributorsFromJiraUseCase_Execute(t *testing.T) {
 }
 
 func TestSyncAssetContributorsFromJiraUseCase_ExtractAssetNameFromLabel(t *testing.T) {
+	t.Parallel()
 	uc := &SyncAssetContributorsFromJiraUseCase{}
 
 	tests := []struct {
@@ -327,6 +329,7 @@ func TestSyncAssetContributorsFromJiraUseCase_ExtractAssetNameFromLabel(t *testi
 }
 
 func TestSyncAssetContributorsFromJiraUseCase_GroupTasksByAsset(t *testing.T) {
+	t.Parallel()
 	uc := &SyncAssetContributorsFromJiraUseCase{}
 
 	tasks := []JiraTaskInfo{
@@ -354,6 +357,7 @@ func TestSyncAssetContributorsFromJiraUseCase_GroupTasksByAsset(t *testing.T) {
 }
 
 func TestSyncAssetContributorsFromJiraUseCase_ExtractTeamsFromTasks(t *testing.T) {
+	t.Parallel()
 	mockTeam := new(MockTeamConfigPort)
 	uc := &SyncAssetContributorsFromJiraUseCase{
 		teamConfig: mockTeam,
@@ -386,6 +390,7 @@ func TestSyncAssetContributorsFromJiraUseCase_ExtractTeamsFromTasks(t *testing.T
 }
 
 func TestSyncAssetContributorsFromJiraUseCase_FindNewAndRemovedTeams(t *testing.T) {
+	t.Parallel()
 	uc := &SyncAssetContributorsFromJiraUseCase{}
 
 	current := []string{"TeamA", "TeamB"}
@@ -399,6 +404,7 @@ func TestSyncAssetContributorsFromJiraUseCase_FindNewAndRemovedTeams(t *testing.
 }
 
 func TestSyncAssetContributorsFromJiraUseCase_MergeTeams(t *testing.T) {
+	t.Parallel()
 	uc := &SyncAssetContributorsFromJiraUseCase{}
 
 	foundTeams := []string{"TeamA", "TeamB", "OwningTeam", "TeamC"}
@@ -414,6 +420,7 @@ func TestSyncAssetContributorsFromJiraUseCase_MergeTeams(t *testing.T) {
 }
 
 func TestSyncAssetContributorsFromJiraUseCase_ConvertLabelToAssetName(t *testing.T) {
+	t.Parallel()
 	uc := &SyncAssetContributorsFromJiraUseCase{}
 
 	tests := []struct {
@@ -462,6 +469,7 @@ func TestSyncAssetContributorsFromJiraUseCase_ConvertLabelToAssetName(t *testing
 }
 
 func TestSyncAssetContributorsFromJiraUseCase_ProcessAssetContributors(t *testing.T) {
+	t.Parallel()
 	t.Run("should process asset contributors successfully", func(t *testing.T) {
 		mockAsset := new(MockAssetRepository)
 		mockTeam := new(MockTeamConfigPort)

--- a/internal/assets/application/usecase/update_asset_test.go
+++ b/internal/assets/application/usecase/update_asset_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestUpdateAssetUseCase(t *testing.T) {
+	t.Parallel()
 	// Create a mock repository
 	mockRepo := testutil.NewMockAssetRepository()
 	useCase := NewUpdateAssetUseCase(mockRepo)

--- a/internal/assets/application/usecase/update_documentation_test.go
+++ b/internal/assets/application/usecase/update_documentation_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestUpdateDocumentationUseCase(t *testing.T) {
+	t.Parallel()
 	// Create a mock repository
 	mockRepo := testutil.NewMockAssetRepository()
 	useCase := NewUpdateDocumentationUseCase(mockRepo)

--- a/internal/assets/domain/asset_test.go
+++ b/internal/assets/domain/asset_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestNewAsset(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		assetName   string
@@ -81,6 +82,7 @@ func TestNewAsset(t *testing.T) {
 }
 
 func TestNewAssetDefaultStatus(t *testing.T) {
+	t.Parallel()
 	t.Run("NewAsset sets Planning status", func(t *testing.T) {
 		asset, err := NewAsset("test-asset", "Test description")
 		require.NoError(t, err)
@@ -97,6 +99,7 @@ func TestNewAssetDefaultStatus(t *testing.T) {
 }
 
 func TestUpdateDescription(t *testing.T) {
+	t.Parallel()
 	asset, err := NewAsset("test-asset", "Initial description")
 	require.NoError(t, err)
 
@@ -137,6 +140,7 @@ func TestUpdateDescription(t *testing.T) {
 }
 
 func TestUpdateDocumentation(t *testing.T) {
+	t.Parallel()
 	asset, err := NewAsset("test-asset", "Test description")
 	require.NoError(t, err)
 
@@ -153,6 +157,7 @@ func TestUpdateDocumentation(t *testing.T) {
 }
 
 func TestTaskCountOperations(t *testing.T) {
+	t.Parallel()
 	asset, err := NewAsset("test-asset", "Test description")
 	require.NoError(t, err)
 
@@ -173,6 +178,7 @@ func TestTaskCountOperations(t *testing.T) {
 }
 
 func TestGenerateID(t *testing.T) {
+	t.Parallel()
 	// Test that IDs follow cap-asset-* format
 	id1 := generateID("test-asset")
 	assert.Equal(t, "cap-asset-test-asset", id1, "Expected cap-asset-* format")
@@ -195,6 +201,7 @@ func TestGenerateID(t *testing.T) {
 }
 
 func TestDateStarted(t *testing.T) {
+	t.Parallel()
 	asset, err := NewAsset("test-asset", "Test description")
 	require.NoError(t, err)
 
@@ -211,6 +218,7 @@ func TestDateStarted(t *testing.T) {
 }
 
 func TestAsset_GetTaskCount(t *testing.T) {
+	t.Parallel()
 	asset, err := NewAsset("Test Asset", "Test Description")
 	require.NoError(t, err)
 
@@ -275,6 +283,7 @@ func TestAsset_GetTaskCount(t *testing.T) {
 }
 
 func TestAsset_GetVersion(t *testing.T) {
+	t.Parallel()
 	asset, err := NewAsset("Test Asset", "Test Description")
 	require.NoError(t, err)
 
@@ -329,6 +338,7 @@ func TestAsset_GetVersion(t *testing.T) {
 }
 
 func TestAsset_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	t.Run("should unmarshal valid JSON correctly", func(t *testing.T) {
 		jsonData := `{
 			"id": "test-id-123",
@@ -439,6 +449,7 @@ func TestAsset_UnmarshalJSON(t *testing.T) {
 }
 
 func TestNewAsset_ErrorBranches(t *testing.T) {
+	t.Parallel()
 	_, err := NewAsset("", "desc")
 	if err == nil || err != ErrEmptyName {
 		t.Errorf("expected ErrEmptyName, got %v", err)
@@ -450,6 +461,7 @@ func TestNewAsset_ErrorBranches(t *testing.T) {
 }
 
 func TestAsset_DecrementTaskCount_ErrorBranch(t *testing.T) {
+	t.Parallel()
 	asset, err := NewAsset("name", "desc")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -462,6 +474,7 @@ func TestAsset_DecrementTaskCount_ErrorBranch(t *testing.T) {
 }
 
 func TestAsset_TeamManagement(t *testing.T) {
+	t.Parallel()
 	asset, err := NewAsset("test-asset", "Test description")
 	require.NoError(t, err)
 
@@ -609,6 +622,7 @@ func TestAsset_TeamManagement(t *testing.T) {
 }
 
 func TestAsset_GetID(t *testing.T) {
+	t.Parallel()
 	asset, err := NewAsset("Payment Gateway", "Processes payments")
 	require.NoError(t, err)
 	// GetID exists specifically because the mutex-protected accessor
@@ -619,6 +633,7 @@ func TestAsset_GetID(t *testing.T) {
 }
 
 func TestValidateAssetID(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name    string
 		id      string
@@ -647,6 +662,7 @@ func TestValidateAssetID(t *testing.T) {
 }
 
 func TestIsValidAssetID(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		id   string
 		want bool

--- a/internal/assets/domain/ports/ports_test.go
+++ b/internal/assets/domain/ports/ports_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestBulkEnrichmentResult_Methods(t *testing.T) {
+	t.Parallel()
 	result := NewBulkEnrichmentResult()
 
 	// Test initial state
@@ -68,6 +69,7 @@ func TestInterfaceContracts(_ *testing.T) {
 }
 
 func TestBulkEnrichmentInput(t *testing.T) {
+	t.Parallel()
 	input := BulkEnrichmentInput{
 		AssetNames:    []string{"asset1", "asset2"},
 		FilterBy:      "test-filter",
@@ -89,6 +91,7 @@ func TestBulkEnrichmentInput(t *testing.T) {
 }
 
 func TestDummyImplementations(t *testing.T) {
+	t.Parallel()
 	// Test dummy implementations don't panic and return expected values
 	keywordsService := &dummyKeywordsService{}
 	keywords, err := keywordsService.GenerateKeywords(context.Background(), &domain.Asset{})

--- a/internal/assets/domain/sync_result_test.go
+++ b/internal/assets/domain/sync_result_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestNewSyncResult(t *testing.T) {
+	t.Parallel()
 	t.Run("should create valid SyncResult", func(t *testing.T) {
 		result := NewSyncResult()
 

--- a/internal/config/application/service/config_service_test.go
+++ b/internal/config/application/service/config_service_test.go
@@ -54,6 +54,7 @@ func (m *MockConfigurationRepository) InitializeConfigDirectory() error {
 }
 
 func TestNewConfigService(t *testing.T) {
+	t.Parallel()
 	repo := &MockConfigurationRepository{}
 	service := NewConfigService(repo)
 
@@ -62,6 +63,7 @@ func TestNewConfigService(t *testing.T) {
 }
 
 func TestConfigService_GetJiraConfig(t *testing.T) {
+	t.Parallel()
 	t.Run("should return jira config successfully", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -98,6 +100,7 @@ func TestConfigService_GetJiraConfig(t *testing.T) {
 }
 
 func TestConfigService_GetTeamConfig(t *testing.T) {
+	t.Parallel()
 	t.Run("should return team config successfully", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -134,6 +137,7 @@ func TestConfigService_GetTeamConfig(t *testing.T) {
 }
 
 func TestConfigService_GetTeamMapForSprint(t *testing.T) {
+	t.Parallel()
 	t.Run("should convert team config to sprint format successfully", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -229,6 +233,7 @@ func TestConfigService_GetTeamMapForSprint(t *testing.T) {
 }
 
 func TestConfigService_GetTeamForProject(t *testing.T) {
+	t.Parallel()
 	t.Run("should return team members for existing project", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -271,6 +276,7 @@ func TestConfigService_GetTeamForProject(t *testing.T) {
 }
 
 func TestConfigService_IsTeamMember(t *testing.T) {
+	t.Parallel()
 	t.Run("should return true for existing team member", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -330,6 +336,7 @@ func TestConfigService_IsTeamMember(t *testing.T) {
 }
 
 func TestConfigService_ConfigExists(t *testing.T) {
+	t.Parallel()
 	t.Run("should return true when config exists", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -358,6 +365,7 @@ func TestConfigService_ConfigExists(t *testing.T) {
 }
 
 func TestConfigService_InitializeConfigDirectory(t *testing.T) {
+	t.Parallel()
 	t.Run("should initialize directory successfully", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -385,6 +393,7 @@ func TestConfigService_InitializeConfigDirectory(t *testing.T) {
 }
 
 func TestConfigService_SetTribeForProject(t *testing.T) {
+	t.Parallel()
 	t.Run("should set tribe for existing project successfully", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -458,6 +467,7 @@ func TestConfigService_SetTribeForProject(t *testing.T) {
 }
 
 func TestConfigService_GetTribeForProject(t *testing.T) {
+	t.Parallel()
 	t.Run("should return tribe for project with tribe set", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -516,6 +526,7 @@ func TestConfigService_GetTribeForProject(t *testing.T) {
 }
 
 func TestConfigService_SetCompanyForProject(t *testing.T) {
+	t.Parallel()
 	t.Run("should set company for existing project successfully", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -589,6 +600,7 @@ func TestConfigService_SetCompanyForProject(t *testing.T) {
 }
 
 func TestConfigService_GetCompanyForProject(t *testing.T) {
+	t.Parallel()
 	t.Run("should return company for project with company set", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -648,6 +660,7 @@ func TestConfigService_GetCompanyForProject(t *testing.T) {
 }
 
 func TestConfigService_SetExcludedIssueTypesForProject(t *testing.T) {
+	t.Parallel()
 	t.Run("should set excluded issue types successfully", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		svc := NewConfigService(repo)
@@ -715,6 +728,7 @@ func TestConfigService_SetExcludedIssueTypesForProject(t *testing.T) {
 }
 
 func TestConfigService_GetExcludedIssueTypesForProject(t *testing.T) {
+	t.Parallel()
 	t.Run("should return excluded types for project", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		svc := NewConfigService(repo)
@@ -766,6 +780,7 @@ func TestConfigService_GetExcludedIssueTypesForProject(t *testing.T) {
 }
 
 func TestConfigService_GetTeamMapForSprintWithDates(t *testing.T) {
+	t.Parallel()
 	date := func(year int, month time.Month, day int) time.Time {
 		return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 	}
@@ -854,6 +869,7 @@ func TestConfigService_GetTeamMapForSprintWithDates(t *testing.T) {
 }
 
 func TestConfigService_GetBoardWorkStream(t *testing.T) {
+	t.Parallel()
 	t.Run("returns workstream for known board", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -894,6 +910,7 @@ func TestConfigService_GetBoardWorkStream(t *testing.T) {
 }
 
 func TestConfigService_GetBoardsForWorkStream(t *testing.T) {
+	t.Parallel()
 	t.Run("returns matching boards (case-insensitive)", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -926,6 +943,7 @@ func TestConfigService_GetBoardsForWorkStream(t *testing.T) {
 }
 
 func TestConfigService_SetBoardWorkStreams(t *testing.T) {
+	t.Parallel()
 	t.Run("happy path saves through to repository", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)
@@ -978,6 +996,7 @@ func TestConfigService_SetBoardWorkStreams(t *testing.T) {
 }
 
 func TestConfigService_SetBoardWorkStream(t *testing.T) {
+	t.Parallel()
 	t.Run("creates a new mapping if none exists", func(t *testing.T) {
 		repo := &MockConfigurationRepository{}
 		service := NewConfigService(repo)

--- a/internal/config/application/team_resolver_service_test.go
+++ b/internal/config/application/team_resolver_service_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestTeamResolverService_ResolveProjectIdentifier(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"Alice", "Bob"},
 		"AD": {"Carol", "Dave"},
@@ -75,6 +76,7 @@ func TestTeamResolverService_ResolveProjectIdentifier(t *testing.T) {
 }
 
 func TestTeamResolverService_ResolveMultipleIdentifiers(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"Alice", "Bob"},
 		"AD": {"Carol", "Dave"},
@@ -134,6 +136,7 @@ func TestTeamResolverService_ResolveMultipleIdentifiers(t *testing.T) {
 }
 
 func TestTeamResolverService_GetProjectWithNicknames(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"Alice", "Bob"},
 		"AD": {"Carol", "Dave"},
@@ -179,6 +182,7 @@ func TestTeamResolverService_GetProjectWithNicknames(t *testing.T) {
 }
 
 func TestTeamResolverService_GetAllMappings(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"Alice", "Bob"},
 		"AD": {"Carol", "Dave"},
@@ -204,6 +208,7 @@ func TestTeamResolverService_GetAllMappings(t *testing.T) {
 }
 
 func TestTeamResolverService_UpdateTeamConfig(t *testing.T) {
+	t.Parallel()
 	// Create initial config
 	teams1 := map[string][]string{
 		"FN": {"Alice", "Bob"},

--- a/internal/config/application/usecase/initialize_config_test.go
+++ b/internal/config/application/usecase/initialize_config_test.go
@@ -149,6 +149,7 @@ func (m *MockUserInteraction) DisplayWarning(message string) {
 }
 
 func TestNewInitializeConfig(t *testing.T) {
+	t.Parallel()
 	repo := &MockConfigurationRepository{}
 	envProvider := &MockEnvironmentProvider{}
 	ui := &MockUserInteraction{}
@@ -162,6 +163,7 @@ func TestNewInitializeConfig(t *testing.T) {
 }
 
 func TestInitializeConfig_Execute(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		setupMocks     func(*MockConfigurationRepository, *MockEnvironmentProvider, *MockUserInteraction)

--- a/internal/config/application/usecase/sync_team_from_jira_extra_test.go
+++ b/internal/config/application/usecase/sync_team_from_jira_extra_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestSyncTeamFromJira_Execute_InvalidProjectTeamDataAddsValidationError(t *testing.T) {
+	t.Parallel()
 	mockTeamSyncPort := &MockTeamSyncPort{}
 	mockConfigRepo := &MockConfigurationRepository{}
 
@@ -39,6 +40,7 @@ func TestSyncTeamFromJira_Execute_InvalidProjectTeamDataAddsValidationError(t *t
 }
 
 func TestSyncTeamFromJira_Execute_TimelineMaintenanceAddsAndRemovesMembers(t *testing.T) {
+	t.Parallel()
 	mockTeamSyncPort := &MockTeamSyncPort{}
 	mockConfigRepo := &MockConfigurationRepository{}
 

--- a/internal/config/application/usecase/sync_team_from_jira_test.go
+++ b/internal/config/application/usecase/sync_team_from_jira_test.go
@@ -34,6 +34,7 @@ func (m *MockTeamSyncPort) GetAssignableUsers(projectKey string) ([]domain.TeamM
 }
 
 func TestNewSyncTeamFromJira(t *testing.T) {
+	t.Parallel()
 	mockTeamSyncPort := &MockTeamSyncPort{}
 	mockConfigRepo := &MockConfigurationRepository{}
 
@@ -45,6 +46,7 @@ func TestNewSyncTeamFromJira(t *testing.T) {
 }
 
 func TestSyncTeamFromJira_Execute_EmptyProjectKey(t *testing.T) {
+	t.Parallel()
 	mockTeamSyncPort := &MockTeamSyncPort{}
 	mockConfigRepo := &MockConfigurationRepository{}
 	useCase := NewSyncTeamFromJira(mockTeamSyncPort, mockConfigRepo)
@@ -57,6 +59,7 @@ func TestSyncTeamFromJira_Execute_EmptyProjectKey(t *testing.T) {
 }
 
 func TestSyncTeamFromJira_Execute_SuccessfulSync(t *testing.T) {
+	t.Parallel()
 	// Setup mocks
 	mockTeamSyncPort := &MockTeamSyncPort{}
 	mockConfigRepo := &MockConfigurationRepository{}
@@ -104,6 +107,7 @@ func TestSyncTeamFromJira_Execute_SuccessfulSync(t *testing.T) {
 }
 
 func TestSyncTeamFromJira_Execute_NoExistingConfig(t *testing.T) {
+	t.Parallel()
 	// Setup mocks
 	mockTeamSyncPort := &MockTeamSyncPort{}
 	mockConfigRepo := &MockConfigurationRepository{}
@@ -141,6 +145,7 @@ func TestSyncTeamFromJira_Execute_NoExistingConfig(t *testing.T) {
 }
 
 func TestSyncTeamFromJira_Execute_JiraError(t *testing.T) {
+	t.Parallel()
 	// Setup mocks
 	mockTeamSyncPort := &MockTeamSyncPort{}
 	mockConfigRepo := &MockConfigurationRepository{}
@@ -167,6 +172,7 @@ func TestSyncTeamFromJira_Execute_JiraError(t *testing.T) {
 }
 
 func TestSyncTeamFromJira_Execute_SaveConfigError(t *testing.T) {
+	t.Parallel()
 	// Setup mocks
 	mockTeamSyncPort := &MockTeamSyncPort{}
 	mockConfigRepo := &MockConfigurationRepository{}
@@ -201,6 +207,7 @@ func TestSyncTeamFromJira_Execute_SaveConfigError(t *testing.T) {
 }
 
 func TestFindAddedMembers(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		currentMembers []string
@@ -236,6 +243,7 @@ func TestFindAddedMembers(t *testing.T) {
 }
 
 func TestFindRemovedMembers(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		currentMembers []string

--- a/internal/config/domain/jira_config_test.go
+++ b/internal/config/domain/jira_config_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestNewJiraConfig(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		baseURL string
@@ -85,6 +86,7 @@ func TestNewJiraConfig(t *testing.T) {
 }
 
 func TestJiraConfig_IsValid(t *testing.T) {
+	t.Parallel()
 	validConfig, err := NewJiraConfig("https://company.atlassian.net", "user@company.com", "token-123")
 	require.NoError(t, err)
 
@@ -92,6 +94,7 @@ func TestJiraConfig_IsValid(t *testing.T) {
 }
 
 func TestJiraConfig_AuthHeader(t *testing.T) {
+	t.Parallel()
 	config, err := NewJiraConfig("https://company.atlassian.net", "user@company.com", "token-123")
 	require.NoError(t, err)
 
@@ -101,6 +104,7 @@ func TestJiraConfig_AuthHeader(t *testing.T) {
 }
 
 func TestJiraConfig_String(t *testing.T) {
+	t.Parallel()
 	config, err := NewJiraConfig("https://company.atlassian.net", "user@company.com", "token-123")
 	require.NoError(t, err)
 

--- a/internal/config/domain/min_int_test.go
+++ b/internal/config/domain/min_int_test.go
@@ -5,6 +5,7 @@ import "testing"
 // TestMinInt_BothBranches covers the b<=a branch that wasn't
 // exercised by the existing jira_config tests.
 func TestMinInt_BothBranches(t *testing.T) {
+	t.Parallel()
 	if got := minInt(1, 2); got != 1 {
 		t.Errorf("minInt(1,2) = %d, want 1", got)
 	}

--- a/internal/config/domain/team_config_coverage_test.go
+++ b/internal/config/domain/team_config_coverage_test.go
@@ -26,6 +26,7 @@ func baseTeams() map[string][]string {
 }
 
 func TestNewTeamConfigComplete(t *testing.T) {
+	t.Parallel()
 	t.Run("threads confluence maps through to the underlying config", func(t *testing.T) {
 		tc, err := NewTeamConfigComplete(
 			baseTeams(),
@@ -66,6 +67,7 @@ func TestNewTeamConfigComplete(t *testing.T) {
 }
 
 func TestNewTeamConfigWithExcludedTypes_ExcludedTypesBranch(t *testing.T) {
+	t.Parallel()
 	tc, err := NewTeamConfigWithExcludedTypes(
 		baseTeams(),
 		nil, nil, nil, nil, nil,
@@ -81,6 +83,7 @@ func TestNewTeamConfigWithExcludedTypes_ExcludedTypesBranch(t *testing.T) {
 }
 
 func TestTeamConfig_Confluence_GettersAndSetters(t *testing.T) {
+	t.Parallel()
 	t.Run("setters reject empty project key", func(t *testing.T) {
 		tc, err := NewTeamConfig(baseTeams())
 		require.NoError(t, err)
@@ -107,6 +110,7 @@ func TestTeamConfig_Confluence_GettersAndSetters(t *testing.T) {
 }
 
 func TestNewTeamConfigWithBoardWorkStreams(t *testing.T) {
+	t.Parallel()
 	tc, err := NewTeamConfigWithBoardWorkStreams(
 		baseTeams(),
 		nil, nil, nil, nil, nil, nil,
@@ -127,6 +131,7 @@ func TestNewTeamConfigWithBoardWorkStreams(t *testing.T) {
 }
 
 func TestTeamConfig_BoardWorkStream_GettersAndSetters(t *testing.T) {
+	t.Parallel()
 	tc, err := NewTeamConfig(baseTeams())
 	require.NoError(t, err)
 
@@ -159,6 +164,7 @@ func TestTeamConfig_BoardWorkStream_GettersAndSetters(t *testing.T) {
 }
 
 func TestTeamConfig_TeamTimeline_SetAndQuery(t *testing.T) {
+	t.Parallel()
 	tc, err := NewTeamConfig(baseTeams())
 	require.NoError(t, err)
 
@@ -186,6 +192,7 @@ func TestTeamConfig_TeamTimeline_SetAndQuery(t *testing.T) {
 }
 
 func TestTeamConfig_ToCompleteMapWithBoardWorkStreams_DeepCopy(t *testing.T) {
+	t.Parallel()
 	tc, err := NewTeamConfigWithBoardWorkStreams(
 		baseTeams(),
 		nil, nil, nil, nil, nil, nil,
@@ -200,6 +207,7 @@ func TestTeamConfig_ToCompleteMapWithBoardWorkStreams_DeepCopy(t *testing.T) {
 }
 
 func TestProjectTeamData_Validate(t *testing.T) {
+	t.Parallel()
 	t.Run("missing project key", func(t *testing.T) {
 		err := (&ProjectTeamData{Members: []TeamMember{{DisplayName: "Alice"}}}).Validate()
 		require.Error(t, err)

--- a/internal/config/domain/team_config_test.go
+++ b/internal/config/domain/team_config_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestNewTeamConfig(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		teams   map[string][]string
@@ -86,6 +87,7 @@ func TestNewTeamConfig(t *testing.T) {
 }
 
 func TestTeamConfig_GetTeam(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"helio.medeiros", "julio.medeiros"},
 		"MZ": {"alice.smith", "bob.jones"},
@@ -108,6 +110,7 @@ func TestTeamConfig_GetTeam(t *testing.T) {
 }
 
 func TestTeamConfig_GetProjects(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"helio.medeiros", "julio.medeiros"},
 		"MZ": {"alice.smith", "bob.jones"},
@@ -123,6 +126,7 @@ func TestTeamConfig_GetProjects(t *testing.T) {
 }
 
 func TestTeamConfig_IsTeamMember(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"helio.medeiros", "julio.medeiros"},
 		"MZ": {"alice.smith", "bob.jones"},
@@ -147,6 +151,7 @@ func TestTeamConfig_IsTeamMember(t *testing.T) {
 }
 
 func TestTeamConfig_AddTeamMember(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"helio.medeiros"},
 	}
@@ -192,6 +197,7 @@ func TestTeamConfig_AddTeamMember(t *testing.T) {
 }
 
 func TestTeamConfig_RemoveTeamMember(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"helio.medeiros", "julio.medeiros"},
 	}
@@ -223,6 +229,7 @@ func TestTeamConfig_RemoveTeamMember(t *testing.T) {
 }
 
 func TestTeamConfig_IsEmpty(t *testing.T) {
+	t.Parallel()
 	t.Run("empty config", func(t *testing.T) {
 		config, err := NewTeamConfig(map[string][]string{})
 		require.NoError(t, err)
@@ -240,6 +247,7 @@ func TestTeamConfig_IsEmpty(t *testing.T) {
 }
 
 func TestTeamConfig_ToMap(t *testing.T) {
+	t.Parallel()
 	t.Run("should return empty map for empty config", func(t *testing.T) {
 		config, err := NewTeamConfig(map[string][]string{})
 		require.NoError(t, err)
@@ -352,6 +360,7 @@ func TestTeamConfig_ToMap(t *testing.T) {
 }
 
 func TestTeamConfig_SetTeam(t *testing.T) {
+	t.Parallel()
 	config, err := NewTeamConfig(map[string][]string{})
 	require.NoError(t, err)
 
@@ -416,6 +425,7 @@ func TestTeamConfig_SetTeam(t *testing.T) {
 // Tests for nickname functionality
 
 func TestNewTeamConfigWithNicknames(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		teams     map[string][]string
@@ -485,6 +495,7 @@ func TestNewTeamConfigWithNicknames(t *testing.T) {
 }
 
 func TestTeamConfig_ResolveTeamIdentifier(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"Alice", "Bob"},
 		"AD": {"Carol", "Dave"},
@@ -568,6 +579,7 @@ func TestTeamConfig_ResolveTeamIdentifier(t *testing.T) {
 }
 
 func TestTeamConfig_SetNicknames(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"Alice", "Bob"},
 	}
@@ -624,6 +636,7 @@ func TestTeamConfig_SetNicknames(t *testing.T) {
 }
 
 func TestTeamConfig_GetNicknames(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"Alice", "Bob"},
 		"AD": {"Carol", "Dave"},
@@ -666,6 +679,7 @@ func TestTeamConfig_GetNicknames(t *testing.T) {
 }
 
 func TestTeamConfig_GetAllNicknameMappings(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"Alice", "Bob"},
 		"AD": {"Carol", "Dave"},
@@ -689,6 +703,7 @@ func TestTeamConfig_GetAllNicknameMappings(t *testing.T) {
 }
 
 func TestNewTeamConfigWithTribes(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN":  {"alice", "bob"},
 		"COP": {"charlie"},
@@ -719,6 +734,7 @@ func TestNewTeamConfigWithTribes(t *testing.T) {
 }
 
 func TestNewTeamConfigWithTribes_IgnoresInvalidProjects(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"alice"},
 	}
@@ -738,6 +754,7 @@ func TestNewTeamConfigWithTribes_IgnoresInvalidProjects(t *testing.T) {
 }
 
 func TestGetTribe(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN":  {"alice"},
 		"COP": {"bob"},
@@ -758,6 +775,7 @@ func TestGetTribe(t *testing.T) {
 }
 
 func TestSetTribe(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"alice"},
 	}
@@ -777,6 +795,7 @@ func TestSetTribe(t *testing.T) {
 }
 
 func TestSetTribe_Errors(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN": {"alice"},
 	}
@@ -796,6 +815,7 @@ func TestSetTribe_Errors(t *testing.T) {
 }
 
 func TestToFullMap(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN":  {"alice", "bob"},
 		"COP": {"charlie"},
@@ -834,6 +854,7 @@ func TestToFullMap(t *testing.T) {
 }
 
 func TestGetCompany(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"FN":  {"alice", "bob"},
 		"COP": {"charlie"},
@@ -864,6 +885,7 @@ func TestGetCompany(t *testing.T) {
 }
 
 func TestSetCompany(t *testing.T) {
+	t.Parallel()
 	t.Run("sets company for existing project", func(t *testing.T) {
 		teams := map[string][]string{
 			"FN": {"alice", "bob"},
@@ -916,6 +938,7 @@ func TestSetCompany(t *testing.T) {
 }
 
 func TestNewTeamConfigFull(t *testing.T) {
+	t.Parallel()
 	t.Run("creates config with all fields", func(t *testing.T) {
 		teams := map[string][]string{
 			"FN":  {"alice", "bob"},
@@ -968,6 +991,7 @@ func TestNewTeamConfigFull(t *testing.T) {
 }
 
 func TestGetExcludedIssueTypes(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"COP": {"alice"},
 		"FN":  {"bob"},
@@ -996,6 +1020,7 @@ func TestGetExcludedIssueTypes(t *testing.T) {
 }
 
 func TestSetExcludedIssueTypes(t *testing.T) {
+	t.Parallel()
 	t.Run("sets excluded types for existing project", func(t *testing.T) {
 		teams := map[string][]string{"COP": {"alice"}}
 		config, err := NewTeamConfig(teams)
@@ -1028,6 +1053,7 @@ func TestSetExcludedIssueTypes(t *testing.T) {
 }
 
 func TestNewTeamConfigWithExcludedTypes(t *testing.T) {
+	t.Parallel()
 	t.Run("creates config with excluded issue types", func(t *testing.T) {
 		teams := map[string][]string{
 			"COP": {"alice"},
@@ -1080,6 +1106,7 @@ func datePtr(year int, month time.Month, day int) *time.Time {
 }
 
 func TestTeamMemberPeriod_IsActiveAt(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		period TeamMemberPeriod
@@ -1132,6 +1159,7 @@ func TestTeamMemberPeriod_IsActiveAt(t *testing.T) {
 }
 
 func TestTeamMemberPeriod_IsActiveDuring(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		period TeamMemberPeriod
@@ -1198,6 +1226,7 @@ func TestTeamMemberPeriod_IsActiveDuring(t *testing.T) {
 }
 
 func TestTeamConfig_GetTeamForPeriod(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"PROJECT-A": {"Alice", "Bob", "Charlie", "Dave"},
 		"PROJECT-B": {"Eve"},
@@ -1260,6 +1289,7 @@ func TestTeamConfig_GetTeamForPeriod(t *testing.T) {
 }
 
 func TestTeamConfig_AddMemberWithDates(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{"PROJECT-A": {"Alice"}}
 	config, err := NewTeamConfig(teams)
 	require.NoError(t, err)
@@ -1298,6 +1328,7 @@ func TestTeamConfig_AddMemberWithDates(t *testing.T) {
 }
 
 func TestTeamConfig_SetMemberLeft(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{"PROJECT-A": {"Alice"}}
 	timeline := map[string][]TeamMemberPeriod{
 		"PROJECT-A": {
@@ -1340,6 +1371,7 @@ func TestTeamConfig_SetMemberLeft(t *testing.T) {
 }
 
 func TestTeamConfig_DeriveActiveTeamFromTimeline(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{"PROJECT-A": {"Alice", "Bob", "Charlie"}}
 	timeline := map[string][]TeamMemberPeriod{
 		"PROJECT-A": {
@@ -1357,6 +1389,7 @@ func TestTeamConfig_DeriveActiveTeamFromTimeline(t *testing.T) {
 }
 
 func TestTeamConfig_HasTeamTimeline(t *testing.T) {
+	t.Parallel()
 	teams := map[string][]string{
 		"PROJECT-A": {"Alice"},
 		"PROJECT-B": {"Bob"},
@@ -1374,6 +1407,7 @@ func TestTeamConfig_HasTeamTimeline(t *testing.T) {
 }
 
 func TestNewTeamConfigWithTimelines(t *testing.T) {
+	t.Parallel()
 	t.Run("creates config with timelines", func(t *testing.T) {
 		teams := map[string][]string{"PROJECT-A": {"Alice"}}
 		timeline := map[string][]TeamMemberPeriod{

--- a/internal/config/domain/team_sync_result_test.go
+++ b/internal/config/domain/team_sync_result_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestNewTeamSyncResult(t *testing.T) {
+	t.Parallel()
 	members := []TeamMember{
 		{Name: "John Doe", Email: "john@example.com", DisplayName: "John Doe"},
 		{Name: "Jane Smith", Email: "jane@example.com", DisplayName: "Jane Smith"},
@@ -25,6 +26,7 @@ func TestNewTeamSyncResult(t *testing.T) {
 }
 
 func TestTeamSyncResult_AddError(t *testing.T) {
+	t.Parallel()
 	result := NewTeamSyncResult("TEST", []TeamMember{}, "jira")
 
 	result.AddError("Connection failed", "network")
@@ -39,6 +41,7 @@ func TestTeamSyncResult_AddError(t *testing.T) {
 }
 
 func TestTeamSyncResult_GetMemberNames(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		members  []TeamMember
@@ -77,6 +80,7 @@ func TestTeamSyncResult_GetMemberNames(t *testing.T) {
 }
 
 func TestTeamSyncResult_Validate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		result  *TeamSyncResult
@@ -140,6 +144,7 @@ func TestTeamSyncResult_Validate(t *testing.T) {
 }
 
 func TestTeamSyncResult_String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		result   *TeamSyncResult

--- a/internal/console/application/console_service_test.go
+++ b/internal/console/application/console_service_test.go
@@ -99,6 +99,7 @@ func (m *MockContextStore) CleanupExpired(ctx context.Context, timeout int) erro
 }
 
 func TestNewConsoleService(t *testing.T) {
+	t.Parallel()
 	service := NewConsoleService(nil, nil, nil)
 
 	require.NotNil(t, service)
@@ -107,6 +108,7 @@ func TestNewConsoleService(t *testing.T) {
 }
 
 func TestGenerateSessionID(t *testing.T) {
+	t.Parallel()
 	id1 := generateSessionID()
 
 	assert.NotEmpty(t, id1)
@@ -115,6 +117,7 @@ func TestGenerateSessionID(t *testing.T) {
 }
 
 func TestConsoleService_StartSession(t *testing.T) {
+	t.Parallel()
 	mockStore := &MockContextStore{}
 	service := NewConsoleService(nil, nil, mockStore)
 	ctx := context.Background()
@@ -131,6 +134,7 @@ func TestConsoleService_StartSession(t *testing.T) {
 }
 
 func TestProcessResult_Structure(t *testing.T) {
+	t.Parallel()
 	result := &ProcessResult{
 		Success:               true,
 		Command:               nil,
@@ -153,6 +157,7 @@ func TestProcessResult_Structure(t *testing.T) {
 }
 
 func TestConsoleService_EndSession(t *testing.T) {
+	t.Parallel()
 	mockStore := &MockContextStore{}
 	service := NewConsoleService(nil, nil, mockStore)
 	ctx := context.Background()
@@ -167,6 +172,7 @@ func TestConsoleService_EndSession(t *testing.T) {
 }
 
 func TestConsoleService_GetSessionContext(t *testing.T) {
+	t.Parallel()
 	mockStore := &MockContextStore{}
 	service := NewConsoleService(nil, nil, mockStore)
 	ctx := context.Background()
@@ -182,6 +188,7 @@ func TestConsoleService_GetSessionContext(t *testing.T) {
 }
 
 func TestConsoleService_ProcessInput_SessionNotFound(t *testing.T) {
+	t.Parallel()
 	mockStore := &MockContextStore{}
 	service := NewConsoleService(nil, nil, mockStore)
 	ctx := context.Background()
@@ -198,6 +205,7 @@ func TestConsoleService_ProcessInput_SessionNotFound(t *testing.T) {
 }
 
 func TestConsoleService_ProcessInput_LoadError(t *testing.T) {
+	t.Parallel()
 	mockStore := &MockContextStore{}
 	service := NewConsoleService(nil, nil, mockStore)
 	ctx := context.Background()
@@ -214,6 +222,7 @@ func TestConsoleService_ProcessInput_LoadError(t *testing.T) {
 }
 
 func TestConsoleService_StartSession_SaveError(t *testing.T) {
+	t.Parallel()
 	mockStore := &MockContextStore{}
 	service := NewConsoleService(nil, nil, mockStore)
 	ctx := context.Background()
@@ -230,6 +239,7 @@ func TestConsoleService_StartSession_SaveError(t *testing.T) {
 }
 
 func TestConsoleService_ProcessInput_ExpiredSession(t *testing.T) {
+	t.Parallel()
 	mockStore := &MockContextStore{}
 	service := NewConsoleService(nil, nil, mockStore)
 	ctx := context.Background()
@@ -249,6 +259,7 @@ func TestConsoleService_ProcessInput_ExpiredSession(t *testing.T) {
 }
 
 func TestConsoleService_ProcessInput_InterpretationError(t *testing.T) {
+	t.Parallel()
 	mockInterpreter := &MockAIInterpreter{}
 	mockStore := &MockContextStore{}
 	service := NewConsoleService(mockInterpreter, nil, mockStore)
@@ -271,6 +282,7 @@ func TestConsoleService_ProcessInput_InterpretationError(t *testing.T) {
 }
 
 func TestConsoleService_ProcessInput_ExecutionError(t *testing.T) {
+	t.Parallel()
 	mockInterpreter := &MockAIInterpreter{}
 	mockExecutor := &MockCommandExecutor{}
 	mockStore := &MockContextStore{}
@@ -299,6 +311,7 @@ func TestConsoleService_ProcessInput_ExecutionError(t *testing.T) {
 }
 
 func TestConsoleService_ProcessInput_SuccessfulExecution(t *testing.T) {
+	t.Parallel()
 	mockInterpreter := &MockAIInterpreter{}
 	mockExecutor := &MockCommandExecutor{}
 	mockStore := &MockContextStore{}
@@ -337,6 +350,7 @@ func TestConsoleService_ProcessInput_SuccessfulExecution(t *testing.T) {
 }
 
 func TestConsoleService_ProcessInput_ValidationError(t *testing.T) {
+	t.Parallel()
 	mockInterpreter := &MockAIInterpreter{}
 	mockExecutor := &MockCommandExecutor{}
 	mockStore := &MockContextStore{}
@@ -368,6 +382,7 @@ func TestConsoleService_ProcessInput_ValidationError(t *testing.T) {
 }
 
 func TestConsoleService_ProcessInput_ExecutionErrorType(t *testing.T) {
+	t.Parallel()
 	mockInterpreter := &MockAIInterpreter{}
 	mockExecutor := &MockCommandExecutor{}
 	mockStore := &MockContextStore{}
@@ -399,6 +414,7 @@ func TestConsoleService_ProcessInput_ExecutionErrorType(t *testing.T) {
 }
 
 func TestConsoleService_GetAvailableCommands(t *testing.T) {
+	t.Parallel()
 	mockExecutor := &MockCommandExecutor{}
 	service := NewConsoleService(nil, mockExecutor, nil)
 

--- a/internal/console/application/update_context_test.go
+++ b/internal/console/application/update_context_test.go
@@ -15,6 +15,7 @@ import (
 // on ConsoleService, but since it only touches ctx + cmd + result, we
 // can drive it directly off a zero-valued ConsoleService.
 func TestConsoleService_UpdateContextFromResult_AssetBranch(t *testing.T) {
+	t.Parallel()
 	svc := &ConsoleService{}
 	ctx := domain.NewContext("session-1")
 
@@ -40,6 +41,7 @@ func TestConsoleService_UpdateContextFromResult_AssetBranch(t *testing.T) {
 }
 
 func TestConsoleService_UpdateContextFromResult_AssetReadAlsoUpdates(t *testing.T) {
+	t.Parallel()
 	svc := &ConsoleService{}
 	ctx := domain.NewContext("s")
 
@@ -55,6 +57,7 @@ func TestConsoleService_UpdateContextFromResult_AssetReadAlsoUpdates(t *testing.
 }
 
 func TestConsoleService_UpdateContextFromResult_AssetNoUpdateOnUnknownAction(t *testing.T) {
+	t.Parallel()
 	svc := &ConsoleService{}
 	ctx := domain.NewContext("s")
 
@@ -70,6 +73,7 @@ func TestConsoleService_UpdateContextFromResult_AssetNoUpdateOnUnknownAction(t *
 }
 
 func TestConsoleService_UpdateContextFromResult_TaskBranch(t *testing.T) {
+	t.Parallel()
 	svc := &ConsoleService{}
 	ctx := domain.NewContext("s")
 
@@ -82,6 +86,7 @@ func TestConsoleService_UpdateContextFromResult_TaskBranch(t *testing.T) {
 }
 
 func TestConsoleService_UpdateContextFromResult_SprintBranch(t *testing.T) {
+	t.Parallel()
 	svc := &ConsoleService{}
 	ctx := domain.NewContext("s")
 
@@ -96,6 +101,7 @@ func TestConsoleService_UpdateContextFromResult_SprintBranch(t *testing.T) {
 }
 
 func TestConsoleService_UpdateContextFromResult_UnknownResourceIsNoop(t *testing.T) {
+	t.Parallel()
 	svc := &ConsoleService{}
 	before := domain.NewContext("s")
 	cmd := &domain.Command{

--- a/internal/console/application/usecase/execute_command_test.go
+++ b/internal/console/application/usecase/execute_command_test.go
@@ -40,6 +40,7 @@ func (m *MockCommandExecutor) GetAvailableCommands() []ports.CommandInfo {
 }
 
 func TestNewExecuteCommandUseCase(t *testing.T) {
+	t.Parallel()
 	mockExecutor := new(MockCommandExecutor)
 	useCase := NewExecuteCommandUseCase(mockExecutor)
 
@@ -48,6 +49,7 @@ func TestNewExecuteCommandUseCase(t *testing.T) {
 }
 
 func TestExecuteCommandUseCase_Execute_Success(t *testing.T) {
+	t.Parallel()
 	mockExecutor := new(MockCommandExecutor)
 	useCase := NewExecuteCommandUseCase(mockExecutor)
 	ctx := context.Background()
@@ -81,6 +83,7 @@ func TestExecuteCommandUseCase_Execute_Success(t *testing.T) {
 }
 
 func TestExecuteCommandUseCase_Execute_PreValidationFailure(t *testing.T) {
+	t.Parallel()
 	mockExecutor := new(MockCommandExecutor)
 	useCase := NewExecuteCommandUseCase(mockExecutor)
 	ctx := context.Background()
@@ -103,6 +106,7 @@ func TestExecuteCommandUseCase_Execute_PreValidationFailure(t *testing.T) {
 }
 
 func TestExecuteCommandUseCase_Execute_ValidationFailure(t *testing.T) {
+	t.Parallel()
 	mockExecutor := new(MockCommandExecutor)
 	useCase := NewExecuteCommandUseCase(mockExecutor)
 	ctx := context.Background()
@@ -129,6 +133,7 @@ func TestExecuteCommandUseCase_Execute_ValidationFailure(t *testing.T) {
 }
 
 func TestExecuteCommandUseCase_Execute_ExecutionFailure(t *testing.T) {
+	t.Parallel()
 	mockExecutor := new(MockCommandExecutor)
 	useCase := NewExecuteCommandUseCase(mockExecutor)
 	ctx := context.Background()
@@ -158,6 +163,7 @@ func TestExecuteCommandUseCase_Execute_ExecutionFailure(t *testing.T) {
 }
 
 func TestExecuteCommandUseCase_ValidateCommand(t *testing.T) {
+	t.Parallel()
 	mockExecutor := new(MockCommandExecutor)
 	useCase := NewExecuteCommandUseCase(mockExecutor)
 
@@ -215,6 +221,7 @@ func TestExecuteCommandUseCase_ValidateCommand(t *testing.T) {
 }
 
 func TestExecuteCommandUseCase_GetAvailableCommands(t *testing.T) {
+	t.Parallel()
 	mockExecutor := new(MockCommandExecutor)
 	useCase := NewExecuteCommandUseCase(mockExecutor)
 
@@ -240,6 +247,7 @@ func TestExecuteCommandUseCase_GetAvailableCommands(t *testing.T) {
 }
 
 func TestExecuteCommandUseCase_PreValidate(t *testing.T) {
+	t.Parallel()
 	mockExecutor := new(MockCommandExecutor)
 	useCase := NewExecuteCommandUseCase(mockExecutor)
 
@@ -306,6 +314,7 @@ func TestExecuteCommandUseCase_PreValidate(t *testing.T) {
 }
 
 func TestExecuteCommandUseCase_PostProcessResult(t *testing.T) {
+	t.Parallel()
 	mockExecutor := new(MockCommandExecutor)
 	useCase := NewExecuteCommandUseCase(mockExecutor)
 

--- a/internal/console/application/usecase/interpret_command_ai_test.go
+++ b/internal/console/application/usecase/interpret_command_ai_test.go
@@ -30,6 +30,7 @@ func (s *stubAIInterpreter) AnalyzeIntent(context.Context, string) (*domain.Comm
 }
 
 func TestInterpretCommandUseCase_Execute_DelegatesToInterpreter(t *testing.T) {
+	t.Parallel()
 	wantCmd, _ := domain.NewCommand("s", "Show all assets", "list", 0.9)
 	wantCmd.SetIntent(domain.CommandTypeList, domain.ResourceTypeAsset, "")
 
@@ -59,6 +60,7 @@ func TestInterpretCommandUseCase_Execute_DelegatesToInterpreter(t *testing.T) {
 }
 
 func TestInterpretCommandUseCase_Execute_PropagatesInterpreterError(t *testing.T) {
+	t.Parallel()
 	interpreter := &stubAIInterpreter{
 		interpretFn: func(context.Context, string, *domain.Context) (*domain.Command, error) {
 			return nil, errors.New("model unavailable")
@@ -74,6 +76,7 @@ func TestInterpretCommandUseCase_Execute_PropagatesInterpreterError(t *testing.T
 }
 
 func TestInterpretCommandUseCase_Execute_SpecialCommandsBypassInterpreter(t *testing.T) {
+	t.Parallel()
 	// If the special-command handler returns non-nil, Interpret must
 	// not be called. We use an interpreter whose Interpret panics to
 	// guarantee that. "bye" is the special-command that's not yet

--- a/internal/console/application/usecase/interpret_command_test.go
+++ b/internal/console/application/usecase/interpret_command_test.go
@@ -11,11 +11,13 @@ import (
 )
 
 func TestNewInterpretCommandUseCase(t *testing.T) {
+	t.Parallel()
 	useCase := NewInterpretCommandUseCase(nil)
 	require.NotNil(t, useCase)
 }
 
 func TestInterpretCommandUseCase_Execute_EmptyInput(t *testing.T) {
+	t.Parallel()
 	useCase := NewInterpretCommandUseCase(nil)
 	ctx := context.Background()
 	sessionContext := domain.NewContext("test-session")
@@ -33,6 +35,7 @@ func TestInterpretCommandUseCase_Execute_EmptyInput(t *testing.T) {
 }
 
 func TestInterpretCommandUseCase_Execute_ExitCommands(t *testing.T) {
+	t.Parallel()
 	useCase := NewInterpretCommandUseCase(nil)
 	ctx := context.Background()
 	sessionContext := domain.NewContext("test-session")
@@ -54,6 +57,7 @@ func TestInterpretCommandUseCase_Execute_ExitCommands(t *testing.T) {
 }
 
 func TestInterpretCommandUseCase_Execute_HelpCommands(t *testing.T) {
+	t.Parallel()
 	useCase := NewInterpretCommandUseCase(nil)
 	ctx := context.Background()
 	sessionContext := domain.NewContext("test-session")

--- a/internal/console/application/usecase/maintain_context_test.go
+++ b/internal/console/application/usecase/maintain_context_test.go
@@ -66,6 +66,7 @@ func (m *MockContextStore) List(ctx context.Context) ([]string, error) {
 }
 
 func TestNewMaintainContextUseCase(t *testing.T) {
+	t.Parallel()
 	mockStore := new(MockContextStore)
 	useCase := NewMaintainContextUseCase(mockStore)
 
@@ -74,6 +75,7 @@ func TestNewMaintainContextUseCase(t *testing.T) {
 }
 
 func TestMaintainContextUseCase_UpdateContext(t *testing.T) {
+	t.Parallel()
 	mockStore := new(MockContextStore)
 	useCase := NewMaintainContextUseCase(mockStore)
 	ctx := context.Background()
@@ -107,6 +109,7 @@ func TestMaintainContextUseCase_UpdateContext(t *testing.T) {
 }
 
 func TestMaintainContextUseCase_UpdateContext_StoreError(t *testing.T) {
+	t.Parallel()
 	mockStore := new(MockContextStore)
 	useCase := NewMaintainContextUseCase(mockStore)
 	ctx := context.Background()
@@ -139,6 +142,7 @@ func TestMaintainContextUseCase_UpdateContext_StoreError(t *testing.T) {
 }
 
 func TestMaintainContextUseCase_UpdateContext_WithEmptyCommand(t *testing.T) {
+	t.Parallel()
 	mockStore := new(MockContextStore)
 	useCase := NewMaintainContextUseCase(mockStore)
 	ctx := context.Background()
@@ -163,6 +167,7 @@ func TestMaintainContextUseCase_UpdateContext_WithEmptyCommand(t *testing.T) {
 }
 
 func TestMaintainContextUseCase_UpdateContext_WithNilParameters(t *testing.T) {
+	t.Parallel()
 	mockStore := new(MockContextStore)
 	useCase := NewMaintainContextUseCase(mockStore)
 	ctx := context.Background()

--- a/internal/console/application/usecase/validate_command_invalid_test.go
+++ b/internal/console/application/usecase/validate_command_invalid_test.go
@@ -13,6 +13,7 @@ import (
 // covers the previously-untested branch where command.Validate() itself
 // fails (missing ID), so the executor is never reached.
 func TestExecuteCommandUseCase_ValidateCommand_DomainInvalidShortCircuits(t *testing.T) {
+	t.Parallel()
 	mockExecutor := new(MockCommandExecutor)
 	// Intentionally no .On("ValidateCommand") — the test asserts the
 	// short-circuit prevents that call.

--- a/internal/console/domain/add_recent_task_test.go
+++ b/internal/console/domain/add_recent_task_test.go
@@ -12,6 +12,7 @@ import (
 // already present, and drop-tail when the list exceeds five.
 // It's exercised via the public UpdateTaskContext entry point.
 func TestAddRecentTask_MoveToFrontAndCapAtFive(t *testing.T) {
+	t.Parallel()
 	ctx := NewContext("session-1")
 
 	for _, key := range []string{"T-1", "T-2", "T-3", "T-4", "T-5"} {

--- a/internal/console/domain/command_test.go
+++ b/internal/console/domain/command_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestNewCommand(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		sessionID   string
@@ -114,6 +115,7 @@ func TestNewCommand(t *testing.T) {
 }
 
 func TestCommand_Validate(t *testing.T) {
+	t.Parallel()
 	validCmd := &Command{
 		ID:          "cmd-123",
 		SessionID:   "session-123",
@@ -189,6 +191,7 @@ func TestCommand_Validate(t *testing.T) {
 }
 
 func TestCommand_ConfidenceMethods(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                 string
 		confidence           float64
@@ -244,6 +247,7 @@ func TestCommand_ConfidenceMethods(t *testing.T) {
 }
 
 func TestCommand_Parameters(t *testing.T) {
+	t.Parallel()
 	cmd := &Command{}
 
 	// Test adding parameters
@@ -286,6 +290,7 @@ func TestCommand_Parameters(t *testing.T) {
 }
 
 func TestCommand_SetIntent(t *testing.T) {
+	t.Parallel()
 	cmd := &Command{}
 
 	cmd.SetIntent(CommandTypeCreate, ResourceTypeAsset, "Payment Processing")
@@ -296,6 +301,7 @@ func TestCommand_SetIntent(t *testing.T) {
 }
 
 func TestNewCommandResult(t *testing.T) {
+	t.Parallel()
 	output := map[string]string{"status": "success"}
 	duration := 100 * time.Millisecond
 

--- a/internal/console/domain/context_test.go
+++ b/internal/console/domain/context_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestNewContext(t *testing.T) {
+	t.Parallel()
 	sessionID := "test-session-123"
 	ctx := NewContext(sessionID)
 
@@ -26,6 +27,7 @@ func TestNewContext(t *testing.T) {
 }
 
 func TestContext_CommandManagement(t *testing.T) {
+	t.Parallel()
 	ctx := NewContext("test-session")
 
 	// Add commands
@@ -76,6 +78,7 @@ func TestContext_CommandManagement(t *testing.T) {
 }
 
 func TestContext_CommandResults(t *testing.T) {
+	t.Parallel()
 	ctx := NewContext("test-session")
 
 	result1 := CommandResult{
@@ -100,6 +103,7 @@ func TestContext_CommandResults(t *testing.T) {
 }
 
 func TestContext_EntityUpdates(t *testing.T) {
+	t.Parallel()
 	ctx := NewContext("test-session")
 
 	// Test asset context
@@ -130,6 +134,7 @@ func TestContext_EntityUpdates(t *testing.T) {
 }
 
 func TestContext_RecentEntityLimits(t *testing.T) {
+	t.Parallel()
 	ctx := NewContext("test-session")
 
 	// Add more than 5 assets
@@ -153,6 +158,7 @@ func TestContext_RecentEntityLimits(t *testing.T) {
 }
 
 func TestContext_ProjectSprintSpace(t *testing.T) {
+	t.Parallel()
 	ctx := NewContext("test-session")
 
 	ctx.SetCurrentProject("PROJECT1")
@@ -166,6 +172,7 @@ func TestContext_ProjectSprintSpace(t *testing.T) {
 }
 
 func TestContext_Variables(t *testing.T) {
+	t.Parallel()
 	ctx := NewContext("test-session")
 
 	// Set variables
@@ -193,6 +200,7 @@ func TestContext_Variables(t *testing.T) {
 }
 
 func TestContext_SessionManagement(t *testing.T) {
+	t.Parallel()
 	ctx := NewContext("test-session")
 
 	// Backdate StartTime/LastActivity so the assertions don't depend on
@@ -214,6 +222,7 @@ func TestContext_SessionManagement(t *testing.T) {
 }
 
 func TestContext_Clear(t *testing.T) {
+	t.Parallel()
 	ctx := NewContext("test-session")
 
 	// Populate context
@@ -246,6 +255,7 @@ func TestContext_Clear(t *testing.T) {
 }
 
 func TestContext_GetSummary(t *testing.T) {
+	t.Parallel()
 	ctx := NewContext("test-session-123")
 
 	// Add some data
@@ -270,6 +280,7 @@ func TestContext_GetSummary(t *testing.T) {
 }
 
 func TestContext_ThreadSafety(t *testing.T) {
+	t.Parallel()
 	ctx := NewContext("test-session")
 	done := make(chan bool, 3)
 

--- a/internal/console/domain/ports/ai_interpreter_test.go
+++ b/internal/console/domain/ports/ai_interpreter_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestNewInterpretationError(t *testing.T) {
+	t.Parallel()
 	err := NewInterpretationError("show me everything", "ambiguous", []string{"assets list", "tasks list"})
 	require.NotNil(t, err)
 	assert.Equal(t, "show me everything", err.Input)
@@ -17,6 +18,7 @@ func TestNewInterpretationError(t *testing.T) {
 }
 
 func TestInterpretationError_Error(t *testing.T) {
+	t.Parallel()
 	err := NewInterpretationError("anything", "the reason text", nil)
 	assert.Equal(t, "the reason text", err.Error())
 

--- a/internal/console/domain/ports/errors_test.go
+++ b/internal/console/domain/ports/errors_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestExecutionError(t *testing.T) {
+	t.Parallel()
 	err := NewExecutionError("test command", "test reason", "test help")
 
 	assert.Equal(t, "test command", err.Command)
@@ -17,6 +18,7 @@ func TestExecutionError(t *testing.T) {
 }
 
 func TestValidationError(t *testing.T) {
+	t.Parallel()
 	// Test with field
 	err := NewValidationError("field", "message")
 	assert.Equal(t, "field", err.Field)
@@ -31,6 +33,7 @@ func TestValidationError(t *testing.T) {
 }
 
 func TestCommandInfo(t *testing.T) {
+	t.Parallel()
 	paramInfo := ParameterInfo{
 		Name:        "test-param",
 		Description: "Test parameter",
@@ -54,6 +57,7 @@ func TestCommandInfo(t *testing.T) {
 }
 
 func TestStoreError(t *testing.T) {
+	t.Parallel()
 	originalErr := errors.New("original error")
 	storeErr := NewStoreError("save", "session-123", originalErr)
 
@@ -70,6 +74,7 @@ func TestStoreError(t *testing.T) {
 }
 
 func TestContextStoreErrors(t *testing.T) {
+	t.Parallel()
 	assert.NotNil(t, ErrContextNotFound)
 	assert.Equal(t, "context not found", ErrContextNotFound.Error())
 

--- a/internal/deployments/application/deployment_service_test.go
+++ b/internal/deployments/application/deployment_service_test.go
@@ -101,6 +101,7 @@ func (m *MockAssetResolver) ResolveAssetsForTask(ctx context.Context, taskKey st
 }
 
 func TestNewDeploymentService(t *testing.T) {
+	t.Parallel()
 	mockRepo := new(MockDeploymentRepository)
 	mockResolver := new(MockAssetResolver)
 
@@ -112,6 +113,7 @@ func TestNewDeploymentService(t *testing.T) {
 }
 
 func TestDeploymentService_RecordDeployment(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	tests := []struct {
@@ -193,6 +195,7 @@ func TestDeploymentService_RecordDeployment(t *testing.T) {
 }
 
 func TestDeploymentService_UpdateDeploymentStatus(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	deploymentID := "dep-123"
 
@@ -269,6 +272,7 @@ func TestDeploymentService_UpdateDeploymentStatus(t *testing.T) {
 }
 
 func TestDeploymentService_GetDeploymentByID(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	deploymentID := "dep-123"
 
@@ -295,6 +299,7 @@ func TestDeploymentService_GetDeploymentByID(t *testing.T) {
 }
 
 func TestDeploymentService_GetDeploymentsByTask(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	taskKey := "TASK-1"
 
@@ -343,6 +348,7 @@ func TestDeploymentService_GetDeploymentsByTask(t *testing.T) {
 }
 
 func TestDeploymentService_GetDeploymentsByAsset(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	assetName := "TestAsset"
 
@@ -388,6 +394,7 @@ func TestDeploymentService_GetDeploymentsByAsset(t *testing.T) {
 }
 
 func TestDeploymentService_GetDeploymentsTimeline(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	from := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2025, 9, 30, 23, 59, 59, 0, time.UTC)
@@ -432,6 +439,7 @@ func TestDeploymentService_GetDeploymentsTimeline(t *testing.T) {
 }
 
 func TestDeploymentService_GetDeploymentStatistics(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	from := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2025, 9, 30, 23, 59, 59, 0, time.UTC)
@@ -477,6 +485,7 @@ func TestDeploymentService_GetDeploymentStatistics(t *testing.T) {
 }
 
 func TestDeploymentService_ListAllDeployments(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	deployments := []*domain.Deployment{

--- a/internal/deployments/application/usecase/usecase_test.go
+++ b/internal/deployments/application/usecase/usecase_test.go
@@ -79,6 +79,7 @@ func newService(t *testing.T, repo ports.DeploymentRepository, resolver ports.As
 // ----- RecordDeploymentUseCase -----
 
 func TestRecordDeploymentUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("nil service is reported as not configured", func(t *testing.T) {
@@ -156,6 +157,7 @@ func mustNewDeployment(t *testing.T, key string, env domain.Environment) *domain
 }
 
 func TestGetDeploymentHistoryUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("nil service is reported as not configured", func(t *testing.T) {
@@ -222,6 +224,7 @@ func TestGetDeploymentHistoryUseCase_Execute(t *testing.T) {
 // ----- GetDeploymentsTimelineUseCase -----
 
 func TestGetDeploymentsTimelineUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)

--- a/internal/deployments/domain/deployment_test.go
+++ b/internal/deployments/domain/deployment_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestNewDeployment(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		taskKeys    []string
@@ -76,6 +77,7 @@ func TestNewDeployment(t *testing.T) {
 }
 
 func TestDeployment_SetStatus(t *testing.T) {
+	t.Parallel()
 	deployment := &Deployment{
 		ID:          "dep-123",
 		TaskKeys:    []string{"TASK-1"},
@@ -98,6 +100,7 @@ func TestDeployment_SetStatus(t *testing.T) {
 }
 
 func TestDeployment_SetDeployedBy(t *testing.T) {
+	t.Parallel()
 	deployment := &Deployment{
 		ID:          "dep-123",
 		TaskKeys:    []string{"TASK-1"},
@@ -113,6 +116,7 @@ func TestDeployment_SetDeployedBy(t *testing.T) {
 }
 
 func TestDeployment_SetCommitSHA(t *testing.T) {
+	t.Parallel()
 	deployment := &Deployment{
 		ID:          "dep-123",
 		TaskKeys:    []string{"TASK-1"},
@@ -125,6 +129,7 @@ func TestDeployment_SetCommitSHA(t *testing.T) {
 }
 
 func TestDeployment_SetMetadata(t *testing.T) {
+	t.Parallel()
 	deployment := &Deployment{
 		ID:          "dep-123",
 		TaskKeys:    []string{"TASK-1"},
@@ -143,6 +148,7 @@ func TestDeployment_SetMetadata(t *testing.T) {
 }
 
 func TestDeployment_UpdateTimestamp(t *testing.T) {
+	t.Parallel()
 	deployment := &Deployment{
 		ID:          "dep-123",
 		TaskKeys:    []string{"TASK-1"},
@@ -158,6 +164,7 @@ func TestDeployment_UpdateTimestamp(t *testing.T) {
 }
 
 func TestDeployment_Validate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		deployment *Deployment
@@ -249,6 +256,7 @@ func TestDeployment_Validate(t *testing.T) {
 }
 
 func TestTimeRange_Validate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		tr      TimeRange
@@ -266,6 +274,7 @@ func TestTimeRange_Validate(t *testing.T) {
 }
 
 func TestTimeRange_ValidateSkipped(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		tr      TimeRange
@@ -344,6 +353,7 @@ func TestTimeRange_ValidateSkipped(t *testing.T) {
 }
 
 func TestTimeRange_Contains(t *testing.T) {
+	t.Parallel()
 	tr := TimeRange{
 		From: time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC),
 		To:   time.Date(2025, 9, 30, 23, 59, 59, 0, time.UTC),
@@ -390,6 +400,7 @@ func TestTimeRange_Contains(t *testing.T) {
 }
 
 func TestGenerateDeploymentID(t *testing.T) {
+	t.Parallel()
 	// Test ID generation format
 	now := time.Now()
 	id := generateDeploymentID(now)
@@ -405,6 +416,7 @@ func TestGenerateDeploymentID(t *testing.T) {
 }
 
 func TestEnvironment_IsValid(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		env      Environment
@@ -421,6 +433,7 @@ func TestEnvironment_IsValid(t *testing.T) {
 }
 
 func TestEnvironment_IsValidSkipped(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		env      Environment
@@ -471,6 +484,7 @@ func TestEnvironment_IsValidSkipped(t *testing.T) {
 }
 
 func TestDeploymentStatus_IsValid(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		status   DeploymentStatus
@@ -487,6 +501,7 @@ func TestDeploymentStatus_IsValid(t *testing.T) {
 }
 
 func TestDeploymentStatus_IsValidSkipped(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		status   DeploymentStatus
@@ -537,6 +552,7 @@ func TestDeploymentStatus_IsValidSkipped(t *testing.T) {
 }
 
 func TestDeployment_AddTaskKey(t *testing.T) {
+	t.Parallel()
 	deployment := &Deployment{
 		ID:          "dep-123",
 		TaskKeys:    []string{"TASK-1"},
@@ -569,6 +585,7 @@ func TestDeployment_AddTaskKey(t *testing.T) {
 }
 
 func TestDeployment_IsProduction(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		environment Environment
@@ -607,6 +624,7 @@ func TestDeployment_IsProduction(t *testing.T) {
 }
 
 func TestDeployment_IsSuccessful(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		status   DeploymentStatus
@@ -645,6 +663,7 @@ func TestDeployment_IsSuccessful(t *testing.T) {
 }
 
 func TestTimeRange_IsValid(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		tr       TimeRange

--- a/internal/investment/application/service/investment_service_test.go
+++ b/internal/investment/application/service/investment_service_test.go
@@ -75,6 +75,7 @@ func (m *mockInvestmentRepository) DeleteInvestment(_ context.Context, assetName
 }
 
 func TestInvestmentService_InitializeCostModel(t *testing.T) {
+	t.Parallel()
 	costModelRepo := &mockCostModelRepository{}
 	investmentRepo := &mockInvestmentRepository{}
 
@@ -103,6 +104,7 @@ func TestInvestmentService_InitializeCostModel(t *testing.T) {
 }
 
 func TestInvestmentService_GetCostModel(t *testing.T) {
+	t.Parallel()
 	costModelRepo := &mockCostModelRepository{
 		costModels: make(map[string]*domain.CostModel),
 	}
@@ -126,6 +128,7 @@ func TestInvestmentService_GetCostModel(t *testing.T) {
 }
 
 func TestInvestmentService_UpdateCostModel(t *testing.T) {
+	t.Parallel()
 	costModelRepo := &mockCostModelRepository{
 		costModels: make(map[string]*domain.CostModel),
 	}
@@ -156,6 +159,7 @@ func TestInvestmentService_UpdateCostModel(t *testing.T) {
 }
 
 func TestInvestmentService_ListInvestments(t *testing.T) {
+	t.Parallel()
 	investmentRepo := &mockInvestmentRepository{
 		investments: make(map[string]*domain.Investment),
 	}
@@ -188,6 +192,7 @@ func TestInvestmentService_ListInvestments(t *testing.T) {
 // Additional comprehensive test cases for service layer
 
 func TestInvestmentService_CalculateAssetInvestment(t *testing.T) {
+	t.Parallel()
 	costModel, _ := domain.NewCostModel(domain.EUR, 8.0, 2.0)
 	costModel.SetDefaultRate(domain.Senior, 75.0)
 
@@ -232,6 +237,7 @@ func TestInvestmentService_CalculateAssetInvestment(t *testing.T) {
 }
 
 func TestInvestmentService_CalculateSprintInvestment(t *testing.T) {
+	t.Parallel()
 	costModel, _ := domain.NewCostModel(domain.EUR, 8.0, 2.0)
 	costModel.SetDefaultRate(domain.Senior, 75.0)
 
@@ -284,6 +290,7 @@ func TestInvestmentService_CalculateSprintInvestment(t *testing.T) {
 }
 
 func TestInvestmentService_GetInvestment(t *testing.T) {
+	t.Parallel()
 	testInvestment := domain.NewInvestment("Test Asset", "TEST", []string{"Sprint1"}, time.Now(), time.Now(), domain.EUR)
 
 	investmentRepo := &mockInvestmentRepository{
@@ -307,6 +314,7 @@ func TestInvestmentService_GetInvestment(t *testing.T) {
 }
 
 func TestInvestmentService_GetInvestment_NotFound(t *testing.T) {
+	t.Parallel()
 	investmentRepo := &mockInvestmentRepository{
 		investments: make(map[string]*domain.Investment),
 	}
@@ -322,6 +330,7 @@ func TestInvestmentService_GetInvestment_NotFound(t *testing.T) {
 }
 
 func TestInvestmentService_DeleteInvestment(t *testing.T) {
+	t.Parallel()
 	testInvestment := domain.NewInvestment("Test Asset", "TEST", []string{"Sprint1"}, time.Now(), time.Now(), domain.EUR)
 
 	investmentRepo := &mockInvestmentRepository{
@@ -347,6 +356,7 @@ func TestInvestmentService_DeleteInvestment(t *testing.T) {
 }
 
 func TestInvestmentService_DeleteInvestment_NotFound(t *testing.T) {
+	t.Parallel()
 	investmentRepo := &mockInvestmentRepository{
 		investments: make(map[string]*domain.Investment),
 	}
@@ -362,6 +372,7 @@ func TestInvestmentService_DeleteInvestment_NotFound(t *testing.T) {
 }
 
 func TestInvestmentService_InitializeCostModel_AlreadyExists(t *testing.T) {
+	t.Parallel()
 	existingModel, _ := domain.NewCostModel(domain.USD, 8.0, 2.5)
 
 	costModelRepo := &mockCostModelRepository{
@@ -389,6 +400,7 @@ func TestInvestmentService_InitializeCostModel_AlreadyExists(t *testing.T) {
 }
 
 func TestInvestmentService_GetCostModel_NotFound(t *testing.T) {
+	t.Parallel()
 	costModelRepo := &mockCostModelRepository{
 		costModels: make(map[string]*domain.CostModel),
 	}
@@ -404,6 +416,7 @@ func TestInvestmentService_GetCostModel_NotFound(t *testing.T) {
 }
 
 func TestInvestmentService_UpdateCostModel_InvalidModel(t *testing.T) {
+	t.Parallel()
 	costModelRepo := &mockCostModelRepository{
 		costModels: make(map[string]*domain.CostModel),
 	}
@@ -426,6 +439,7 @@ func TestInvestmentService_UpdateCostModel_InvalidModel(t *testing.T) {
 }
 
 func TestInvestmentService_ListInvestments_EmptyProject(t *testing.T) {
+	t.Parallel()
 	investmentRepo := &mockInvestmentRepository{
 		investments: make(map[string]*domain.Investment),
 	}
@@ -484,6 +498,7 @@ func (m *mockCostModelRepositoryWithErrors) SaveCostModel(ctx context.Context, p
 }
 
 func TestInvestmentService_InitializeCostModel_GetDefaultError(t *testing.T) {
+	t.Parallel()
 	costModelRepo := &mockCostModelRepositoryWithErrors{
 		mockCostModelRepository: &mockCostModelRepository{},
 		shouldFailGetDefault:    true,
@@ -505,6 +520,7 @@ func TestInvestmentService_InitializeCostModel_GetDefaultError(t *testing.T) {
 }
 
 func TestInvestmentService_InitializeCostModel_SaveError(t *testing.T) {
+	t.Parallel()
 	costModelRepo := &mockCostModelRepositoryWithErrors{
 		mockCostModelRepository: &mockCostModelRepository{},
 		shouldFailSave:          true,

--- a/internal/investment/application/usecase/calculate_asset_investment_test.go
+++ b/internal/investment/application/usecase/calculate_asset_investment_test.go
@@ -93,6 +93,7 @@ func (m *mockInvestmentRepository) DeleteInvestment(_ context.Context, assetName
 }
 
 func TestCalculateAssetInvestmentUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	// Set up mocks
 	costModelRepo := &mockCostModelRepository{
 		costModels: make(map[string]*domain.CostModel),
@@ -184,6 +185,7 @@ func TestCalculateAssetInvestmentUseCase_Execute(t *testing.T) {
 }
 
 func TestCalculateAssetInvestmentUseCase_Execute_CostModelNotFound(t *testing.T) {
+	t.Parallel()
 	// Set up mocks with empty cost model repo - it should fallback to default
 	costModelRepo := &mockCostModelRepository{
 		costModels: make(map[string]*domain.CostModel),
@@ -215,6 +217,7 @@ func TestCalculateAssetInvestmentUseCase_Execute_CostModelNotFound(t *testing.T)
 }
 
 func TestCalculateAssetInvestmentUseCase_Execute_EmptySprints(t *testing.T) {
+	t.Parallel()
 	costModelRepo := &mockCostModelRepository{
 		costModels: make(map[string]*domain.CostModel),
 	}
@@ -263,6 +266,7 @@ func TestCalculateAssetInvestmentUseCase_Execute_EmptySprints(t *testing.T) {
 // Additional comprehensive test cases
 
 func TestCalculateAssetInvestmentUseCase_Execute_WithInfrastructureCosts(t *testing.T) {
+	t.Parallel()
 	costModel, _ := domain.NewCostModel(domain.EUR, 8.0, 2.0)
 	costModel.InfrastructureCosts.CloudCostsPerMonth = 1000.0
 	costModel.InfrastructureCosts.ToolingCostsPerMonth = 500.0
@@ -329,6 +333,7 @@ func TestCalculateAssetInvestmentUseCase_Execute_WithInfrastructureCosts(t *test
 }
 
 func TestCalculateAssetInvestmentUseCase_Execute_WithDateRangeFiltering(t *testing.T) {
+	t.Parallel()
 	costModel, _ := domain.NewCostModel(domain.EUR, 8.0, 2.0)
 	costModel.SetDefaultRate(domain.Senior, 75.0)
 
@@ -409,6 +414,7 @@ func TestCalculateAssetInvestmentUseCase_Execute_WithDateRangeFiltering(t *testi
 }
 
 func TestCalculateAssetInvestmentUseCase_Execute_WithProvidedCostModel(t *testing.T) {
+	t.Parallel()
 	// Provide cost model in input instead of using repository
 	costModel, _ := domain.NewCostModel(domain.USD, 7.5, 1.8)
 	costModel.SetDefaultRate(domain.Staff, 90.0)
@@ -463,6 +469,7 @@ func TestCalculateAssetInvestmentUseCase_Execute_WithProvidedCostModel(t *testin
 }
 
 func TestCalculateAssetInvestmentUseCase_Execute_InvalidCostModel(t *testing.T) {
+	t.Parallel()
 	// Create invalid cost model
 	invalidCostModel := &domain.CostModel{
 		Currency:           domain.EUR,
@@ -503,6 +510,7 @@ func TestCalculateAssetInvestmentUseCase_Execute_InvalidCostModel(t *testing.T) 
 }
 
 func TestCalculateAssetInvestmentUseCase_Execute_MultipleEngineersAndTasks(t *testing.T) {
+	t.Parallel()
 	costModel, _ := domain.NewCostModel(domain.EUR, 8.0, 2.0)
 	costModel.SetDefaultRate(domain.Senior, 75.0)
 	costModel.SetDefaultRate(domain.Mid, 60.0)
@@ -630,6 +638,7 @@ func TestCalculateAssetInvestmentUseCase_Execute_MultipleEngineersAndTasks(t *te
 }
 
 func TestCalculateAssetInvestmentUseCase_Execute_AllocationProviderError(t *testing.T) {
+	t.Parallel()
 	costModel, _ := domain.NewCostModel(domain.EUR, 8.0, 2.0)
 	costModelRepo := &mockCostModelRepository{
 		costModels: map[string]*domain.CostModel{
@@ -681,6 +690,7 @@ func (m *mockTimeAllocationProviderWithError) GetTaskAllocations(_ context.Conte
 // Additional tests to improve coverage to 90%+
 
 func TestCalculateAssetInvestmentUseCase_InferEngineerLevel_AllCases(t *testing.T) {
+	t.Parallel()
 	costModel, _ := domain.NewCostModel(domain.EUR, 8.0, 2.0)
 
 	// Set up all default rates
@@ -722,6 +732,7 @@ func TestCalculateAssetInvestmentUseCase_InferEngineerLevel_AllCases(t *testing.
 }
 
 func TestCalculateAssetInvestmentUseCase_ContainsString_AllCases(t *testing.T) {
+	t.Parallel()
 	useCase := NewCalculateAssetInvestmentUseCase(&mockCostModelRepository{}, &mockTimeAllocationProvider{}, &mockInvestmentRepository{})
 
 	// Test string found
@@ -748,6 +759,7 @@ func TestCalculateAssetInvestmentUseCase_ContainsString_AllCases(t *testing.T) {
 }
 
 func TestCalculateAssetInvestmentUseCase_Execute_InfrastructureCostCalculationError(t *testing.T) {
+	t.Parallel()
 	// Create cost model that will cause infrastructure cost calculation error
 	costModel, _ := domain.NewCostModel(domain.EUR, 8.0, 2.0)
 	costModel.SetDefaultRate(domain.Senior, 75.0)
@@ -796,6 +808,7 @@ func TestCalculateAssetInvestmentUseCase_Execute_InfrastructureCostCalculationEr
 }
 
 func TestCalculateAssetInvestmentUseCase_Execute_SaveInvestmentError(t *testing.T) {
+	t.Parallel()
 	costModel, _ := domain.NewCostModel(domain.EUR, 8.0, 2.0)
 	costModel.SetDefaultRate(domain.Senior, 75.0)
 

--- a/internal/investment/domain/cost_model_test.go
+++ b/internal/investment/domain/cost_model_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestNewCostModel(t *testing.T) {
+	t.Parallel()
 	costModel, err := NewCostModel(EUR, 8.0, 2.0)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -33,6 +34,7 @@ func TestNewCostModel(t *testing.T) {
 }
 
 func TestNewCostModel_InvalidValues(t *testing.T) {
+	t.Parallel()
 	// Test invalid working hours
 	_, err := NewCostModel(EUR, 0, 2.0)
 	if err == nil {
@@ -47,6 +49,7 @@ func TestNewCostModel_InvalidValues(t *testing.T) {
 }
 
 func TestCostModel_AddEngineerRate(t *testing.T) {
+	t.Parallel()
 	costModel, _ := NewCostModel(EUR, 8.0, 2.0)
 
 	rate := EngineerRate{
@@ -76,6 +79,7 @@ func TestCostModel_AddEngineerRate(t *testing.T) {
 }
 
 func TestCostModel_SetDefaultRate(t *testing.T) {
+	t.Parallel()
 	costModel, _ := NewCostModel(EUR, 8.0, 2.0)
 
 	err := costModel.SetDefaultRate(Senior, 75.0)
@@ -94,6 +98,7 @@ func TestCostModel_SetDefaultRate(t *testing.T) {
 }
 
 func TestCostModel_GetEngineerRateOrDefault(t *testing.T) {
+	t.Parallel()
 	costModel, _ := NewCostModel(EUR, 8.0, 2.0)
 
 	// Set a default rate for senior level
@@ -121,6 +126,7 @@ func TestCostModel_GetEngineerRateOrDefault(t *testing.T) {
 }
 
 func TestCostModel_CalculateInfrastructureCostForPeriod(t *testing.T) {
+	t.Parallel()
 	costModel, _ := NewCostModel(EUR, 8.0, 2.0)
 	costModel.InfrastructureCosts.CloudCostsPerMonth = 1000.0
 	costModel.InfrastructureCosts.ToolingCostsPerMonth = 500.0
@@ -142,6 +148,7 @@ func TestCostModel_CalculateInfrastructureCostForPeriod(t *testing.T) {
 }
 
 func TestCostModel_GetTotalMonthlyCost(t *testing.T) {
+	t.Parallel()
 	costModel, _ := NewCostModel(EUR, 8.0, 2.0)
 	costModel.InfrastructureCosts.CloudCostsPerMonth = 1000.0
 	costModel.InfrastructureCosts.ToolingCostsPerMonth = 500.0
@@ -157,6 +164,7 @@ func TestCostModel_GetTotalMonthlyCost(t *testing.T) {
 // Additional test cases for complete coverage
 
 func TestCostModel_AddEngineerRate_NegativeRate(t *testing.T) {
+	t.Parallel()
 	costModel, _ := NewCostModel(EUR, 8.0, 2.0)
 
 	rate := EngineerRate{
@@ -176,6 +184,7 @@ func TestCostModel_AddEngineerRate_NegativeRate(t *testing.T) {
 }
 
 func TestCostModel_SetDefaultRate_NegativeRate(t *testing.T) {
+	t.Parallel()
 	costModel, _ := NewCostModel(EUR, 8.0, 2.0)
 
 	err := costModel.SetDefaultRate(Senior, -75.0)
@@ -188,6 +197,7 @@ func TestCostModel_SetDefaultRate_NegativeRate(t *testing.T) {
 }
 
 func TestCostModel_GetEngineerRate(t *testing.T) {
+	t.Parallel()
 	costModel, _ := NewCostModel(EUR, 8.0, 2.0)
 
 	// Add an engineer
@@ -218,6 +228,7 @@ func TestCostModel_GetEngineerRate(t *testing.T) {
 }
 
 func TestCostModel_GetEngineerRateOrDefault_NoDefault(t *testing.T) {
+	t.Parallel()
 	costModel, _ := NewCostModel(EUR, 8.0, 2.0)
 
 	// Test with no default and no specific rate
@@ -228,6 +239,7 @@ func TestCostModel_GetEngineerRateOrDefault_NoDefault(t *testing.T) {
 }
 
 func TestCostModel_CalculateInfrastructureCostForPeriod_InvalidDates(t *testing.T) {
+	t.Parallel()
 	costModel, _ := NewCostModel(EUR, 8.0, 2.0)
 
 	startDate := time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC)
@@ -243,6 +255,7 @@ func TestCostModel_CalculateInfrastructureCostForPeriod_InvalidDates(t *testing.
 }
 
 func TestCostModel_Validate(t *testing.T) {
+	t.Parallel()
 	costModel, _ := NewCostModel(EUR, 8.0, 2.0)
 
 	// Valid model should pass validation
@@ -276,6 +289,7 @@ func TestCostModel_Validate(t *testing.T) {
 }
 
 func TestEngineerLevel_Constants(t *testing.T) {
+	t.Parallel()
 	// Test that all constants are defined correctly
 	levels := []EngineerLevel{Junior, Mid, Senior, Staff, Principal}
 	expected := []string{"junior", "mid", "senior", "staff", "principal"}
@@ -288,6 +302,7 @@ func TestEngineerLevel_Constants(t *testing.T) {
 }
 
 func TestCurrency_Constants(t *testing.T) {
+	t.Parallel()
 	// Test that all currency constants are defined correctly
 	currencies := []Currency{EUR, USD, GBP}
 	expected := []string{"EUR", "USD", "GBP"}
@@ -300,6 +315,7 @@ func TestCurrency_Constants(t *testing.T) {
 }
 
 func TestInfrastructureCosts_ZeroCosts(t *testing.T) {
+	t.Parallel()
 	costModel, _ := NewCostModel(EUR, 8.0, 2.0)
 
 	// Test with zero infrastructure costs
@@ -316,6 +332,7 @@ func TestInfrastructureCosts_ZeroCosts(t *testing.T) {
 }
 
 func TestCostModel_InferEngineerLevel(t *testing.T) {
+	t.Parallel()
 	costModel, _ := NewCostModel(EUR, 8.0, 2.0)
 
 	// Set up default rates for testing

--- a/internal/investment/domain/infer_engineer_level_fallbacks_test.go
+++ b/internal/investment/domain/infer_engineer_level_fallbacks_test.go
@@ -12,6 +12,7 @@ import (
 // cost model has no defaults configured. The existing test sets
 // defaults for every level, so this branch was untested.
 func TestInferEngineerLevel_FallbackRateRanges(t *testing.T) {
+	t.Parallel()
 	cm, err := NewCostModel(EUR, 8.0, 2.0)
 	require.NoError(t, err)
 	// No SetDefaultRate calls: forces the switch fallback for every input.
@@ -44,6 +45,7 @@ func TestInferEngineerLevel_FallbackRateRanges(t *testing.T) {
 // far outside their +/-10% tolerance — the loop completes without a
 // match and the rate-range switch decides instead.
 func TestInferEngineerLevel_OutsideToleranceFallsThrough(t *testing.T) {
+	t.Parallel()
 	cm, err := NewCostModel(EUR, 8.0, 2.0)
 	require.NoError(t, err)
 	// Configure ONLY the Senior default. A rate of 30 is well outside

--- a/internal/investment/domain/investment_test.go
+++ b/internal/investment/domain/investment_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestNewInvestment(t *testing.T) {
+	t.Parallel()
 	startDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	endDate := time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC)
 
@@ -37,6 +38,7 @@ func TestNewInvestment(t *testing.T) {
 }
 
 func TestInvestment_AddEngineerInvestment(t *testing.T) {
+	t.Parallel()
 	investment := NewInvestment("Test", "PROJECT", []string{"Sprint1"}, time.Now(), time.Now(), EUR)
 
 	engineerInvestment := EngineerInvestment{
@@ -60,6 +62,7 @@ func TestInvestment_AddEngineerInvestment(t *testing.T) {
 }
 
 func TestInvestment_GetDurationInDays(t *testing.T) {
+	t.Parallel()
 	startDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	endDate := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC) // 14 days
 
@@ -72,6 +75,7 @@ func TestInvestment_GetDurationInDays(t *testing.T) {
 }
 
 func TestInvestment_GetEngineerCount(t *testing.T) {
+	t.Parallel()
 	investment := NewInvestment("Test", "PROJECT", []string{"Sprint1"}, time.Now(), time.Now(), EUR)
 
 	// Initially should be 0
@@ -88,6 +92,7 @@ func TestInvestment_GetEngineerCount(t *testing.T) {
 }
 
 func TestInvestment_CalculateTotalCost(t *testing.T) {
+	t.Parallel()
 	investment := NewInvestment("Test", "PROJECT", []string{"Sprint1"}, time.Now(), time.Now(), EUR)
 
 	investment.EngineerCosts = NewMoney(5000, EUR)
@@ -105,6 +110,7 @@ func TestInvestment_CalculateTotalCost(t *testing.T) {
 // Additional test cases for complete coverage
 
 func TestInvestment_AddTaskInvestment(t *testing.T) {
+	t.Parallel()
 	investment := NewInvestment("Test", "PROJECT", []string{"Sprint1"}, time.Now(), time.Now(), EUR)
 
 	task := TaskInvestment{
@@ -150,6 +156,7 @@ func TestInvestment_AddTaskInvestment(t *testing.T) {
 }
 
 func TestInvestment_SetInfrastructureCosts(t *testing.T) {
+	t.Parallel()
 	investment := NewInvestment("Test", "PROJECT", []string{"Sprint1"}, time.Now(), time.Now(), EUR)
 
 	infraCosts := NewMoney(2500, EUR)
@@ -161,6 +168,7 @@ func TestInvestment_SetInfrastructureCosts(t *testing.T) {
 }
 
 func TestInvestment_GetTaskCount(t *testing.T) {
+	t.Parallel()
 	investment := NewInvestment("Test", "PROJECT", []string{"Sprint1"}, time.Now(), time.Now(), EUR)
 
 	// Initially should be 0
@@ -182,6 +190,7 @@ func TestInvestment_GetTaskCount(t *testing.T) {
 }
 
 func TestMoney_Add_DifferentCurrencies(t *testing.T) {
+	t.Parallel()
 	money1 := NewMoney(100.0, EUR)
 	money2 := NewMoney(50.0, USD)
 
@@ -197,6 +206,7 @@ func TestMoney_Add_DifferentCurrencies(t *testing.T) {
 }
 
 func TestMoney_IsZero(t *testing.T) {
+	t.Parallel()
 	// Test zero money
 	zeroMoney := NewMoney(0, EUR)
 	if !zeroMoney.IsZero() {
@@ -211,6 +221,7 @@ func TestMoney_IsZero(t *testing.T) {
 }
 
 func TestEngineerTaskEffort_Structure(t *testing.T) {
+	t.Parallel()
 	effort := EngineerTaskEffort{
 		Allocation:   25.5,
 		Hours:        40.0,
@@ -231,6 +242,7 @@ func TestEngineerTaskEffort_Structure(t *testing.T) {
 }
 
 func TestTaskInvestment_Structure(t *testing.T) {
+	t.Parallel()
 	startDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	endDate := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
 
@@ -268,6 +280,7 @@ func TestTaskInvestment_Structure(t *testing.T) {
 }
 
 func TestEngineerInvestment_Structure(t *testing.T) {
+	t.Parallel()
 	engineer := EngineerInvestment{
 		Name:         "Jane Smith",
 		Level:        Staff,
@@ -294,6 +307,7 @@ func TestEngineerInvestment_Structure(t *testing.T) {
 }
 
 func TestNewInvestment_CalculatedAtSet(t *testing.T) {
+	t.Parallel()
 	before := time.Now()
 	investment := NewInvestment("Test", "PROJECT", []string{"Sprint1"}, time.Now(), time.Now(), EUR)
 	after := time.Now()

--- a/internal/investment/domain/money_test.go
+++ b/internal/investment/domain/money_test.go
@@ -3,6 +3,7 @@ package domain
 import "testing"
 
 func TestNewMoney(t *testing.T) {
+	t.Parallel()
 	money := NewMoney(100.50, EUR)
 
 	if money.Amount != 100.50 {
@@ -15,6 +16,7 @@ func TestNewMoney(t *testing.T) {
 }
 
 func TestMoney_Add(t *testing.T) {
+	t.Parallel()
 	money1 := NewMoney(100.0, EUR)
 	money2 := NewMoney(50.0, EUR)
 
@@ -30,6 +32,7 @@ func TestMoney_Add(t *testing.T) {
 }
 
 func TestMoney_Multiply(t *testing.T) {
+	t.Parallel()
 	money := NewMoney(100.0, EUR)
 
 	result := money.Multiply(2.5)
@@ -44,6 +47,7 @@ func TestMoney_Multiply(t *testing.T) {
 }
 
 func TestMoney_String(t *testing.T) {
+	t.Parallel()
 	money := NewMoney(123.45, EUR)
 
 	str := money.String()
@@ -54,6 +58,7 @@ func TestMoney_String(t *testing.T) {
 }
 
 func TestCurrency_String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		currency Currency
 		expected string

--- a/internal/shared/domain/status_mapping_test.go
+++ b/internal/shared/domain/status_mapping_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestStatusMapper(t *testing.T) {
+	t.Parallel()
 	// Test data
 	teamConfigs := map[string]TeamConfig{
 		"AD": {
@@ -194,6 +195,7 @@ func TestStatusMapper(t *testing.T) {
 }
 
 func TestNewStatusMapper(t *testing.T) {
+	t.Parallel()
 	t.Run("should create mapper with valid configs", func(t *testing.T) {
 		configs := map[string]TeamConfig{
 			"TEST": {
@@ -227,6 +229,7 @@ func TestNewStatusMapper(t *testing.T) {
 }
 
 func TestStatusType(t *testing.T) {
+	t.Parallel()
 	t.Run("constants are properly defined", func(t *testing.T) {
 		assert.Equal(t, StatusType("done"), StatusTypeDone)
 		assert.Equal(t, StatusType("in_progress"), StatusTypeInProgress)
@@ -237,6 +240,7 @@ func TestStatusType(t *testing.T) {
 }
 
 func TestBoardConfig(t *testing.T) {
+	t.Parallel()
 	t.Run("should create board config with all fields", func(t *testing.T) {
 		config := BoardConfig{
 			ID:   "123",
@@ -256,6 +260,7 @@ func TestBoardConfig(t *testing.T) {
 }
 
 func TestTeamConfig(t *testing.T) {
+	t.Parallel()
 	t.Run("should create team config with all fields", func(t *testing.T) {
 		config := TeamConfig{
 			Team:      []string{"user1@example.com", "user2@example.com"},

--- a/internal/sprint/application/service/status_service_test.go
+++ b/internal/sprint/application/service/status_service_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestStatusService(t *testing.T) {
+	t.Parallel()
 	// Test data for isolated testing
 	testTeamConfigs := map[string]sharedDomain.TeamConfig{
 		"AD": {
@@ -132,6 +133,7 @@ func TestStatusService(t *testing.T) {
 }
 
 func TestNewStatusServiceWithPath(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 
 	t.Run("with valid config file", func(t *testing.T) {
@@ -183,6 +185,7 @@ func TestNewStatusServiceWithPath(t *testing.T) {
 }
 
 func TestLoadTeamConfigs(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 
 	t.Run("with valid file", func(t *testing.T) {
@@ -273,6 +276,7 @@ func TestLoadTeamConfigs(t *testing.T) {
 }
 
 func TestNewStatusService(t *testing.T) {
+	t.Parallel()
 	// NewStatusService delegates to NewStatusServiceWithPath("") which
 	// looks up the user's home directory. We don't care which path it
 	// finally settles on -- only that the delegation works without

--- a/internal/sprint/application/usecase/list_sprints_test.go
+++ b/internal/sprint/application/usecase/list_sprints_test.go
@@ -66,6 +66,7 @@ func (m *MockJiraPort) FetchCustomFields(_ string) (*ports.CustomFieldValues, er
 }
 
 func TestListSprintsUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	t.Run("should list sprints for a project in Q2 2025", func(t *testing.T) {
 		// Given
 		mockJira := &MockJiraPort{
@@ -162,6 +163,7 @@ func TestListSprintsUseCase_Execute(t *testing.T) {
 }
 
 func TestListSprintsUseCase_parseYear(t *testing.T) {
+	t.Parallel()
 	u := NewListSprintsUseCase(nil)
 
 	start, end, err := u.parseYear("2025")
@@ -176,6 +178,7 @@ func TestListSprintsUseCase_parseYear(t *testing.T) {
 }
 
 func TestListSprintsUseCase_parseYear_ErrorBranch(t *testing.T) {
+	t.Parallel()
 	u := NewListSprintsUseCase(nil)
 
 	_, _, err := u.parseYear("")
@@ -184,6 +187,7 @@ func TestListSprintsUseCase_parseYear_ErrorBranch(t *testing.T) {
 }
 
 func TestListSprintsUseCase_parseQuarter_InvalidQuarter(t *testing.T) {
+	t.Parallel()
 	u := NewListSprintsUseCase(nil)
 
 	// Test invalid quarter number
@@ -203,6 +207,7 @@ func TestListSprintsUseCase_parseQuarter_InvalidQuarter(t *testing.T) {
 }
 
 func TestListSprintsUseCase_parseQuarter_InvalidQuarterNumber(t *testing.T) {
+	t.Parallel()
 	u := NewListSprintsUseCase(nil)
 	_, _, err := u.parseQuarter("QX 2025")
 	assert.Error(t, err)
@@ -210,6 +215,7 @@ func TestListSprintsUseCase_parseQuarter_InvalidQuarterNumber(t *testing.T) {
 }
 
 func TestListSprintsUseCase_parseQuarter_TooFewParts(t *testing.T) {
+	t.Parallel()
 	u := NewListSprintsUseCase(nil)
 	_, _, err := u.parseQuarter("Q2")
 	assert.Error(t, err)
@@ -217,6 +223,7 @@ func TestListSprintsUseCase_parseQuarter_TooFewParts(t *testing.T) {
 }
 
 func TestListSprintsUseCase_parseQuarter_TooManyParts(t *testing.T) {
+	t.Parallel()
 	u := NewListSprintsUseCase(nil)
 	_, _, err := u.parseQuarter("Q2 2025 extra")
 	assert.Error(t, err)
@@ -224,6 +231,7 @@ func TestListSprintsUseCase_parseQuarter_TooManyParts(t *testing.T) {
 }
 
 func TestListSprintsUseCase_parsePeriod_UnsupportedFormat(t *testing.T) {
+	t.Parallel()
 	u := NewListSprintsUseCase(nil)
 
 	// Test unsupported format
@@ -233,6 +241,7 @@ func TestListSprintsUseCase_parsePeriod_UnsupportedFormat(t *testing.T) {
 }
 
 func TestListSprintsUseCase_parsePeriod_FourCharNonYear(t *testing.T) {
+	t.Parallel()
 	u := NewListSprintsUseCase(nil)
 	_, _, err := u.parsePeriod("abcd")
 	assert.Error(t, err)
@@ -240,6 +249,7 @@ func TestListSprintsUseCase_parsePeriod_FourCharNonYear(t *testing.T) {
 }
 
 func TestListSprintsUseCase_filterSprintsByDateRange_InvalidDates(t *testing.T) {
+	t.Parallel()
 	u := NewListSprintsUseCase(nil)
 
 	sprints := []ports.Sprint{
@@ -274,6 +284,7 @@ func TestListSprintsUseCase_filterSprintsByDateRange_InvalidDates(t *testing.T) 
 }
 
 func TestListSprintsUseCase_Execute_EmptyProject(t *testing.T) {
+	t.Parallel()
 	mockJira := &MockJiraPort{}
 	u := NewListSprintsUseCase(mockJira)
 
@@ -283,6 +294,7 @@ func TestListSprintsUseCase_Execute_EmptyProject(t *testing.T) {
 }
 
 func TestListSprintsUseCase_Execute_EmptyPeriod(t *testing.T) {
+	t.Parallel()
 	mockJira := &MockJiraPort{}
 	u := NewListSprintsUseCase(mockJira)
 
@@ -292,6 +304,7 @@ func TestListSprintsUseCase_Execute_EmptyPeriod(t *testing.T) {
 }
 
 func TestListSprintsUseCase_Execute_JiraError(t *testing.T) {
+	t.Parallel()
 	mockJira := &MockJiraPort{
 		err: fmt.Errorf("jira api error"),
 	}
@@ -303,6 +316,7 @@ func TestListSprintsUseCase_Execute_JiraError(t *testing.T) {
 }
 
 func TestListSprintsUseCase_parseQuarter_EmptyQuarter(t *testing.T) {
+	t.Parallel()
 	u := NewListSprintsUseCase(nil)
 	_, _, err := u.parseQuarter("Q 2025")
 	assert.Error(t, err)
@@ -310,6 +324,7 @@ func TestListSprintsUseCase_parseQuarter_EmptyQuarter(t *testing.T) {
 }
 
 func TestListSprintsUseCase_parseQuarter_ValidQuarters(t *testing.T) {
+	t.Parallel()
 	u := NewListSprintsUseCase(nil)
 
 	tests := []struct {

--- a/internal/sprint/application/usecase/push_allocation_test.go
+++ b/internal/sprint/application/usecase/push_allocation_test.go
@@ -88,6 +88,7 @@ func floatPtr(v float64) *float64 {
 }
 
 func TestPushAllocationUseCase_EmptyFieldsGetUpdated(t *testing.T) {
+	t.Parallel()
 	mock := &mockJiraPortForPush{
 		fetchResults: map[string]*ports.CustomFieldValues{
 			"COP-1": {},
@@ -115,6 +116,7 @@ func TestPushAllocationUseCase_EmptyFieldsGetUpdated(t *testing.T) {
 }
 
 func TestPushAllocationUseCase_NonEmptyFieldsSkipped(t *testing.T) {
+	t.Parallel()
 	mock := &mockJiraPortForPush{
 		fetchResults: map[string]*ports.CustomFieldValues{
 			"COP-2": {
@@ -148,6 +150,7 @@ func TestPushAllocationUseCase_NonEmptyFieldsSkipped(t *testing.T) {
 }
 
 func TestPushAllocationUseCase_DryRunDoesNotCallUpdate(t *testing.T) {
+	t.Parallel()
 	mock := &mockJiraPortForPush{
 		fetchResults: map[string]*ports.CustomFieldValues{
 			"COP-3": {},
@@ -178,6 +181,7 @@ func TestPushAllocationUseCase_DryRunDoesNotCallUpdate(t *testing.T) {
 }
 
 func TestPushAllocationUseCase_FetchErrorDoesNotStopProcessing(t *testing.T) {
+	t.Parallel()
 	mock := &mockJiraPortForPush{
 		fetchResults: map[string]*ports.CustomFieldValues{
 			"COP-5": {},
@@ -204,6 +208,7 @@ func TestPushAllocationUseCase_FetchErrorDoesNotStopProcessing(t *testing.T) {
 }
 
 func TestPushAllocationUseCase_PerFieldErrors(t *testing.T) {
+	t.Parallel()
 	mock := &mockJiraPortForPush{
 		fetchResults: map[string]*ports.CustomFieldValues{
 			"COP-6": {},
@@ -236,6 +241,7 @@ func TestPushAllocationUseCase_PerFieldErrors(t *testing.T) {
 }
 
 func TestPushAllocationUseCase_PartialUpdate(t *testing.T) {
+	t.Parallel()
 	mock := &mockJiraPortForPush{
 		fetchResults: map[string]*ports.CustomFieldValues{
 			"COP-7": {
@@ -265,6 +271,7 @@ func TestPushAllocationUseCase_PartialUpdate(t *testing.T) {
 }
 
 func TestPushAllocationUseCase_WorkStreamTitleCased(t *testing.T) {
+	t.Parallel()
 	mock := &mockJiraPortForPush{
 		fetchResults: map[string]*ports.CustomFieldValues{
 			"COP-8": {},
@@ -292,6 +299,7 @@ func TestPushAllocationUseCase_WorkStreamTitleCased(t *testing.T) {
 }
 
 func TestTitleCase(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "Product", titleCase("product"))
 	assert.Equal(t, "Operational", titleCase("operational"))
 	assert.Equal(t, "Product", titleCase("Product"))
@@ -299,6 +307,7 @@ func TestTitleCase(t *testing.T) {
 }
 
 func TestPushAllocationUseCase_AllFieldsError(t *testing.T) {
+	t.Parallel()
 	mock := &mockJiraPortForPush{
 		fetchResults: map[string]*ports.CustomFieldValues{
 			"COP-9": {},

--- a/internal/sprint/domain/coverage_lift_test.go
+++ b/internal/sprint/domain/coverage_lift_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestJiraIssue_ParentHelpers(t *testing.T) {
+	t.Parallel()
 	t.Run("issue without parent", func(t *testing.T) {
 		i := &JiraIssue{Fields: JiraFields{Parent: nil}}
 		assert.False(t, i.HasParent())
@@ -26,6 +27,7 @@ func TestJiraIssue_ParentHelpers(t *testing.T) {
 }
 
 func TestJiraIssue_IsSubTask(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		typeName string
 		want     bool
@@ -44,6 +46,7 @@ func TestJiraIssue_IsSubTask(t *testing.T) {
 }
 
 func TestJiraFields_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	t.Run("populates standard and raw fields", func(t *testing.T) {
 		payload := []byte(`{
 			"summary": "Implement feature",
@@ -73,6 +76,7 @@ func TestJiraFields_UnmarshalJSON(t *testing.T) {
 }
 
 func TestJiraIssue_EnrichCustomFields(t *testing.T) {
+	t.Parallel()
 	t.Run("nil RawFields is a safe no-op", func(t *testing.T) {
 		i := &JiraIssue{Fields: JiraFields{RawFields: nil}}
 		i.EnrichCustomFields(sharedjira.CustomFieldIDs{
@@ -125,6 +129,7 @@ func TestJiraIssue_EnrichCustomFields(t *testing.T) {
 }
 
 func TestParseMultiSelectField(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		in   interface{}
@@ -159,6 +164,7 @@ func TestParseMultiSelectField(t *testing.T) {
 }
 
 func TestParseNumericField(t *testing.T) {
+	t.Parallel()
 	t.Run("float64 returns pointer to value", func(t *testing.T) {
 		got := parseNumericField(3.5)
 		require.NotNil(t, got)
@@ -175,6 +181,7 @@ func TestParseNumericField(t *testing.T) {
 }
 
 func TestParseSingleSelectField(t *testing.T) {
+	t.Parallel()
 	t.Run("object with value returns that string", func(t *testing.T) {
 		assert.Equal(t, "Pricing", parseSingleSelectField(map[string]interface{}{"value": "Pricing"}))
 	})
@@ -187,6 +194,7 @@ func TestParseSingleSelectField(t *testing.T) {
 }
 
 func TestTeam_IsTeamMember(t *testing.T) {
+	t.Parallel()
 	team := &Team{Team: []string{"Alice", "Bob"}}
 	assert.True(t, team.IsTeamMember("Alice"))
 	assert.True(t, team.IsTeamMember("Bob"))
@@ -195,6 +203,7 @@ func TestTeam_IsTeamMember(t *testing.T) {
 }
 
 func TestTeamMap_GetTeam(t *testing.T) {
+	t.Parallel()
 	tm := TeamMap{
 		"PROJ": Team{Team: []string{"Alice"}, ExcludedIssueTypes: []string{"Experiment"}},
 	}
@@ -215,6 +224,7 @@ func TestTeamMap_GetTeam(t *testing.T) {
 }
 
 func TestStatusChangePeriod_Duration(t *testing.T) {
+	t.Parallel()
 	start := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
 
 	t.Run("zero end time returns zero duration", func(t *testing.T) {
@@ -249,6 +259,7 @@ func (f *fakeStatusChecker) IsWontDo(status, _, _ string) bool {
 }
 
 func TestStatusChangePeriod_IsWorkTimeWithStatusChecker(t *testing.T) {
+	t.Parallel()
 	scp := StatusChangePeriod{Status: "In Progress"}
 
 	t.Run("nil checker falls back to the pattern-matching path", func(t *testing.T) {
@@ -282,6 +293,7 @@ func TestStatusChangePeriod_IsWorkTimeWithStatusChecker(t *testing.T) {
 }
 
 func TestNewSprintBoundedTimeCalculatorWithStatusChecker(t *testing.T) {
+	t.Parallel()
 	checker := &fakeStatusChecker{}
 	calc := NewSprintBoundedTimeCalculatorWithStatusChecker(checker, "TEAM", "BOARD-1")
 	require.NotNil(t, calc)

--- a/internal/sprint/domain/jira_test.go
+++ b/internal/sprint/domain/jira_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestJiraChangeItem_IsStatusChange(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		item JiraChangeItem
@@ -38,6 +39,7 @@ func TestJiraChangeItem_IsStatusChange(t *testing.T) {
 }
 
 func TestJiraIssue_GetStatusChanges(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		issue JiraIssue
@@ -167,6 +169,7 @@ func TestJiraIssue_GetStatusChanges(t *testing.T) {
 }
 
 func TestJiraIssue_IsInProgress(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		issue JiraIssue
@@ -233,6 +236,7 @@ func TestJiraIssue_IsInProgress(t *testing.T) {
 }
 
 func TestJiraIssue_IsDone(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		issue JiraIssue
@@ -319,6 +323,7 @@ func TestJiraIssue_IsDone(t *testing.T) {
 }
 
 func TestJiraIssue_GetWorkType(t *testing.T) {
+	t.Parallel()
 	issue := &JiraIssue{Fields: JiraFields{Labels: []string{"cap-maintenance", "other"}}}
 	assert.Equal(t, "cap-maintenance", issue.GetWorkType())
 
@@ -333,6 +338,7 @@ func TestJiraIssue_GetWorkType(t *testing.T) {
 }
 
 func TestJiraIssue_GetAssetName(t *testing.T) {
+	t.Parallel()
 	issue := &JiraIssue{Fields: JiraFields{Labels: []string{"cap-asset-foo", "other"}}}
 	assert.Equal(t, "cap-asset-foo", issue.GetAssetName())
 

--- a/internal/sprint/domain/sprint_bounded_time_calculation_test.go
+++ b/internal/sprint/domain/sprint_bounded_time_calculation_test.go
@@ -11,6 +11,7 @@ import (
 
 // TestSprintBoundedTimeCalculation tests all scenarios for sprint-bounded time calculation
 func TestSprintBoundedTimeCalculation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                string
 		issue               JiraIssue
@@ -259,6 +260,7 @@ func TestSprintBoundedTimeCalculation(t *testing.T) {
 
 // TestSprintBoundaryValidation tests validation of sprint boundaries
 func TestSprintBoundaryValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		sprintBoundary SprintBoundary
@@ -314,6 +316,7 @@ func TestSprintBoundaryValidation(t *testing.T) {
 
 // TestTimeCalculationStrategy tests the strategy pattern implementation
 func TestTimeCalculationStrategy(t *testing.T) {
+	t.Parallel()
 	t.Run("Legacy strategy maintains backward compatibility", func(t *testing.T) {
 		issue := createIssueWithStatusChanges([]statusChange{
 			{timestamp: "2024-03-05T10:00:00.000Z", from: "To Do", to: StatusInProgress},

--- a/internal/sprint/domain/sprint_test.go
+++ b/internal/sprint/domain/sprint_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestSprint_IsActive(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
 	tomorrow := now.AddDate(0, 0, 1).Format("2006-01-02")
@@ -68,6 +69,7 @@ func TestSprint_IsActive(t *testing.T) {
 }
 
 func TestSprint_IsCompleted(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
 	tomorrow := now.AddDate(0, 0, 1).Format("2006-01-02")
@@ -126,6 +128,7 @@ func TestSprint_IsCompleted(t *testing.T) {
 }
 
 func TestSprint_GetDuration(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		sprint   Sprint
@@ -160,6 +163,7 @@ func TestSprint_GetDuration(t *testing.T) {
 }
 
 func TestSprint_GetRemainingTime(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
 	tomorrow := now.AddDate(0, 0, 1).Format("2006-01-02")
@@ -206,6 +210,7 @@ func TestSprint_GetRemainingTime(t *testing.T) {
 }
 
 func TestTeam_IsExcludedIssueType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		team      Team

--- a/internal/sprint/domain/time_calculation_test.go
+++ b/internal/sprint/domain/time_calculation_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestNewSprintBoundary(t *testing.T) {
+	t.Parallel()
 	start := time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC)
 	end := time.Date(2024, 1, 29, 18, 0, 0, 0, time.UTC)
 
@@ -21,6 +22,7 @@ func TestNewSprintBoundary(t *testing.T) {
 }
 
 func TestNewSprintBoundary_ValidationErrors(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		startDate time.Time
@@ -70,6 +72,7 @@ func TestNewSprintBoundary_ValidationErrors(t *testing.T) {
 }
 
 func TestNewWorkTimeCalculator(t *testing.T) {
+	t.Parallel()
 	strategy := NewSprintBoundedTimeCalculator()
 	calculator := NewWorkTimeCalculator(strategy)
 
@@ -77,6 +80,7 @@ func TestNewWorkTimeCalculator(t *testing.T) {
 }
 
 func TestWorkTimeCalculator_SetStrategy(t *testing.T) {
+	t.Parallel()
 	strategy1 := NewSprintBoundedTimeCalculator()
 	strategy2 := NewLegacyTimeCalculator()
 
@@ -88,6 +92,7 @@ func TestWorkTimeCalculator_SetStrategy(t *testing.T) {
 }
 
 func TestCalendarToWorkingHours(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		start    time.Time
@@ -177,6 +182,7 @@ func TestCalendarToWorkingHours(t *testing.T) {
 }
 
 func TestWorkTimeCalculator_CalculateWorkingHours(t *testing.T) {
+	t.Parallel()
 	// Create a mock issue
 	issue := JiraIssue{
 		Key: "TEST-1",

--- a/internal/tasks/application/service_test.go
+++ b/internal/tasks/application/service_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestTasksService_FetchTasks(t *testing.T) {
+	t.Parallel()
 	remoteRepo := testutil.NewMockTaskRepository()
 	localRepo := testutil.NewMockTaskRepository()
 	assetService := testutil.NewMockAssetService()
@@ -127,6 +128,7 @@ func TestTasksService_FetchTasks(t *testing.T) {
 }
 
 func TestTasksService_ClassifyTasks(t *testing.T) {
+	t.Parallel()
 	remoteRepo := testutil.NewMockTaskRepository()
 	localRepo := testutil.NewMockTaskRepository()
 	classifier := testutil.NewMockTaskClassifier()
@@ -327,6 +329,7 @@ func TestTasksService_ClassifyTasks(t *testing.T) {
 }
 
 func TestTaskService_GetTasksByAsset(t *testing.T) {
+	t.Parallel()
 	// Set up mock dependencies
 	jiraRepo := testutil.NewMockTaskRepository()
 	localRepo := testutil.NewMockTaskRepository()
@@ -420,6 +423,7 @@ func TestTaskService_GetTasksByAsset(t *testing.T) {
 }
 
 func TestTaskService_GetTasks(t *testing.T) {
+	t.Parallel()
 	// Create test tasks
 	expectedTasks := []*domain.Task{
 		{
@@ -504,6 +508,7 @@ func TestTaskService_GetTasks(t *testing.T) {
 }
 
 func TestTaskService_GetLocalRepository(t *testing.T) {
+	t.Parallel()
 	t.Run("should return the local repository", func(t *testing.T) {
 		// Set up mock dependencies
 		jiraRepo := testutil.NewMockTaskRepository()
@@ -666,6 +671,7 @@ func (s *TestableTaskServiceImpl) GetLocalRepository() ports.TaskRepository {
 }
 
 func TestTaskServiceImpl_GetTasks(t *testing.T) {
+	t.Parallel()
 	t.Run("should delegate to classify tasks use case", func(t *testing.T) {
 		// Set up mock dependencies
 		jiraRepo := testutil.NewMockTaskRepository()
@@ -727,6 +733,7 @@ func TestTaskServiceImpl_GetTasks(t *testing.T) {
 }
 
 func TestTaskService_GetTaskByKey(t *testing.T) {
+	t.Parallel()
 	t.Run("should return task when found", func(t *testing.T) {
 		// Set up mock dependencies
 		jiraRepo := testutil.NewMockTaskRepository()
@@ -811,6 +818,7 @@ func TestTaskService_GetTaskByKey(t *testing.T) {
 }
 
 func TestTaskService_FetchTaskByKey(t *testing.T) {
+	t.Parallel()
 	t.Run("should successfully fetch task by key", func(t *testing.T) {
 		// Set up mock dependencies
 		jiraRepo := testutil.NewMockTaskRepository()

--- a/internal/tasks/application/usecase/classify_tasks_test.go
+++ b/internal/tasks/application/usecase/classify_tasks_test.go
@@ -171,6 +171,7 @@ func (m *MockTaskFetcher) FetchTasks(project, sprint string) ([]*domain.Task, er
 }
 
 func TestClassifyTasksUseCase_Execute(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	tests := []struct {
@@ -314,6 +315,7 @@ func TestClassifyTasksUseCase_Execute(t *testing.T) {
 }
 
 func TestGetTasks(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("should return tasks from local repository when available", func(t *testing.T) {
@@ -495,6 +497,7 @@ func TestGetTasks(t *testing.T) {
 }
 
 func TestGetAllTasks(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("should return all tasks from local repository", func(t *testing.T) {
@@ -575,6 +578,7 @@ func TestGetAllTasks(t *testing.T) {
 }
 
 func TestGetLocalRepository(t *testing.T) {
+	t.Parallel()
 	t.Run("should return the local repository instance", func(t *testing.T) {
 		// Create mocks
 		mockLocalRepo := new(MockTaskRepository)
@@ -596,6 +600,7 @@ func TestGetLocalRepository(t *testing.T) {
 }
 
 func TestFormatWorkType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		workType domain.WorkType
@@ -637,6 +642,7 @@ func TestFormatWorkType(t *testing.T) {
 }
 
 func TestBuildLabelChanges(t *testing.T) {
+	t.Parallel()
 	// Create mocks for the use case (needed to call the method)
 	mockLocalRepo := new(MockTaskRepository)
 	mockRemoteRepo := new(MockTaskRepository)
@@ -805,6 +811,7 @@ func TestBuildLabelChanges(t *testing.T) {
 }
 
 func TestGetAssetLabel(t *testing.T) {
+	t.Parallel()
 	// Create mocks for the use case (needed to call the method)
 	mockLocalRepo := new(MockTaskRepository)
 	mockRemoteRepo := new(MockTaskRepository)
@@ -864,6 +871,7 @@ func TestGetAssetLabel(t *testing.T) {
 }
 
 func TestGetAssetLabel_WithAssetObject(t *testing.T) {
+	t.Parallel()
 	mockLocalRepo := new(MockTaskRepository)
 	mockRemoteRepo := new(MockTaskRepository)
 	mockClassifier := new(MockTaskClassifier)
@@ -902,6 +910,7 @@ func TestGetAssetLabel_WithAssetObject(t *testing.T) {
 }
 
 func TestFormatAssetLabel(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -920,6 +929,7 @@ func TestFormatAssetLabel(t *testing.T) {
 }
 
 func TestClassifyTasksComprehensive(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("should use comprehensive classification when available", func(t *testing.T) {
@@ -1060,6 +1070,7 @@ func TestClassifyTasksComprehensive(t *testing.T) {
 }
 
 func TestClassifyTasksEdgeCases(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("should handle classification with empty tasks", func(t *testing.T) {
@@ -1320,6 +1331,7 @@ func TestClassifyTasksEdgeCases(t *testing.T) {
 }
 
 func TestPreviewClassificationsWithAssetSync(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("should trigger asset sync when unassigned tasks found in comprehensive preview", func(t *testing.T) {
@@ -1634,6 +1646,7 @@ func TestPreviewClassificationsWithAssetSync(t *testing.T) {
 }
 
 func TestAdditionalErrorHandlingAndEdgeCases(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("should handle UpdateWorkType error during classification", func(t *testing.T) {
@@ -2006,6 +2019,7 @@ func TestAdditionalErrorHandlingAndEdgeCases(t *testing.T) {
 }
 
 func TestSortingAndDisplayLogic(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("should sort tasks alphabetically during classification", func(t *testing.T) {
@@ -2296,6 +2310,7 @@ func (m *MockSprintLockRepository) SaveLock(ctx context.Context, lock *domain.Sp
 }
 
 func TestSprintLockBehavior(t *testing.T) {
+	t.Parallel()
 	tasks := []*domain.Task{
 		{Key: "TEST-1", Summary: "Task 1", Labels: []string{"cap-asset-test"}},
 	}

--- a/internal/tasks/application/usecase/fetch_tasks_test.go
+++ b/internal/tasks/application/usecase/fetch_tasks_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestFetchTasksUseCase(t *testing.T) {
+	t.Parallel()
 	// Create mock repositories
 	remoteRepo := testutil.NewMockTaskRepository()
 	localRepo := testutil.NewMockTaskRepository()
@@ -137,6 +138,7 @@ func TestFetchTasksUseCase(t *testing.T) {
 }
 
 func TestFetchTasksUseCase_ExecuteByKey(t *testing.T) {
+	t.Parallel()
 	// Create mock repositories
 	remoteRepo := testutil.NewMockTaskRepository()
 	localRepo := testutil.NewMockTaskRepository()
@@ -250,6 +252,7 @@ func TestFetchTasksUseCase_ExecuteByKey(t *testing.T) {
 }
 
 func TestFetchTasksUseCase_GetRemoteRepository(t *testing.T) {
+	t.Parallel()
 	// Create mock repositories
 	remoteRepo := testutil.NewMockTaskRepository()
 	localRepo := testutil.NewMockTaskRepository()
@@ -264,6 +267,7 @@ func TestFetchTasksUseCase_GetRemoteRepository(t *testing.T) {
 }
 
 func TestFetchTasksUseCase_EdgeCases(t *testing.T) {
+	t.Parallel()
 	t.Run("should handle nil task from remote repository", func(t *testing.T) {
 		// Create mock repositories
 		remoteRepo := testutil.NewMockTaskRepository()

--- a/internal/tasks/application/usecase/sprint_resolver_test.go
+++ b/internal/tasks/application/usecase/sprint_resolver_test.go
@@ -88,6 +88,7 @@ func (m *mockSelectionPort) SelectSprint(candidates []ports.SprintCandidate) (*s
 }
 
 func TestSprintResolver_ResolveSprint(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("empty sprint name should return error", func(t *testing.T) {
@@ -208,6 +209,7 @@ func TestSprintResolver_ResolveSprint(t *testing.T) {
 }
 
 func TestSprintResolver_NormalizeSprintName(t *testing.T) {
+	t.Parallel()
 	resolver := NewSprintResolver(nil, nil)
 
 	tests := []struct {
@@ -256,6 +258,7 @@ func TestSprintResolver_NormalizeSprintName(t *testing.T) {
 }
 
 func TestSprintResolver_RemoveEmojis(t *testing.T) {
+	t.Parallel()
 	resolver := NewSprintResolver(nil, nil)
 
 	tests := []struct {
@@ -299,6 +302,7 @@ func TestSprintResolver_RemoveEmojis(t *testing.T) {
 }
 
 func TestSprintResolver_CalculateSimilarity(t *testing.T) {
+	t.Parallel()
 	resolver := NewSprintResolver(nil, nil)
 
 	tests := []struct {
@@ -354,6 +358,7 @@ func TestSprintResolver_CalculateSimilarity(t *testing.T) {
 }
 
 func TestSprintResolver_FindSprintCandidates(t *testing.T) {
+	t.Parallel()
 	resolver := NewSprintResolver(nil, nil)
 
 	sprints := []sprintPorts.Sprint{
@@ -426,6 +431,7 @@ func TestSprintResolver_FindSprintCandidates(t *testing.T) {
 }
 
 func TestSprintResolver_LevenshteinDistance(t *testing.T) {
+	t.Parallel()
 	resolver := NewSprintResolver(nil, nil)
 
 	tests := []struct {

--- a/internal/tasks/application/usecase/testutil/mock_asset_service_test.go
+++ b/internal/tasks/application/usecase/testutil/mock_asset_service_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestMockAssetService_DefaultBehavior(t *testing.T) {
+	t.Parallel()
 	mock := NewMockAssetService()
 
 	// Test default behavior (should not panic and return sensible defaults)
@@ -77,6 +78,7 @@ func TestMockAssetService_DefaultBehavior(t *testing.T) {
 }
 
 func TestMockAssetService_CustomBehavior(t *testing.T) {
+	t.Parallel()
 	mock := NewMockAssetService()
 
 	// Test custom behavior through function setters
@@ -142,6 +144,7 @@ func TestMockAssetService_CustomBehavior(t *testing.T) {
 }
 
 func TestMockAssetService_Reset(t *testing.T) {
+	t.Parallel()
 	mock := NewMockAssetService()
 
 	// Set custom functions
@@ -185,6 +188,7 @@ func TestMockAssetService_Reset(t *testing.T) {
 }
 
 func TestMockAssetService_PublishToConfluence(t *testing.T) {
+	t.Parallel()
 	mock := NewMockAssetService()
 
 	// Test default behavior (returns nil, nil)
@@ -198,6 +202,7 @@ func TestMockAssetService_PublishToConfluence(t *testing.T) {
 }
 
 func TestMockAssetService_UpdateConfluencePage(t *testing.T) {
+	t.Parallel()
 	mock := NewMockAssetService()
 
 	// Test default behavior (returns nil, nil)
@@ -211,6 +216,7 @@ func TestMockAssetService_UpdateConfluencePage(t *testing.T) {
 }
 
 func TestMockAssetService_TeamOperations(t *testing.T) {
+	t.Parallel()
 	mock := NewMockAssetService()
 
 	// Test default behavior for team operations

--- a/internal/tasks/domain/ports/task_repository_test.go
+++ b/internal/tasks/domain/ports/task_repository_test.go
@@ -150,6 +150,7 @@ func (m *mockRepository) UpdateLabels(_ context.Context, taskKey string, addLabe
 var _ TaskRepository = (*mockRepository)(nil)
 
 func TestRepositoryOperations(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	repo := newMockRepository()
 

--- a/internal/tasks/domain/sprint_lock_test.go
+++ b/internal/tasks/domain/sprint_lock_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestSprintLockKey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		project  string
@@ -43,6 +44,7 @@ func TestSprintLockKey(t *testing.T) {
 }
 
 func TestNewSprintLock(t *testing.T) {
+	t.Parallel()
 	before := time.Now()
 	lock := NewSprintLock("COP", "Sprint 1", 5)
 	after := time.Now()
@@ -55,6 +57,7 @@ func TestNewSprintLock(t *testing.T) {
 }
 
 func TestSprintLock_Key(t *testing.T) {
+	t.Parallel()
 	lock := &SprintLock{
 		Project:   "COP",
 		Sprint:    "Sprint 1",

--- a/internal/tasks/domain/task_test.go
+++ b/internal/tasks/domain/task_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestNewTask(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		key      string
@@ -127,6 +128,7 @@ func TestNewTask(t *testing.T) {
 }
 
 func TestNewTaskWithSprints(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		key      string
@@ -245,6 +247,7 @@ func TestNewTaskWithSprints(t *testing.T) {
 }
 
 func TestGetSprints(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		task            *Task
@@ -295,6 +298,7 @@ func TestGetSprints(t *testing.T) {
 }
 
 func TestGetPrimarySprint(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		task            *Task
@@ -337,6 +341,7 @@ func TestGetPrimarySprint(t *testing.T) {
 }
 
 func TestHasSprint(t *testing.T) {
+	t.Parallel()
 	task := &Task{
 		Sprints: []string{"Sprint 1", "Sprint 2", "Sprint 3"},
 		Sprint:  "Sprint 1, Sprint 2, Sprint 3",
@@ -383,6 +388,7 @@ func TestHasSprint(t *testing.T) {
 }
 
 func TestSetSprints(t *testing.T) {
+	t.Parallel()
 	task := &Task{
 		Key:     "TEST-1",
 		Version: 1,
@@ -398,6 +404,7 @@ func TestSetSprints(t *testing.T) {
 }
 
 func TestAddSprint(t *testing.T) {
+	t.Parallel()
 	task := &Task{
 		Key:     "TEST-1",
 		Sprints: []string{"Sprint 1"},
@@ -419,6 +426,7 @@ func TestAddSprint(t *testing.T) {
 }
 
 func TestRemoveSprint(t *testing.T) {
+	t.Parallel()
 	task := &Task{
 		Key:     "TEST-1",
 		Sprints: []string{"Sprint 1", "Sprint 2", "Sprint 3"},
@@ -440,6 +448,7 @@ func TestRemoveSprint(t *testing.T) {
 }
 
 func TestJSONMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		task *Task
@@ -494,6 +503,7 @@ func TestJSONMarshalUnmarshal(t *testing.T) {
 }
 
 func TestJSONBackwardCompatibility(t *testing.T) {
+	t.Parallel()
 	// Test unmarshaling legacy JSON format (only sprint field)
 	legacyJSON := `{
 		"key": "TEST-1",
@@ -525,6 +535,7 @@ func TestJSONBackwardCompatibility(t *testing.T) {
 }
 
 func TestJSONForwardCompatibility(t *testing.T) {
+	t.Parallel()
 	// Test marshaling new format and ensuring Sprint field is populated
 	task := &Task{
 		Key:     "TEST-1",
@@ -552,6 +563,7 @@ func TestJSONForwardCompatibility(t *testing.T) {
 }
 
 func TestUpdateStatus(t *testing.T) {
+	t.Parallel()
 	task, err := NewTask("TEST-1", "Test task", "TEST", "Sprint 1", "jira")
 	require.NoError(t, err)
 
@@ -613,6 +625,7 @@ func TestUpdateStatus(t *testing.T) {
 }
 
 func TestUpdateType(t *testing.T) {
+	t.Parallel()
 	task, err := NewTask("TEST-1", "Test task", "TEST", "Sprint 1", "jira")
 	require.NoError(t, err)
 
@@ -680,6 +693,7 @@ func TestUpdateType(t *testing.T) {
 }
 
 func TestUpdatePriority(t *testing.T) {
+	t.Parallel()
 	task, err := NewTask("TEST-1", "Test task", "TEST", "Sprint 1", "jira")
 	require.NoError(t, err)
 
@@ -747,6 +761,7 @@ func TestUpdatePriority(t *testing.T) {
 }
 
 func TestUpdateDescription(t *testing.T) {
+	t.Parallel()
 	task, err := NewTask("TEST-1", "Test task", "TEST", "Sprint 1", "jira")
 	require.NoError(t, err)
 
@@ -759,6 +774,7 @@ func TestUpdateDescription(t *testing.T) {
 }
 
 func TestStatusChecks(t *testing.T) {
+	t.Parallel()
 	task, err := NewTask("TEST-1", "Test task", "TEST", "Sprint 1", "jira")
 	require.NoError(t, err)
 
@@ -794,6 +810,7 @@ func TestStatusChecks(t *testing.T) {
 }
 
 func TestTask_UpdateWorkType(t *testing.T) {
+	t.Parallel()
 	task, err := NewTask("TEST-1", "Test Task", "TEST", "Sprint 1", "web")
 	require.NoError(t, err)
 
@@ -884,6 +901,7 @@ func TestTask_UpdateWorkType(t *testing.T) {
 }
 
 func TestNewTaskWithoutSprint(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		key         string


### PR DESCRIPTION
## Summary

Adds \`t.Parallel()\` to every top-level \`Test\` function in \`internal/*/domain\` and \`internal/*/application\` that's safe to run in parallel — i.e. doesn't mutate process state (no \`os.Setenv\`, \`t.Setenv\`, or \`os.Chdir\`).

**Why only top-level**: subtests in this codebase often share parent-scope state via closure (e.g. \`TestAsset_GetVersion\`'s subtests all probe a single \`asset\` built once at the top). Parallelising those subtests surfaces real shared-state races but would require larger refactors. Top-level parallelism captures most of the value without the risk.

## Coverage
- 27 domain test files
- 41 application test files (4 excluded for env-var mutation)
- **447 lines added across 69 files** — pure \`t.Parallel()\` calls, no other changes

## What this unlocks
The wall-clock improvement on a fresh \`go test ./...\` is modest because \`go test\` already runs packages in parallel at GOMAXPROCS. The bigger prize: \`go test -race ./...\` now exercises significantly more concurrent test paths — which is how shared-state bugs typically surface.

During development of this PR, the race detector actually caught one such bug: when applied indiscriminately to subtests, \`TestAsset_GetVersion\` failed because three subtests share a single asset instance. We backed off to top-level-only as a result, but the underlying shared-state pattern in those subtests is now flagged for follow-up.

## Test plan
- [x] \`go test ./...\` passes
- [x] \`go test -race ./...\` passes (zero races detected)
- [x] \`golangci-lint run\` clean