### PR TITLE
test(llama): make timeout test deterministic, kill 1.5s retry backoff

### DIFF
--- a/internal/assets/infrastructure/llama/client_test.go
+++ b/internal/assets/infrastructure/llama/client_test.go
@@ -263,13 +263,22 @@ func TestNewClientTimeout(t *testing.T) {
 	})
 
 	t.Run("aborts requests that exceed the timeout", func(t *testing.T) {
+		// The handler delays past the configured client timeout. Disable
+		// retries (MaxAttempts: 1) and tighten BackoffBase so the test
+		// reports the first-attempt timeout immediately rather than
+		// waiting through the default 500ms+1s retry backoff schedule.
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			time.Sleep(200 * time.Millisecond)
 			w.WriteHeader(http.StatusOK)
 		}))
 		defer server.Close()
 
-		client, err := NewClient(Config{BaseURL: server.URL, Timeout: 25 * time.Millisecond})
+		client, err := NewClient(Config{
+			BaseURL:     server.URL,
+			Timeout:     25 * time.Millisecond,
+			MaxAttempts: 1,
+			BackoffBase: time.Microsecond,
+		})
 		require.NoError(t, err)
 
 		_, err = client.GenerateEmbeddings("llama3", []string{"hello"})


### PR DESCRIPTION
## Summary

\`TestNewClientTimeout\`'s "aborts requests that exceed the timeout" subtest was on the audit list as a "remove the time.Sleep" target. After investigation, the 200ms server-side sleep **isn't** the source of slowness or flakiness — the http.Client's 25ms timeout aborts the request long before that fires.

The real culprit was the **default retry policy**: NewClient inherits \`DefaultMaxAttempts=3\` and \`DefaultBackoffBase=500ms\`, so every invocation waits through ~1.5s of dead time (500ms backoff before attempt 2, 1s before attempt 3) on top of the three 25ms attempt windows. That's where the ~1.6s baseline came from.

## Fix

Override \`MaxAttempts: 1\` (no retries — the test verifies a single attempt's timeout behaviour, not retry semantics) and \`BackoffBase: time.Microsecond\` so any future retry tuning can't reintroduce the wait.

## Results

- End-to-end \`TestNewClientTimeout\` runtime: **1.6s → 0.42s** (3.8×)
- Race-hang risk on slow CI: removed
- Test semantics: unchanged — still verifies the configured \`Timeout\` aborts in-flight requests

## Test plan
- [x] \`go test -count=1 ./internal/assets/infrastructure/llama/\` passes in 0.4s
- [x] \`go test -race ./...\` passes