### PR TITLE
test: add Example* tests for key domain types

### DIFF
--- a/internal/assets/domain/example_test.go
+++ b/internal/assets/domain/example_test.go
@@ -1,0 +1,43 @@
+package domain_test
+
+import (
+	"fmt"
+
+	"github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
+)
+
+// ExampleNewAsset shows the canonical constructor. A fresh asset
+// starts at version 1 with zero associated tasks.
+func ExampleNewAsset() {
+	asset, err := domain.NewAsset("Search", "Search subsystem ranking and indexing")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(asset.Name, "v"+fmt.Sprint(asset.GetVersion()), "tasks:", asset.GetTaskCount())
+	// Output: Search v1 tasks: 0
+}
+
+// ExampleAsset_IncrementTaskCount demonstrates the version bump that
+// rides along with every state-changing operation, keeping consumers
+// honest about optimistic concurrency.
+func ExampleAsset_IncrementTaskCount() {
+	asset, _ := domain.NewAsset("Search", "x")
+	_ = asset.IncrementTaskCount()
+	_ = asset.IncrementTaskCount()
+	fmt.Println("tasks:", asset.GetTaskCount(), "version:", asset.GetVersion())
+	// Output: tasks: 2 version: 3
+}
+
+// ExampleAsset_AddContributingTeam shows the team set semantics: each
+// team only appears once even if added repeatedly, mirroring the
+// owning-team / contributing-teams shape rendered on the asset page.
+func ExampleAsset_AddContributingTeam() {
+	asset, _ := domain.NewAsset("Search", "x")
+	_ = asset.SetOwningTeam("Voyager")
+	_ = asset.AddContributingTeam("Catalog")
+	_ = asset.AddContributingTeam("Catalog") // duplicate -- no-op
+	_ = asset.AddContributingTeam("Indexer")
+	fmt.Println("owner:", asset.GetOwningTeam(), "contributors:", asset.ContributingTeams)
+	// Output: owner: Voyager contributors: [Catalog Indexer]
+}

--- a/internal/console/domain/example_test.go
+++ b/internal/console/domain/example_test.go
@@ -1,0 +1,41 @@
+package domain_test
+
+import (
+	"fmt"
+
+	"github.com/helmedeiros/digital-asset-capitalization/internal/console/domain"
+)
+
+// ExampleNewContext shows the empty starting state of a console
+// session: no assets, no tasks, no project, no sprint.
+func ExampleNewContext() {
+	ctx := domain.NewContext("session-42")
+	fmt.Println("session:", ctx.SessionID,
+		"assets:", len(ctx.RecentAssets),
+		"tasks:", len(ctx.RecentTasks))
+	// Output: session: session-42 assets: 0 tasks: 0
+}
+
+// ExampleContext_UpdateTaskContext shows the recency list semantics:
+// LRU-style head-insertion with deduplication and a cap of 5 entries.
+func ExampleContext_UpdateTaskContext() {
+	ctx := domain.NewContext("s")
+	for _, key := range []string{"T-1", "T-2", "T-3", "T-1"} { // T-1 mentioned twice
+		ctx.UpdateTaskContext(key, nil)
+	}
+	fmt.Println(ctx.RecentTasks)
+	// Output: [T-1 T-3 T-2]
+}
+
+// ExampleContext_SetVariable demonstrates the typed-but-untyped scratch
+// space the AI console uses for conversational follow-ups. Values
+// returned from GetVariable carry their concrete type via the
+// interface{} return.
+func ExampleContext_SetVariable() {
+	ctx := domain.NewContext("s")
+	ctx.SetVariable("last_count", 42)
+	if v, ok := ctx.GetVariable("last_count"); ok {
+		fmt.Printf("%v (%T)\n", v, v)
+	}
+	// Output: 42 (int)
+}

--- a/internal/investment/domain/example_test.go
+++ b/internal/investment/domain/example_test.go
@@ -1,0 +1,57 @@
+package domain_test
+
+import (
+	"fmt"
+
+	"github.com/helmedeiros/digital-asset-capitalization/internal/investment/domain"
+)
+
+// ExampleNewMoney shows the common shape: build a Money, print it
+// using the String() method so the formatting contract stays pinned.
+func ExampleNewMoney() {
+	cost := domain.NewMoney(199.99, domain.EUR)
+	fmt.Println(cost)
+	// Output: 199.99 EUR
+}
+
+// ExampleMoney_Add demonstrates same-currency addition; mismatched
+// currencies fall through to the receiver unchanged rather than
+// silently converting.
+func ExampleMoney_Add() {
+	dev := domain.NewMoney(1500, domain.EUR)
+	infra := domain.NewMoney(250, domain.EUR)
+	total := dev.Add(infra)
+	fmt.Println(total)
+	// Output: 1750.00 EUR
+}
+
+// ExampleMoney_Multiply is how the cost model applies an overhead
+// multiplier — the Currency travels through unchanged.
+func ExampleMoney_Multiply() {
+	base := domain.NewMoney(1000, domain.USD)
+	withOverhead := base.Multiply(2.0)
+	fmt.Println(withOverhead)
+	// Output: 2000.00 USD
+}
+
+// ExampleNewCostModel shows the minimum valid construction: working
+// hours must be > 0 and overhead must be >= 1.0.
+func ExampleNewCostModel() {
+	cm, err := domain.NewCostModel(domain.EUR, 8.0, 2.0)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Printf("currency=%s workingHours=%.1f overhead=%.1fx\n",
+		cm.Currency, cm.WorkingHoursPerDay, cm.OverheadMultiplier)
+	// Output: currency=EUR workingHours=8.0 overhead=2.0x
+}
+
+// ExampleCostModel_InferEngineerLevel falls back to fixed rate ranges
+// when no defaults are configured: 30/hour maps to Junior.
+func ExampleCostModel_InferEngineerLevel() {
+	cm, _ := domain.NewCostModel(domain.EUR, 8.0, 2.0)
+	level := cm.InferEngineerLevel(30.0)
+	fmt.Println(level)
+	// Output: junior
+}


### PR DESCRIPTION
## Summary

Go's testing framework runs \`Example\` functions as tests AND surfaces them in \`go doc\`, so they serve double duty as **runnable usage documentation that can never drift from the code**.

Added **11 examples across three foundational domain packages**:

- \`investment/domain\` (5): \`NewMoney\`, \`Money.Add\` (same-currency, mismatch ignored), \`Money.Multiply\` (overhead pattern), \`NewCostModel\`, and \`CostModel.InferEngineerLevel\` rate-range fallback.

- \`assets/domain\` (3): \`NewAsset\` starting state (v1, 0 tasks), \`IncrementTaskCount\` version-bump-per-mutation contract, and \`AddContributingTeam\` idempotent set semantics.

- \`console/domain\` (3): \`NewContext\` empty state, \`UpdateTaskContext\` LRU-with-dedup recency list (cap 5), and \`SetVariable\` interface{}-preserves-concrete-type contract.

## Design notes

Examples use external test packages (\`domain_test\`) so they exercise the **public API** the way a downstream caller would. Each \`// Output:\` comment pins runtime behaviour — any change to printing or numeric formatting fails the test.

## Test plan
- [x] \`go test ./...\` passes
- [x] \`golangci-lint run\` clean
- [x] \`go test -v -run Example ./internal/{investment,assets,console}/domain/\` — 11 PASS