### PR TITLE
test(cmd): pin every extracted command's --help as golden fixtures

### DIFF
--- a/cmd/golden_fixtures/assets.help.txt
+++ b/cmd/golden_fixtures/assets.help.txt
@@ -1,0 +1,26 @@
+NAME:
+   AssetCap assets - Manage digital assets
+
+USAGE:
+   AssetCap assets [command options]
+
+COMMANDS:
+   create             Create a new asset
+   delete             Delete an existing asset
+   list               List all assets
+   sync               Sync assets from Confluence
+   publish            Publish an asset to Confluence as a new page
+   update-confluence  Update an existing Confluence page with the asset's current content
+   update             Update an asset's description
+   show               Show detailed information about an asset
+   documentation      Manage asset documentation
+   tasks              Manage asset tasks
+   enrich             Enrich asset fields using LLaMA 3
+   keywords           Generate keywords for an asset using LLaMA 3
+   sync-and-enrich    Sync assets from Confluence and enrich them with keywords and fields using AI
+   sync-contributors  Synchronize asset contributors from JIRA task assignments with optional filtering
+   teams              Manage asset team assignments
+   help, h            Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help

--- a/cmd/golden_fixtures/completion.help.txt
+++ b/cmd/golden_fixtures/completion.help.txt
@@ -1,0 +1,14 @@
+NAME:
+   AssetCap completion - Generate shell completion scripts
+
+USAGE:
+   AssetCap completion [command options]
+
+COMMANDS:
+   bash     Generate bash completion script
+   zsh      Generate zsh completion script
+   fish     Generate fish completion script
+   help, h  Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help

--- a/cmd/golden_fixtures/config.help.txt
+++ b/cmd/golden_fixtures/config.help.txt
@@ -1,0 +1,21 @@
+NAME:
+   AssetCap config - Manage configuration settings
+
+USAGE:
+   AssetCap config [command options]
+
+COMMANDS:
+   init                  Initialize configuration
+   show                  Show current configuration
+   validate              Validate current configuration
+   sync-team             Synchronize team members from JIRA for a project
+   team-nicknames        Manage team nicknames
+   team-tribe            Manage team tribes (organizational groupings)
+   team-company          Manage team companies (organization ownership)
+   board-work-streams    Manage board-to-workstream mappings per project
+   excluded-issue-types  Manage excluded issue types for sprint allocation per project
+   team-timeline         Manage team member timeline (join/leave dates) for time-aware sprint allocation
+   help, h               Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help

--- a/cmd/golden_fixtures/deployments.help.txt
+++ b/cmd/golden_fixtures/deployments.help.txt
@@ -1,0 +1,16 @@
+NAME:
+   AssetCap deployments - Manage deployment tracking
+
+USAGE:
+   AssetCap deployments [command options]
+
+COMMANDS:
+   record    Record a new deployment
+   list      List deployments
+   history   Show deployment history for an asset
+   timeline  Show deployment timeline for a time range
+   mock      Generate mock deployment data for testing
+   help, h   Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help

--- a/cmd/golden_fixtures/investment.help.txt
+++ b/cmd/golden_fixtures/investment.help.txt
@@ -1,0 +1,17 @@
+NAME:
+   AssetCap investment - Calculate investment costs for digital assets
+
+USAGE:
+   AssetCap investment [command options]
+
+COMMANDS:
+   calculate          Calculate investment for an asset across sprints
+   sprint             Calculate investment for a specific sprint
+   list               List all saved investment calculations
+   init-cost-model    Initialize cost model for a project
+   set-engineer-rate  Set hourly rate for a specific engineer
+   show-rates         Show current engineer rates for a project
+   help, h            Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help

--- a/cmd/golden_fixtures/sprint.help.txt
+++ b/cmd/golden_fixtures/sprint.help.txt
@@ -1,0 +1,13 @@
+NAME:
+   AssetCap sprint - Manage sprint-related operations
+
+USAGE:
+   AssetCap sprint [command options]
+
+COMMANDS:
+   list      List sprints for a project and time period
+   allocate  Calculate time allocation for JIRA issues in a sprint
+   help, h   Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help

--- a/cmd/golden_fixtures/tasks.help.txt
+++ b/cmd/golden_fixtures/tasks.help.txt
@@ -1,0 +1,16 @@
+NAME:
+   AssetCap tasks - Manage tasks from various platforms
+
+USAGE:
+   AssetCap tasks [command options]
+
+COMMANDS:
+   fetch     Fetch tasks from a platform (e.g., Jira)
+   show      Show tasks for a project and sprint
+   classify  Classify tasks for a specific project and sprint
+   inspect   Inspect a specific task by its key
+   migrate   Migrate sprint data from comma-separated strings to arrays
+   help, h   Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help

--- a/cmd/golden_fixtures/version.help.txt
+++ b/cmd/golden_fixtures/version.help.txt
@@ -1,0 +1,8 @@
+NAME:
+   AssetCap version - Show version information
+
+USAGE:
+   AssetCap version [command options]
+
+OPTIONS:
+   --help, -h  show help

--- a/cmd/golden_help_test.go
+++ b/cmd/golden_help_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+// updateGolden flips the test from "assert equal" to "rewrite the
+// fixture". Run with `go test ./cmd/ -update-golden` after an
+// intentional CLI behaviour change.
+var updateGolden = flag.Bool("update-golden", false, "rewrite golden help files")
+
+// TestHelpOutputsAreGolden pins the --help output of every command
+// group extracted from cmd/main.go. Together with the scientific
+// validation we ran during the split, this turns the byte-level
+// equivalence we manually verified into a permanent regression test.
+//
+// To update after an intentional change:
+//
+//	go test ./cmd/ -update-golden -run TestHelpOutputsAreGolden
+func TestHelpOutputsAreGolden(t *testing.T) {
+	// A bare App with the field defaults needed for each createXxx
+	// helper. We don't wire any service so an Action-triggered call
+	// would crash, but `--help` short-circuits Action entirely.
+	a := &App{}
+
+	cases := []struct {
+		name    string
+		command *cli.Command
+	}{
+		{"version", a.createVersionCommand()},
+		{"completion", a.createCompletionCommand()},
+		{"sprint", a.createSprintCommand()},
+		{"tasks", a.createTasksCommand()},
+		{"assets", a.createAssetsCommand()},
+		{"investment", a.createInvestmentCommand()},
+		{"config", a.createConfigCommand()},
+		{"deployments", a.createDeploymentCommands()},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := captureHelp(t, c.command)
+			path := filepath.Join("golden_fixtures", c.name+".help.txt")
+			if *updateGolden {
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					t.Fatalf("mkdir golden dir: %v", err)
+				}
+				if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+				return
+			}
+			want, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read golden %s: %v (run with -update-golden to create)", path, err)
+			}
+			if string(want) != got {
+				t.Errorf("help output drift for %s.\nDiff (first 1000 chars of each):\nwant:\n%s\n---\ngot:\n%s",
+					c.name, truncate(string(want), 1000), truncate(got, 1000))
+			}
+		})
+	}
+}
+
+// captureHelp runs a one-command throwaway App against
+// `<command> --help` and returns the stdout. urfave/cli's help
+// writer is taken from App.Writer so a bytes.Buffer redirects it.
+func captureHelp(t *testing.T, cmd *cli.Command) string {
+	t.Helper()
+	var buf bytes.Buffer
+	app := &cli.App{
+		Name:     "AssetCap",
+		Writer:   &buf,
+		Commands: []*cli.Command{cmd},
+	}
+	if err := app.Run([]string{"AssetCap", cmd.Name, "--help"}); err != nil {
+		t.Fatalf("running %s --help: %v", cmd.Name, err)
+	}
+	return buf.String()
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...<truncated>"
+}
+
+// init: keep gofmt happy that strings is used in non-truncated paths
+// when -update-golden flips on. The reference also serves as a hook
+// for future help-format normalisation (e.g. stripping ANSI codes).
+var _ = strings.TrimSpace


### PR DESCRIPTION
## Summary

During the six-PR \`cmd/main.go\` split we scientifically verified that every command group's \`--help\` output stayed byte-identical to the pre-split binary. That verification was a one-shot manual protocol — this commit makes it permanent.

Adds \`TestHelpOutputsAreGolden\` in \`cmd/\` which runs each \`createXxxCommand()\` helper through a throwaway \`cli.App\` with a Writer buffer, captures \`<group> --help\` output, and diffs against fixtures under \`cmd/golden_fixtures/\`.

The eight groups (version, completion, sprint, tasks, assets, investment, config, deployments) each get their own \`.help.txt\` fixture.

## Updating after intentional changes

\`\`\`
go test ./cmd/ -update-golden -run TestHelpOutputsAreGolden
\`\`\`

## Why golden_fixtures/ instead of testdata/

Go convention is \`testdata/\`, but this repo's \`.gitignore\` excludes \`testdata/\` for runtime-generated files. A negation pattern (\`!testdata/golden/\`) wouldn't work either — \`git\` doesn't recurse into ignored directories. Rather than carving an exception that silently fails on \`git add\`, the fixtures live next to the test under a name that's obviously not generated.

## Test plan
- [x] \`go test ./cmd/\` passes
- [x] \`go test ./cmd/ -update-golden\` regenerates cleanly
- [x] \`golangci-lint run\` clean
- [x] Re-running tests after regeneration: still passes