### PR TITLE
chore: harden pre-push hook with -race and 78% gate; document patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,10 +150,47 @@ The `excluded_issue_types` field controls which JIRA issue types are skipped dur
 
 ## Testing
 
-- Domain layer: >90% coverage required
-- Application layer: >80% coverage required  
-- Infrastructure layer: >80% coverage required
-- Overall coverage: >70% required
+### Coverage targets
+
+- Domain layer: >90% (architectural requirement)
+- Application layer: >80% (architectural requirement)
+- Infrastructure layer: >80% (architectural requirement)
+- **Overall coverage: >78% enforced by `scripts/coverage-gate.sh`**
+
+The gate runs `go test -race` so a parallel-test data race fails the pre-push hook instead of failing CI later.
+
+### Test conventions established in this repo
+
+**`t.Parallel()`** — top-level `Test*` functions in `internal/*/domain/` and `internal/*/application/` opt in via `t.Parallel()`. Subtests usually share parent-scope state via closure and are kept serial; if you write a self-contained subtest, feel free to add `t.Parallel()` to it too. Avoid `t.Parallel()` in tests that mutate process state (`os.Setenv`, `os.Chdir`).
+
+**Example tests** — `Example*` functions in `<package>_test` external test packages double as runnable docs surfaced by `go doc`. The `// Output:` comment pins the formatted result. See `internal/investment/domain/example_test.go` for the pattern.
+
+**CLI golden fixtures** — `cmd/golden_help_test.go` snapshots every command group's `--help` against fixtures in `cmd/golden_fixtures/`. After an intentional CLI change, regenerate with:
+
+```bash
+go test ./cmd/ -update-golden -run TestHelpOutputsAreGolden
+```
+
+These live under `cmd/golden_fixtures/` rather than the Go-conventional `cmd/testdata/` because the repo's `.gitignore` excludes `testdata/` for runtime-generated files.
+
+**Benchmarks** — `*_benchmark_test.go` files hold `Benchmark*` functions for hot paths (cosine similarity, classifier inheritance, Confluence HTML rendering). They do not run under `go test ./...` (the `-bench` flag is opt-in). To compare two branches:
+
+```bash
+go test -bench=. -benchtime=2s -count=5 ./internal/tasks/infrastructure/classifier/ > new.txt
+# checkout old branch, repeat
+benchstat old.txt new.txt
+```
+
+**Stub vs testify mock** — testify mocks are NOT concurrent-safe. For tests that run in parallel or use `-race`, prefer small hand-rolled stubs implementing the port interface. See `internal/tasks/infrastructure/classifier/inherit_from_parent_test.go` for the stub pattern.
+
+## CLI command extraction pattern
+
+`cmd/main.go` used to be 3,374 lines of inline `urfave/cli` `Action` closures. It now holds the bootstrap (~455 lines); every command group lives in its own `cmd/<group>_commands.go` file behind a `(a *App) create<Group>Command() *cli.Command` method. When adding a new top-level command:
+
+1. Create `cmd/<name>_commands.go` with a `create<Name>Command()` method.
+2. Reference it from the `Commands` slice in `App.Run()` in `cmd/main.go`.
+3. Move any single-use imports (e.g. `errgroup`, package-specific domain types) into the new file. Imports shared with other command groups stay in `cmd/main.go`.
+4. Regenerate the golden help fixture: `go test ./cmd/ -update-golden`.
 
 ## Architecture Guidelines
 

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -1,18 +1,26 @@
 #!/bin/bash
 set -e
 
+# Minimum coverage the gate enforces. We sit at ~80.4% as of this
+# writing; the threshold is set a few points below that so contributors
+# have headroom for genuinely-untestable wiring without it slipping
+# silently below 80%.
+THRESHOLD=78
+
 echo "Running coverage quality gate check..."
 # Plain `go test` instead of gotestsum: CI uses go test here too, and
 # the gate only needs the coverage profile — gotestsum's formatted
-# output was being discarded with `> /dev/null 2>&1` either way.
-go test -coverprofile=coverage.out ./... > /dev/null 2>&1
+# output was being discarded with `> /dev/null 2>&1` either way. The
+# -race flag turns this same run into a race-detector sweep so a
+# parallel-test data race fails pre-push instead of fails CI.
+go test -race -coverprofile=coverage.out ./... > /dev/null 2>&1
 grep -v "testutil" coverage.out > coverage.filtered.out
 COVERAGE=$(go tool cover -func=coverage.filtered.out | grep "total:" | awk '{print $3}' | sed 's/%//')
 echo "Coverage: $COVERAGE%"
-if [ "$(echo "$COVERAGE < 70" | bc -l)" -eq 1 ]; then
-	echo "❌ Coverage $COVERAGE% is below 70% threshold"
+if [ "$(echo "$COVERAGE < $THRESHOLD" | bc -l)" -eq 1 ]; then
+	echo "❌ Coverage $COVERAGE% is below $THRESHOLD% threshold"
 	rm -f coverage.out coverage.filtered.out
 	exit 1
 fi
-echo "✅ Coverage $COVERAGE% meets 70% threshold"
+echo "✅ Coverage $COVERAGE% meets $THRESHOLD% threshold"
 rm -f coverage.out coverage.filtered.out


### PR DESCRIPTION
## Summary

Three small changes that compound:

### \`scripts/coverage-gate.sh\`
- Add \`-race\` to the test run. The \`t.Parallel\` PR proved the suite is race-clean; this catches data races at commit time instead of letting them slip to CI.
- Raise the coverage threshold **70% → 78%**. We sit at ~80.4% today so contributors have a few points of headroom for genuinely-untestable wiring without the project silently slipping below 80%.
- Threshold is now a named \`THRESHOLD\` constant — a future bump is a one-line change.

### \`CLAUDE.md\`
Documents the conventions established by recent PRs that aren't derivable from reading the code:
- \`t.Parallel()\` scope guidance (top-level OK, subtests usually share state)
- \`Example*\` as runnable docs surfaced by \`go doc\`
- \`cmd/golden_fixtures/\` location + \`-update-golden\` flag
- Benchmark layout + \`benchstat\` workflow
- "Prefer hand-rolled stubs over testify mock for concurrent tests"
- The per-group \`cmd/\` extraction pattern (createXxxCommand helpers, single-use vs shared imports, golden-fixture refresh)

## Test plan
- [x] \`make pre-push\` passes end-to-end: lint clean, coverage 80.5% > 78% threshold, \`-race\` clean