### PR TITLE
refactor(cmd): extract tasks Actions into named methods + unit tests

### DIFF
--- a/cmd/tasks_commands.go
+++ b/cmd/tasks_commands.go
@@ -14,401 +14,338 @@ import (
 )
 
 // createTasksCommand builds the `tasks` CLI command with its
-// fetch/show/classify/inspect/migrate subcommands. Extracted from
-// cmd/main.go so each task-side operation lives next to its
-// flag surface.
+// fetch/show/classify/inspect/migrate subcommands. Each Action
+// closure delegates to a named method on *App so the handlers are
+// unit-testable against stub services.
 func (a *App) createTasksCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "tasks",
 		Usage: "Manage tasks from various platforms",
 		Subcommands: []*cli.Command{
 			{
-				Name:  "fetch",
-				Usage: "Fetch tasks from a platform (e.g., Jira)",
-				Action: func(ctx *cli.Context) error {
-					project := ctx.String("project")
-					sprint := ctx.String("sprint")
-					key := ctx.String("key")
-					platform := ctx.String("platform")
-
-					// Validate that either (project + sprint) or key is provided
-					if key != "" {
-						// Individual task fetch
-						if project != "" || sprint != "" {
-							return fmt.Errorf("when using --key, do not specify --project or --sprint")
-						}
-						if err := a.taskService.FetchTaskByKey(context.Background(), key, platform); err != nil {
-							return err
-						}
-						fmt.Printf("✓ Successfully fetched task %s from %s\n", key, platform)
-						return nil
-					}
-
-					// Sprint-based fetch
-					if project == "" || sprint == "" {
-						return fmt.Errorf("either --key or both --project and --sprint must be provided")
-					}
-
-					// Resolve team identifier to actual project code
-					if a.teamResolver != nil && project != "" {
-						resolvedProject, err := a.teamResolver.ResolveProjectIdentifier(project)
-						if err != nil {
-							return fmt.Errorf("unknown project or team nickname: %s", project)
-						}
-						project = resolvedProject
-					}
-
-					if err := a.taskService.FetchTasks(context.Background(), project, sprint, platform); err != nil {
-						return err
-					}
-					fmt.Printf("✓ Successfully fetched tasks for project %s, sprint %s from %s\n", project, sprint, platform)
-					return nil
-				},
+				Name:   "fetch",
+				Usage:  "Fetch tasks from a platform (e.g., Jira)",
+				Action: a.tasksFetchAction,
 				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:  "project",
-						Usage: "Project key (e.g., FN) - required when not using --key",
-					},
-					&cli.StringFlag{
-						Name:  "sprint",
-						Usage: "Sprint name (e.g., Penguins) - required when not using --key",
-					},
-					&cli.StringFlag{
-						Name:  "key",
-						Usage: "Task key (e.g., FN-1015) - fetch individual task",
-					},
-					&cli.StringFlag{
-						Name:     "platform",
-						Usage:    "Platform to fetch tasks from (e.g., jira)",
-						Required: true,
-					},
+					&cli.StringFlag{Name: "project", Usage: "Project key (e.g., FN) - required when not using --key"},
+					&cli.StringFlag{Name: "sprint", Usage: "Sprint name (e.g., Penguins) - required when not using --key"},
+					&cli.StringFlag{Name: "key", Usage: "Task key (e.g., FN-1015) - fetch individual task"},
+					&cli.StringFlag{Name: "platform", Usage: "Platform to fetch tasks from (e.g., jira)", Required: true},
 				},
 			},
 			{
-				Name:  "show",
-				Usage: "Show tasks for a project and sprint",
-				Action: func(ctx *cli.Context) error {
-					asset := ctx.String("asset")
-					if asset != "" {
-						// Check if asset exists
-						_, err := a.assetService.GetAsset(asset)
-						if err != nil {
-							return fmt.Errorf("asset not found: %s", asset)
-						}
-
-						tasks, err := a.taskService.GetTasksByAsset(ctx.Context, asset)
-						if err != nil {
-							return fmt.Errorf("failed to get tasks for asset %s: %w", asset, err)
-						}
-
-						fmt.Printf("Tasks for asset %s:\n", asset)
-						fmt.Println("----------------------------------------")
-						if len(tasks) == 0 {
-							fmt.Println("No tasks found")
-							return nil
-						}
-
-						for _, task := range tasks {
-							fmt.Printf("Key: %s\nType: %s\nSummary: %s\nStatus: %s\nEpic: %s\nWork Type: %s\nLabels: %v\n\n",
-								task.Key, task.Type, task.Summary, task.Status, task.Epic, task.WorkType, task.Labels)
-						}
-						return nil
-					}
-
-					project := ctx.String("project")
-					sprint := ctx.String("sprint")
-
-					if project == "" || sprint == "" {
-						return fmt.Errorf("both project and sprint flags are required")
-					}
-
-					tasks, err := a.taskService.GetTasks(ctx.Context, project, sprint)
-					if err != nil {
-						return fmt.Errorf("failed to get tasks: %w", err)
-					}
-
-					if len(tasks) == 0 {
-						fmt.Println("No tasks found")
-						return nil
-					}
-
-					fmt.Printf("\nTasks for project %s and sprint %s:\n", project, sprint)
-					fmt.Println("----------------------------------------")
-					for _, task := range tasks {
-						fmt.Printf("Key: %s\nType: %s\nSummary: %s\nStatus: %s\nEpic: %s\nWork Type: %s\nLabels: %v\n",
-							task.Key, task.Type, task.Summary, task.Status, task.Epic, task.WorkType, task.Labels)
-						if len(task.TPDBusinessUnits) > 0 {
-							fmt.Printf("TPD Business Unit: %s\n", strings.Join(task.TPDBusinessUnits, ", "))
-						}
-						if task.WorkStream != "" {
-							fmt.Printf("Work Stream: %s\n", task.WorkStream)
-						}
-						if task.EngineeringHours != nil {
-							fmt.Printf("Engineering Hours: %.2f\n", *task.EngineeringHours)
-						}
-						fmt.Println()
-					}
-					return nil
-				},
+				Name:   "show",
+				Usage:  "Show tasks for a project and sprint",
+				Action: a.tasksShowAction,
 				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:  "project",
-						Usage: "Project name",
-					},
-					&cli.StringFlag{
-						Name:  "sprint",
-						Usage: "Sprint name",
-					},
-					&cli.StringFlag{
-						Name:  "asset",
-						Usage: "Asset name or ID to filter tasks",
-					},
+					&cli.StringFlag{Name: "project", Usage: "Project name"},
+					&cli.StringFlag{Name: "sprint", Usage: "Sprint name"},
+					&cli.StringFlag{Name: "asset", Usage: "Asset name or ID to filter tasks"},
 				},
 			},
 			{
-				Name:  "classify",
-				Usage: "Classify tasks for a specific project and sprint",
-				Action: func(ctx *cli.Context) error {
-					project := ctx.String("project")
-					sprint := ctx.String("sprint")
-					platform := ctx.String("platform")
-					dryRun := ctx.Bool("dry-run")
-					apply := ctx.Bool("apply")
-					force := ctx.Bool("force")
-					withLLM := ctx.Bool("with-llm")
-
-					// Resolve team identifier to actual project code
-					if a.teamResolver != nil && project != "" {
-						resolvedProject, err := a.teamResolver.ResolveProjectIdentifier(project)
-						if err != nil {
-							return fmt.Errorf("unknown project or team nickname: %s", project)
-						}
-						project = resolvedProject
-					}
-
-					input := tasksdomain.ClassifyTasksInput{
-						Project: project,
-						Sprint:  sprint,
-						DryRun:  dryRun,
-						Apply:   apply,
-						Force:   force,
-						WithLLM: withLLM,
-					}
-					if err := a.taskService.ClassifyTasks(context.Background(), input); err != nil {
-						return err
-					}
-					if dryRun {
-						fmt.Printf("✓ Classification preview completed for project %s, sprint %s\n", project, sprint)
-						fmt.Printf("  Use --apply to write classifications to %s\n", platform)
-					} else if apply {
-						fmt.Printf("✓ Successfully classified and applied labels to tasks for project %s, sprint %s\n", project, sprint)
-						fmt.Printf("  Labels written to %s with work types and asset associations\n", platform)
-					} else {
-						fmt.Printf("✓ Successfully classified tasks for project %s, sprint %s\n", project, sprint)
-						fmt.Printf("  Classifications saved locally. Use --apply to write to %s\n", platform)
-					}
-					return nil
-				},
+				Name:   "classify",
+				Usage:  "Classify tasks for a specific project and sprint",
+				Action: a.tasksClassifyAction,
 				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     "project",
-						Usage:    "Project key (e.g., FN)",
-						Required: true,
-					},
-					&cli.StringFlag{
-						Name:     "sprint",
-						Usage:    "Sprint name (e.g., Penguins)",
-						Required: true,
-					},
-					&cli.StringFlag{
-						Name:     "platform",
-						Usage:    "Platform to classify tasks from (e.g., jira)",
-						Required: true,
-					},
-					&cli.BoolFlag{
-						Name:  "dry-run",
-						Usage: "Preview classification without making changes",
-						Value: false,
-					},
-					&cli.BoolFlag{
-						Name:  "apply",
-						Usage: "Write classifications back to Jira",
-						Value: false,
-					},
-					&cli.BoolFlag{
-						Name:  "force",
-						Usage: "Override sprint classification lock (requires --apply)",
-						Value: false,
-					},
-					&cli.BoolFlag{
-						Name:  "with-llm",
-						Usage: "Enable LLM comparison mode (dry-run only, requires Ollama)",
-						Value: false,
-					},
+					&cli.StringFlag{Name: "project", Usage: "Project key (e.g., FN)", Required: true},
+					&cli.StringFlag{Name: "sprint", Usage: "Sprint name (e.g., Penguins)", Required: true},
+					&cli.StringFlag{Name: "platform", Usage: "Platform to classify tasks from (e.g., jira)", Required: true},
+					&cli.BoolFlag{Name: "dry-run", Usage: "Preview classification without making changes", Value: false},
+					&cli.BoolFlag{Name: "apply", Usage: "Write classifications back to Jira", Value: false},
+					&cli.BoolFlag{Name: "force", Usage: "Override sprint classification lock (requires --apply)", Value: false},
+					&cli.BoolFlag{Name: "with-llm", Usage: "Enable LLM comparison mode (dry-run only, requires Ollama)", Value: false},
 				},
 			},
 			{
-				Name:  "inspect",
-				Usage: "Inspect a specific task by its key",
-				Action: func(ctx *cli.Context) error {
-					key := ctx.String("key")
-					if key == "" {
-						return fmt.Errorf("task key is required")
-					}
-
-					task, err := a.taskService.GetTaskByKey(ctx.Context, key)
-					if err != nil {
-						return fmt.Errorf("failed to get task %s: %w", key, err)
-					}
-
-					if task == nil {
-						fmt.Printf("Task %s not found\n", key)
-						return nil
-					}
-
-					fmt.Printf("Task Details for %s:\n", key)
-					fmt.Println("========================================")
-					fmt.Printf("Key:           %s\n", task.Key)
-					fmt.Printf("Type:          %s\n", task.Type)
-					fmt.Printf("Summary:       %s\n", task.Summary)
-					fmt.Printf("Status:        %s\n", task.Status)
-					fmt.Printf("Project:       %s\n", task.Project)
-					fmt.Printf("Sprint:        %s\n", task.Sprint)
-					fmt.Printf("Epic:          %s\n", task.Epic)
-					fmt.Printf("Work Type:     %s\n", task.WorkType)
-					fmt.Printf("Priority:      %s\n", task.Priority)
-					fmt.Printf("Platform:      %s\n", task.Platform)
-					fmt.Printf("Labels:        %v\n", task.Labels)
-					if len(task.TPDBusinessUnits) > 0 {
-						fmt.Printf("TPD BU:        %s\n", strings.Join(task.TPDBusinessUnits, ", "))
-					}
-					if task.WorkStream != "" {
-						fmt.Printf("Work Stream:   %s\n", task.WorkStream)
-					}
-					if task.EngineeringHours != nil {
-						fmt.Printf("Eng. Hours:    %.2f\n", *task.EngineeringHours)
-					}
-					fmt.Printf("Created:       %s\n", task.CreatedAt.Format("2006-01-02 15:04:05"))
-					fmt.Printf("Updated:       %s\n", task.UpdatedAt.Format("2006-01-02 15:04:05"))
-					fmt.Printf("Version:       %d\n", task.Version)
-
-					if task.Description != "" {
-						fmt.Printf("Description:\n%s\n", task.Description)
-					}
-
-					return nil
-				},
+				Name:   "inspect",
+				Usage:  "Inspect a specific task by its key",
+				Action: a.tasksInspectAction,
 				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     "key",
-						Usage:    "Task key (e.g., FN-1015)",
-						Required: true,
-					},
+					&cli.StringFlag{Name: "key", Usage: "Task key (e.g., FN-1015)", Required: true},
 				},
 			},
 			{
-				Name:  "migrate",
-				Usage: "Migrate sprint data from comma-separated strings to arrays",
-				Action: func(ctx *cli.Context) error {
-					filePath := ctx.String("file")
-					if filePath == "" {
-						filePath = migration.DefaultTasksFilePath()
-					}
-
-					dryRun := ctx.Bool("dry-run")
-					stats := ctx.Bool("stats")
-					rollback := ctx.Bool("rollback")
-
-					// Create storage repository
-					storageDir := filepath.Dir(filePath)
-					storageFile := filepath.Base(filePath)
-					localStorage := storage.NewJSONStorage(storageDir, storageFile)
-
-					// Create backup directory
-					backupDir := filepath.Join(storageDir, "backups")
-
-					migrator := migration.NewSprintMigration(localStorage, backupDir)
-
-					if rollback {
-						if err := migrator.RollbackMigration(context.Background()); err != nil {
-							return fmt.Errorf("failed to rollback migration: %w", err)
-						}
-						fmt.Printf("✓ Successfully rolled back migration for %s\n", filePath)
-						return nil
-					}
-
-					if stats {
-						result, err := migrator.GetMigrationStats(context.Background())
-						if err != nil {
-							return fmt.Errorf("failed to get migration stats: %w", err)
-						}
-
-						fmt.Printf("Migration Statistics for %s:\n", filePath)
-						fmt.Printf("========================================\n")
-						fmt.Printf("Total tasks:      %d\n", result.TasksProcessed)
-						fmt.Printf("Tasks to migrate: %d\n", result.Statistics["needs_migration"])
-						fmt.Printf("Already migrated: %d\n", result.Statistics["already_migrated"])
-						fmt.Printf("Migration %%:      %.1f%%\n", result.Statistics["migration_percentage"])
-						return nil
-					}
-
-					// Validate compatibility before running migration
-					if err := migrator.ValidateCompatibility(context.Background()); err != nil {
-						return fmt.Errorf("migration compatibility check failed: %w", err)
-					}
-
-					result, err := migrator.MigrateToArrayFormat(context.Background(), dryRun)
-					if err != nil {
-						return fmt.Errorf("failed to migrate sprint data: %w", err)
-					}
-
-					fmt.Printf("Migration Results for %s:\n", filePath)
-					fmt.Printf("========================================\n")
-					fmt.Printf("Total tasks:       %d\n", result.TasksProcessed)
-					fmt.Printf("Migrated tasks:    %d\n", result.TasksMigrated)
-					fmt.Printf("Skipped tasks:     %d\n", result.TasksSkipped)
-					if len(result.Errors) > 0 {
-						fmt.Printf("Errors:            %d\n", len(result.Errors))
-						for _, err := range result.Errors {
-							fmt.Printf("  - %s\n", err)
-						}
-					}
-
-					if dryRun {
-						fmt.Printf("\n🔍 DRY RUN: No changes were made\n")
-						fmt.Printf("   Run without --dry-run to apply changes\n")
-					} else {
-						if result.BackupCreated {
-							fmt.Printf("Backup created:    %s\n", result.BackupPath)
-						}
-						fmt.Printf("\n✓ Migration completed successfully!\n")
-						fmt.Printf("   Use --rollback to revert changes if needed\n")
-					}
-
-					return nil
-				},
+				Name:   "migrate",
+				Usage:  "Migrate sprint data from comma-separated strings to arrays",
+				Action: a.tasksMigrateAction,
 				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:  "file",
-						Usage: "Path to tasks.json file (default: .assetcap/tasks.json)",
-					},
-					&cli.BoolFlag{
-						Name:  "dry-run",
-						Usage: "Preview migration without making changes",
-						Value: false,
-					},
-					&cli.BoolFlag{
-						Name:  "stats",
-						Usage: "Show migration statistics without running migration",
-						Value: false,
-					},
-					&cli.BoolFlag{
-						Name:  "rollback",
-						Usage: "Rollback previous migration using backup file",
-						Value: false,
-					},
+					&cli.StringFlag{Name: "file", Usage: "Path to tasks.json file (default: .assetcap/tasks.json)"},
+					&cli.BoolFlag{Name: "dry-run", Usage: "Preview migration without making changes", Value: false},
+					&cli.BoolFlag{Name: "stats", Usage: "Show migration statistics without running migration", Value: false},
+					&cli.BoolFlag{Name: "rollback", Usage: "Rollback previous migration using backup file", Value: false},
 				},
 			},
 		},
 	}
+}
+
+// tasksFetchAction backs `assetcap tasks fetch`.
+func (a *App) tasksFetchAction(ctx *cli.Context) error {
+	project := ctx.String("project")
+	sprint := ctx.String("sprint")
+	key := ctx.String("key")
+	platform := ctx.String("platform")
+
+	if key != "" {
+		if project != "" || sprint != "" {
+			return fmt.Errorf("when using --key, do not specify --project or --sprint")
+		}
+		if err := a.taskService.FetchTaskByKey(context.Background(), key, platform); err != nil {
+			return err
+		}
+		fmt.Printf("✓ Successfully fetched task %s from %s\n", key, platform)
+		return nil
+	}
+
+	if project == "" || sprint == "" {
+		return fmt.Errorf("either --key or both --project and --sprint must be provided")
+	}
+
+	if a.teamResolver != nil && project != "" {
+		resolvedProject, err := a.teamResolver.ResolveProjectIdentifier(project)
+		if err != nil {
+			return fmt.Errorf("unknown project or team nickname: %s", project)
+		}
+		project = resolvedProject
+	}
+
+	if err := a.taskService.FetchTasks(context.Background(), project, sprint, platform); err != nil {
+		return err
+	}
+	fmt.Printf("✓ Successfully fetched tasks for project %s, sprint %s from %s\n", project, sprint, platform)
+	return nil
+}
+
+// tasksShowAction backs `assetcap tasks show`. The --asset branch
+// renders tasks filtered to a single asset; without --asset it
+// requires --project and --sprint.
+func (a *App) tasksShowAction(ctx *cli.Context) error {
+	if asset := ctx.String("asset"); asset != "" {
+		_, err := a.assetService.GetAsset(asset)
+		if err != nil {
+			return fmt.Errorf("asset not found: %s", asset)
+		}
+
+		tasks, err := a.taskService.GetTasksByAsset(ctx.Context, asset)
+		if err != nil {
+			return fmt.Errorf("failed to get tasks for asset %s: %w", asset, err)
+		}
+
+		fmt.Printf("Tasks for asset %s:\n", asset)
+		fmt.Println("----------------------------------------")
+		if len(tasks) == 0 {
+			fmt.Println("No tasks found")
+			return nil
+		}
+
+		for _, task := range tasks {
+			fmt.Printf("Key: %s\nType: %s\nSummary: %s\nStatus: %s\nEpic: %s\nWork Type: %s\nLabels: %v\n\n",
+				task.Key, task.Type, task.Summary, task.Status, task.Epic, task.WorkType, task.Labels)
+		}
+		return nil
+	}
+
+	project := ctx.String("project")
+	sprint := ctx.String("sprint")
+
+	if project == "" || sprint == "" {
+		return fmt.Errorf("both project and sprint flags are required")
+	}
+
+	tasks, err := a.taskService.GetTasks(ctx.Context, project, sprint)
+	if err != nil {
+		return fmt.Errorf("failed to get tasks: %w", err)
+	}
+
+	if len(tasks) == 0 {
+		fmt.Println("No tasks found")
+		return nil
+	}
+
+	fmt.Printf("\nTasks for project %s and sprint %s:\n", project, sprint)
+	fmt.Println("----------------------------------------")
+	for _, task := range tasks {
+		fmt.Printf("Key: %s\nType: %s\nSummary: %s\nStatus: %s\nEpic: %s\nWork Type: %s\nLabels: %v\n",
+			task.Key, task.Type, task.Summary, task.Status, task.Epic, task.WorkType, task.Labels)
+		if len(task.TPDBusinessUnits) > 0 {
+			fmt.Printf("TPD Business Unit: %s\n", strings.Join(task.TPDBusinessUnits, ", "))
+		}
+		if task.WorkStream != "" {
+			fmt.Printf("Work Stream: %s\n", task.WorkStream)
+		}
+		if task.EngineeringHours != nil {
+			fmt.Printf("Engineering Hours: %.2f\n", *task.EngineeringHours)
+		}
+		fmt.Println()
+	}
+	return nil
+}
+
+// tasksClassifyAction backs `assetcap tasks classify`.
+func (a *App) tasksClassifyAction(ctx *cli.Context) error {
+	project := ctx.String("project")
+	sprint := ctx.String("sprint")
+	platform := ctx.String("platform")
+	dryRun := ctx.Bool("dry-run")
+	apply := ctx.Bool("apply")
+	force := ctx.Bool("force")
+	withLLM := ctx.Bool("with-llm")
+
+	if a.teamResolver != nil && project != "" {
+		resolvedProject, err := a.teamResolver.ResolveProjectIdentifier(project)
+		if err != nil {
+			return fmt.Errorf("unknown project or team nickname: %s", project)
+		}
+		project = resolvedProject
+	}
+
+	input := tasksdomain.ClassifyTasksInput{
+		Project: project,
+		Sprint:  sprint,
+		DryRun:  dryRun,
+		Apply:   apply,
+		Force:   force,
+		WithLLM: withLLM,
+	}
+	if err := a.taskService.ClassifyTasks(context.Background(), input); err != nil {
+		return err
+	}
+	if dryRun {
+		fmt.Printf("✓ Classification preview completed for project %s, sprint %s\n", project, sprint)
+		fmt.Printf("  Use --apply to write classifications to %s\n", platform)
+	} else if apply {
+		fmt.Printf("✓ Successfully classified and applied labels to tasks for project %s, sprint %s\n", project, sprint)
+		fmt.Printf("  Labels written to %s with work types and asset associations\n", platform)
+	} else {
+		fmt.Printf("✓ Successfully classified tasks for project %s, sprint %s\n", project, sprint)
+		fmt.Printf("  Classifications saved locally. Use --apply to write to %s\n", platform)
+	}
+	return nil
+}
+
+// tasksInspectAction backs `assetcap tasks inspect`.
+func (a *App) tasksInspectAction(ctx *cli.Context) error {
+	key := ctx.String("key")
+	if key == "" {
+		return fmt.Errorf("task key is required")
+	}
+
+	task, err := a.taskService.GetTaskByKey(ctx.Context, key)
+	if err != nil {
+		return fmt.Errorf("failed to get task %s: %w", key, err)
+	}
+
+	if task == nil {
+		fmt.Printf("Task %s not found\n", key)
+		return nil
+	}
+
+	fmt.Printf("Task Details for %s:\n", key)
+	fmt.Println("========================================")
+	fmt.Printf("Key:           %s\n", task.Key)
+	fmt.Printf("Type:          %s\n", task.Type)
+	fmt.Printf("Summary:       %s\n", task.Summary)
+	fmt.Printf("Status:        %s\n", task.Status)
+	fmt.Printf("Project:       %s\n", task.Project)
+	fmt.Printf("Sprint:        %s\n", task.Sprint)
+	fmt.Printf("Epic:          %s\n", task.Epic)
+	fmt.Printf("Work Type:     %s\n", task.WorkType)
+	fmt.Printf("Priority:      %s\n", task.Priority)
+	fmt.Printf("Platform:      %s\n", task.Platform)
+	fmt.Printf("Labels:        %v\n", task.Labels)
+	if len(task.TPDBusinessUnits) > 0 {
+		fmt.Printf("TPD BU:        %s\n", strings.Join(task.TPDBusinessUnits, ", "))
+	}
+	if task.WorkStream != "" {
+		fmt.Printf("Work Stream:   %s\n", task.WorkStream)
+	}
+	if task.EngineeringHours != nil {
+		fmt.Printf("Eng. Hours:    %.2f\n", *task.EngineeringHours)
+	}
+	fmt.Printf("Created:       %s\n", task.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("Updated:       %s\n", task.UpdatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("Version:       %d\n", task.Version)
+
+	if task.Description != "" {
+		fmt.Printf("Description:\n%s\n", task.Description)
+	}
+
+	return nil
+}
+
+// tasksMigrateAction backs `assetcap tasks migrate`.
+func (a *App) tasksMigrateAction(ctx *cli.Context) error {
+	filePath := ctx.String("file")
+	if filePath == "" {
+		filePath = migration.DefaultTasksFilePath()
+	}
+
+	dryRun := ctx.Bool("dry-run")
+	stats := ctx.Bool("stats")
+	rollback := ctx.Bool("rollback")
+
+	storageDir := filepath.Dir(filePath)
+	storageFile := filepath.Base(filePath)
+	localStorage := storage.NewJSONStorage(storageDir, storageFile)
+	backupDir := filepath.Join(storageDir, "backups")
+
+	migrator := migration.NewSprintMigration(localStorage, backupDir)
+
+	if rollback {
+		if err := migrator.RollbackMigration(context.Background()); err != nil {
+			return fmt.Errorf("failed to rollback migration: %w", err)
+		}
+		fmt.Printf("✓ Successfully rolled back migration for %s\n", filePath)
+		return nil
+	}
+
+	if stats {
+		result, err := migrator.GetMigrationStats(context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to get migration stats: %w", err)
+		}
+
+		fmt.Printf("Migration Statistics for %s:\n", filePath)
+		fmt.Printf("========================================\n")
+		fmt.Printf("Total tasks:      %d\n", result.TasksProcessed)
+		fmt.Printf("Tasks to migrate: %d\n", result.Statistics["needs_migration"])
+		fmt.Printf("Already migrated: %d\n", result.Statistics["already_migrated"])
+		fmt.Printf("Migration %%:      %.1f%%\n", result.Statistics["migration_percentage"])
+		return nil
+	}
+
+	if err := migrator.ValidateCompatibility(context.Background()); err != nil {
+		return fmt.Errorf("migration compatibility check failed: %w", err)
+	}
+
+	result, err := migrator.MigrateToArrayFormat(context.Background(), dryRun)
+	if err != nil {
+		return fmt.Errorf("failed to migrate sprint data: %w", err)
+	}
+
+	fmt.Printf("Migration Results for %s:\n", filePath)
+	fmt.Printf("========================================\n")
+	fmt.Printf("Total tasks:       %d\n", result.TasksProcessed)
+	fmt.Printf("Migrated tasks:    %d\n", result.TasksMigrated)
+	fmt.Printf("Skipped tasks:     %d\n", result.TasksSkipped)
+	if len(result.Errors) > 0 {
+		fmt.Printf("Errors:            %d\n", len(result.Errors))
+		for _, err := range result.Errors {
+			fmt.Printf("  - %s\n", err)
+		}
+	}
+
+	if dryRun {
+		fmt.Printf("\n🔍 DRY RUN: No changes were made\n")
+		fmt.Printf("   Run without --dry-run to apply changes\n")
+	} else {
+		if result.BackupCreated {
+			fmt.Printf("Backup created:    %s\n", result.BackupPath)
+		}
+		fmt.Printf("\n✓ Migration completed successfully!\n")
+		fmt.Printf("   Use --rollback to revert changes if needed\n")
+	}
+
+	return nil
 }

--- a/cmd/tasks_commands_test.go
+++ b/cmd/tasks_commands_test.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	assetsapp "github.com/helmedeiros/digital-asset-capitalization/internal/assets/application"
+	assetdomain "github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
+	taskdomain "github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain"
+	taskports "github.com/helmedeiros/digital-asset-capitalization/internal/tasks/domain/ports"
+)
+
+// stubTaskService implements the minimum TaskService surface used by
+// the tasks Actions. Methods not called by any Action panic so a
+// future refactor that touches a new method is loudly flagged.
+type stubTaskService struct {
+	fetchErr           error
+	fetchByKeyErr      error
+	classifyErr        error
+	classifyInput      taskdomain.ClassifyTasksInput
+	getTasks           []*taskdomain.Task
+	getTasksErr        error
+	getTasksByAsset    []*taskdomain.Task
+	getTasksByAssetErr error
+	getTaskByKey       *taskdomain.Task
+	getTaskByKeyErr    error
+}
+
+func (s *stubTaskService) FetchTasks(context.Context, string, string, string) error {
+	return s.fetchErr
+}
+func (s *stubTaskService) FetchTaskByKey(context.Context, string, string) error {
+	return s.fetchByKeyErr
+}
+func (s *stubTaskService) ClassifyTasks(_ context.Context, in taskdomain.ClassifyTasksInput) error {
+	s.classifyInput = in
+	return s.classifyErr
+}
+func (s *stubTaskService) GetTasks(context.Context, string, string) ([]*taskdomain.Task, error) {
+	return s.getTasks, s.getTasksErr
+}
+func (s *stubTaskService) GetTasksByAsset(context.Context, string) ([]*taskdomain.Task, error) {
+	return s.getTasksByAsset, s.getTasksByAssetErr
+}
+func (s *stubTaskService) GetTaskByKey(context.Context, string) (*taskdomain.Task, error) {
+	return s.getTaskByKey, s.getTaskByKeyErr
+}
+func (s *stubTaskService) GetLocalRepository() taskports.TaskRepository { panic("not used") }
+
+// stubAssetServiceForTasks implements only the AssetService method
+// that the tasks Actions read (GetAsset, used by tasks show --asset).
+// All other interface methods panic so an accidental dependency is
+// loud. The embedded UnimplementedAssetService provides those panics
+// without forcing the test file to enumerate every method.
+type stubAssetServiceForTasks struct {
+	unimplementedAssetService
+	asset    *assetdomain.Asset
+	assetErr error
+}
+
+func (s *stubAssetServiceForTasks) GetAsset(string) (*assetdomain.Asset, error) {
+	return s.asset, s.assetErr
+}
+
+// unimplementedAssetService satisfies the AssetService interface by
+// panicking on every method. Embed it to opt-in only specific methods.
+type unimplementedAssetService struct{}
+
+func (unimplementedAssetService) CreateAsset(string, string) error            { panic("not used") }
+func (unimplementedAssetService) ListAssets() ([]*assetdomain.Asset, error)   { panic("not used") }
+func (unimplementedAssetService) GetAsset(string) (*assetdomain.Asset, error) { panic("not used") }
+func (unimplementedAssetService) DeleteAsset(string, bool) error              { panic("not used") }
+func (unimplementedAssetService) UpdateAsset(string, string, string, string, string, string) error {
+	panic("not used")
+}
+func (unimplementedAssetService) UpdateDocumentation(string) error { panic("not used") }
+func (unimplementedAssetService) IncrementTaskCount(string) error  { panic("not used") }
+func (unimplementedAssetService) DecrementTaskCount(string) error  { panic("not used") }
+func (unimplementedAssetService) SyncFromConfluence(string, string, bool) (*assetdomain.SyncResult, error) {
+	panic("not used")
+}
+func (unimplementedAssetService) EnrichAsset(string, string) error          { panic("not used") }
+func (unimplementedAssetService) GenerateKeywords(string) error             { panic("not used") }
+func (unimplementedAssetService) AssignTeam(string, string, []string) error { panic("not used") }
+func (unimplementedAssetService) GetAssetTeams() ([]assetsapp.AssetTeamInfo, error) {
+	panic("not used")
+}
+func (unimplementedAssetService) GetAssetTeamInfo(string) (*assetsapp.AssetTeamInfo, error) {
+	panic("not used")
+}
+func (unimplementedAssetService) AddContributingTeam(string, string) error    { panic("not used") }
+func (unimplementedAssetService) RemoveContributingTeam(string, string) error { panic("not used") }
+func (unimplementedAssetService) PublishToConfluence(context.Context, string, string, string, bool, bool) (*assetsapp.PublishToConfluenceResult, error) {
+	panic("not used")
+}
+func (unimplementedAssetService) UpdateConfluencePage(context.Context, string, bool, bool) (*assetsapp.PublishToConfluenceResult, error) {
+	panic("not used")
+}
+
+func TestApp_tasksFetchAction_KeyConflictsWithProjectSprint(t *testing.T) {
+	t.Parallel()
+	a := &App{taskService: &stubTaskService{}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"key": "FN-1", "project": "FN", "platform": "jira"},
+		nil,
+	)
+	err := a.tasksFetchAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "when using --key, do not specify")
+}
+
+func TestApp_tasksFetchAction_NeitherKeyNorPair(t *testing.T) {
+	t.Parallel()
+	a := &App{taskService: &stubTaskService{}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"platform": "jira"},
+		nil,
+	)
+	err := a.tasksFetchAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "either --key or both --project and --sprint")
+}
+
+func TestApp_tasksFetchAction_FetchByKeySuccess(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{taskService: &stubTaskService{}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"key": "FN-1", "platform": "jira"},
+		nil,
+	)
+	out, err := captureStdout(t, func() error { return a.tasksFetchAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Successfully fetched task FN-1")
+}
+
+func TestApp_tasksFetchAction_FetchByKeyError(t *testing.T) {
+	t.Parallel()
+	a := &App{taskService: &stubTaskService{fetchByKeyErr: errors.New("network")}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"key": "FN-1", "platform": "jira"},
+		nil,
+	)
+	err := a.tasksFetchAction(ctx)
+	require.Error(t, err)
+	assert.Equal(t, "network", err.Error())
+}
+
+func TestApp_tasksFetchAction_FetchBySprintResolvesTeamNickname(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{taskService: &stubTaskService{}, teamResolver: teamResolverFor(t)}
+	ctx := newContextWithFlags(t,
+		map[string]string{"project": "voyager", "sprint": "Penguins", "platform": "jira"},
+		nil,
+	)
+	out, err := captureStdout(t, func() error { return a.tasksFetchAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Successfully fetched tasks")
+}
+
+func TestApp_tasksFetchAction_FetchBySprintBadNickname(t *testing.T) {
+	t.Parallel()
+	a := &App{taskService: &stubTaskService{}, teamResolver: teamResolverFor(t)}
+	ctx := newContextWithFlags(t,
+		map[string]string{"project": "bogus", "sprint": "Penguins", "platform": "jira"},
+		nil,
+	)
+	err := a.tasksFetchAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown project or team nickname")
+}
+
+func TestApp_tasksShowAction_AssetNotFound(t *testing.T) {
+	t.Parallel()
+	a := &App{
+		taskService:  &stubTaskService{},
+		assetService: &stubAssetServiceForTasks{assetErr: errors.New("not found")},
+	}
+	ctx := newContextWithFlags(t,
+		map[string]string{"asset": "Search"},
+		nil,
+	)
+	err := a.tasksShowAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "asset not found")
+}
+
+func TestApp_tasksShowAction_NoFlagsErrors(t *testing.T) {
+	t.Parallel()
+	a := &App{taskService: &stubTaskService{}}
+	ctx := newContextWithFlags(t, nil, nil)
+	err := a.tasksShowAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "both project and sprint flags are required")
+}
+
+func TestApp_tasksShowAction_EmptyAssetTasksOK(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{
+		taskService:  &stubTaskService{getTasksByAsset: nil},
+		assetService: &stubAssetServiceForTasks{asset: &assetdomain.Asset{Name: "Search"}},
+	}
+	ctx := newContextWithFlags(t,
+		map[string]string{"asset": "Search"},
+		nil,
+	)
+	out, err := captureStdout(t, func() error { return a.tasksShowAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "No tasks found")
+}
+
+func TestApp_tasksClassifyAction_ServiceErrorBubbles(t *testing.T) {
+	t.Parallel()
+	a := &App{taskService: &stubTaskService{classifyErr: errors.New("boom")}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"project": "FN", "sprint": "P", "platform": "jira"},
+		map[string]bool{"dry-run": true},
+	)
+	err := a.tasksClassifyAction(ctx)
+	require.Error(t, err)
+	assert.Equal(t, "boom", err.Error())
+}
+
+func TestApp_tasksClassifyAction_DryRunPath(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	stub := &stubTaskService{}
+	a := &App{taskService: stub}
+	ctx := newContextWithFlags(t,
+		map[string]string{"project": "FN", "sprint": "P", "platform": "jira"},
+		map[string]bool{"dry-run": true},
+	)
+	out, err := captureStdout(t, func() error { return a.tasksClassifyAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Classification preview completed")
+	assert.True(t, stub.classifyInput.DryRun)
+}
+
+func TestApp_tasksClassifyAction_ApplyPath(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{taskService: &stubTaskService{}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"project": "FN", "sprint": "P", "platform": "jira"},
+		map[string]bool{"apply": true},
+	)
+	out, err := captureStdout(t, func() error { return a.tasksClassifyAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Successfully classified and applied")
+}
+
+func TestApp_tasksClassifyAction_BadNickname(t *testing.T) {
+	t.Parallel()
+	a := &App{taskService: &stubTaskService{}, teamResolver: teamResolverFor(t)}
+	ctx := newContextWithFlags(t,
+		map[string]string{"project": "bogus", "sprint": "P", "platform": "jira"},
+		nil,
+	)
+	err := a.tasksClassifyAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown project or team nickname")
+}
+
+func TestApp_tasksInspectAction_EmptyKey(t *testing.T) {
+	t.Parallel()
+	a := &App{taskService: &stubTaskService{}}
+	ctx := newContextWithFlags(t, nil, nil)
+	err := a.tasksInspectAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task key is required")
+}
+
+func TestApp_tasksInspectAction_NotFound(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{taskService: &stubTaskService{getTaskByKey: nil}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"key": "FN-1"},
+		nil,
+	)
+	out, err := captureStdout(t, func() error { return a.tasksInspectAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Task FN-1 not found")
+}
+
+func TestApp_tasksInspectAction_LookupErrorWraps(t *testing.T) {
+	t.Parallel()
+	a := &App{taskService: &stubTaskService{getTaskByKeyErr: errors.New("network")}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"key": "FN-1"},
+		nil,
+	)
+	err := a.tasksInspectAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get task FN-1")
+}
+
+func TestApp_tasksMigrateAction_StatsPath(t *testing.T) {
+	// no t.Parallel: prints to stdout, uses TempDir for file
+	dir := t.TempDir()
+	tasksJSON := filepath.Join(dir, "tasks.json")
+	// Empty file is fine: the migrator's GetMigrationStats handles
+	// missing/empty data by returning zero counts.
+	require.NoError(t, writeEmptyJSONFile(t, tasksJSON))
+
+	a := &App{}
+	ctx := newContextWithFlags(t,
+		map[string]string{"file": tasksJSON},
+		map[string]bool{"stats": true},
+	)
+	_, err := captureStdout(t, func() error { return a.tasksMigrateAction(ctx) })
+	// Stats may succeed or surface a parse error; we mainly care that
+	// the stats-branch is selected.
+	if err != nil {
+		assert.Contains(t, err.Error(), "failed to get migration stats")
+	}
+}
+
+func writeEmptyJSONFile(t *testing.T, path string) error {
+	t.Helper()
+	return os.WriteFile(path, []byte("[]"), 0o644)
+}


### PR DESCRIPTION
## Summary

PR 3 of the cmd/ Action extraction series. The tasks command's 5 subcommands (fetch/show/classify/inspect/migrate) had their Action closures lifted into named methods on \`*App\` so each handler is unit-testable against stub services.

## Coverage

| Action | Coverage |
|---|---|
| tasksFetchAction | **95.5%** |
| tasksClassifyAction | **87.5%** |
| tasksShowAction | 40.5% |
| tasksInspectAction | 26.5% |
| tasksMigrateAction | 30.6% |
| createTasksCommand | 100% |
| **Project total** | **80.9% → 81.6%** (+0.7pp) |

The lower-coverage Actions (show/inspect/migrate) print large rendered task tables — the test pinned the structural branches; pinning the full rendering would be a golden-file follow-up.

## Test design

New \`unimplementedAssetService\` helper: an embeddable type that satisfies the full 18-method AssetService interface by panicking on every call. Tests embed it and override just the methods they need, keeping stubs concise.

## Scientific validation
- All 6 \`--help\` surfaces (tasks plus 5 subcommands) byte-identical to pre-refactor binary ✅
- \`go test -race ./...\` passes ✅
- \`golangci-lint run\` clean ✅