### PR TITLE
test(cmd): cover NewApp + NewAppWithConfigService constructors

### DIFF
--- a/cmd/main_constructors_test.go
+++ b/cmd/main_constructors_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewApp_WiresAllProvidedServices(t *testing.T) {
+	t.Parallel()
+	asset := &stubAssetServiceForActions{}
+	task := &stubTaskService{}
+	sprint := &stubSprintService{}
+
+	a := NewApp(asset, task, sprint)
+	require.NotNil(t, a)
+	assert.Same(t, asset, a.assetService.(*stubAssetServiceForActions))
+	assert.Same(t, task, a.taskService.(*stubTaskService))
+	assert.Same(t, sprint, a.sprintService.(*stubSprintService))
+	assert.Nil(t, a.configService, "configService is wired in initializeApp, not NewApp")
+}
+
+func TestNewAppWithConfigService_WiresConfigService(t *testing.T) {
+	t.Parallel()
+	asset := &stubAssetServiceForActions{}
+	task := &stubTaskService{}
+	sprint := &stubSprintService{}
+	cfg := &stubConfigService{}
+
+	a := NewAppWithConfigService(asset, task, sprint, cfg)
+	require.NotNil(t, a)
+	assert.Same(t, asset, a.assetService.(*stubAssetServiceForActions))
+	assert.Same(t, task, a.taskService.(*stubTaskService))
+	assert.Same(t, sprint, a.sprintService.(*stubSprintService))
+	assert.Same(t, cfg, a.configService.(*stubConfigService))
+}
+
+// configServiceImpl wraps concrete *usecase.InitializeConfig and
+// *service.ConfigService fields, both of which require live JIRA
+// configuration to construct. They are therefore covered
+// transitively via the integration paths in configInitAction tests
+// rather than directly here.


### PR DESCRIPTION
## Summary

Small but worthwhile: the two App constructors (\`NewApp\` and \`NewAppWithConfigService\`) were both at **0% direct coverage**. Pure DI wiring, but the shape is easy to break with a future field addition that goes through one constructor and not the other.

## Coverage
- \`NewApp\`: 0% → **100%**
- \`NewAppWithConfigService\`: 0% → **100%**

## Note
\`configServiceImpl.InitializeConfig\` and \`GetJiraConfig\` wrap concrete \`*usecase.InitializeConfig\` and \`*service.ConfigService\` fields that need live JIRA configuration to construct; they remain covered transitively via the \`configInitAction\` tests rather than directly. The test file documents this so the next contributor isn't tempted to write a stub that won't compile.

## Test plan
- [x] \`go test -race ./...\` passes
- [x] \`golangci-lint run\` clean