### PR TITLE
refactor(cmd): extract 8 nested assets Actions into named methods

### DIFF
--- a/cmd/assets_commands.go
+++ b/cmd/assets_commands.go
@@ -235,27 +235,11 @@ func (a *App) createAssetsCommand() *cli.Command {
 				Usage: "Manage asset documentation",
 				Subcommands: []*cli.Command{
 					{
-						Name:  "update",
-						Usage: "Mark asset documentation as updated",
-						Action: func(ctx *cli.Context) error {
-							assetName := ctx.String("asset")
-							// First check if the asset exists
-							_, err := a.assetService.GetAsset(assetName)
-							if err != nil {
-								return err
-							}
-							if err := a.assetService.UpdateDocumentation(assetName); err != nil {
-								return err
-							}
-							fmt.Printf("Marked documentation as updated for asset %s\n", assetName)
-							return nil
-						},
+						Name:   "update",
+						Usage:  "Mark asset documentation as updated",
+						Action: a.assetsDocUpdateAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "asset",
-								Usage:    "Asset name",
-								Required: true,
-							},
+							&cli.StringFlag{Name: "asset", Usage: "Asset name", Required: true},
 						},
 					},
 				},
@@ -265,51 +249,19 @@ func (a *App) createAssetsCommand() *cli.Command {
 				Usage: "Manage asset tasks",
 				Subcommands: []*cli.Command{
 					{
-						Name:  "increment",
-						Usage: "Increment task count for an asset",
-						Action: func(ctx *cli.Context) error {
-							assetName := ctx.String("asset")
-							// First check if the asset exists
-							_, err := a.assetService.GetAsset(assetName)
-							if err != nil {
-								return err
-							}
-							if err := a.assetService.IncrementTaskCount(assetName); err != nil {
-								return err
-							}
-							fmt.Printf("Incremented task count for asset %s\n", assetName)
-							return nil
-						},
+						Name:   "increment",
+						Usage:  "Increment task count for an asset",
+						Action: a.assetsTasksIncrementAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "asset",
-								Usage:    "Asset name",
-								Required: true,
-							},
+							&cli.StringFlag{Name: "asset", Usage: "Asset name", Required: true},
 						},
 					},
 					{
-						Name:  "decrement",
-						Usage: "Decrement task count for an asset",
-						Action: func(ctx *cli.Context) error {
-							assetName := ctx.String("asset")
-							// First check if the asset exists
-							_, err := a.assetService.GetAsset(assetName)
-							if err != nil {
-								return err
-							}
-							if err := a.assetService.DecrementTaskCount(assetName); err != nil {
-								return err
-							}
-							fmt.Printf("Decremented task count for asset %s\n", assetName)
-							return nil
-						},
+						Name:   "decrement",
+						Usage:  "Decrement task count for an asset",
+						Action: a.assetsTasksDecrementAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "asset",
-								Usage:    "Asset name",
-								Required: true,
-							},
+							&cli.StringFlag{Name: "asset", Usage: "Asset name", Required: true},
 						},
 					},
 				},
@@ -607,169 +559,44 @@ func (a *App) createAssetsCommand() *cli.Command {
 				Usage: "Manage asset team assignments",
 				Subcommands: []*cli.Command{
 					{
-						Name:  "assign",
-						Usage: "Assign teams to an asset",
-						Action: func(ctx *cli.Context) error {
-							assetName := ctx.String("asset")
-							owningTeam := ctx.String("owner")
-							contributingTeamsInput := ctx.String("contributors")
-
-							// Parse contributing teams from comma-separated string
-							var contributingTeams []string
-							if contributingTeamsInput != "" {
-								teams := strings.Split(contributingTeamsInput, ",")
-								for _, team := range teams {
-									if trimmed := strings.TrimSpace(team); trimmed != "" {
-										contributingTeams = append(contributingTeams, trimmed)
-									}
-								}
-							}
-
-							if err := a.assetService.AssignTeam(assetName, owningTeam, contributingTeams); err != nil {
-								return err
-							}
-
-							fmt.Printf("✓ Successfully assigned teams to asset '%s'\n", assetName)
-							if owningTeam != "" {
-								fmt.Printf("  Owner: %s\n", owningTeam)
-							}
-							if len(contributingTeams) > 0 {
-								fmt.Printf("  Contributors: %s\n", strings.Join(contributingTeams, ", "))
-							}
-							return nil
-						},
+						Name:   "assign",
+						Usage:  "Assign teams to an asset",
+						Action: a.assetsTeamsAssignAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "asset",
-								Usage:    "Asset name",
-								Required: true,
-							},
-							&cli.StringFlag{
-								Name:  "owner",
-								Usage: "Owning team",
-							},
-							&cli.StringFlag{
-								Name:  "contributors",
-								Usage: "Contributing teams (comma-separated)",
-							},
+							&cli.StringFlag{Name: "asset", Usage: "Asset name", Required: true},
+							&cli.StringFlag{Name: "owner", Usage: "Owning team"},
+							&cli.StringFlag{Name: "contributors", Usage: "Contributing teams (comma-separated)"},
 						},
 					},
 					{
-						Name:  "list",
-						Usage: "List asset team assignments",
-						Action: func(_ *cli.Context) error {
-							assetTeams, err := a.assetService.GetAssetTeams()
-							if err != nil {
-								return err
-							}
-
-							if len(assetTeams) == 0 {
-								fmt.Println("No team assignments found")
-								return nil
-							}
-
-							fmt.Println("Asset Team Assignments:")
-							fmt.Println("═══════════════════════════════════════")
-							for _, info := range assetTeams {
-								fmt.Printf("📦 %s\n", info.AssetName)
-								if info.OwningTeam != "" {
-									fmt.Printf("  👤 Owner: %s\n", info.OwningTeam)
-								}
-								if len(info.ContributingTeams) > 0 {
-									fmt.Printf("  🤝 Contributors: %s\n", strings.Join(info.ContributingTeams, ", "))
-								}
-								fmt.Println()
-							}
-							return nil
+						Name:   "list",
+						Usage:  "List asset team assignments",
+						Action: a.assetsTeamsListAction,
+					},
+					{
+						Name:   "show",
+						Usage:  "Show team assignments for a specific asset",
+						Action: a.assetsTeamsShowAction,
+						Flags: []cli.Flag{
+							&cli.StringFlag{Name: "asset", Usage: "Asset name", Required: true},
 						},
 					},
 					{
-						Name:  "show",
-						Usage: "Show team assignments for a specific asset",
-						Action: func(ctx *cli.Context) error {
-							assetName := ctx.String("asset")
-
-							info, err := a.assetService.GetAssetTeamInfo(assetName)
-							if err != nil {
-								return err
-							}
-
-							fmt.Printf("Team Assignments for '%s':\n", info.AssetName)
-							fmt.Println("─────────────────────────────────")
-							if info.OwningTeam != "" {
-								fmt.Printf("👤 Owner: %s\n", info.OwningTeam)
-							} else {
-								fmt.Println("👤 Owner: Not assigned")
-							}
-
-							if len(info.ContributingTeams) > 0 {
-								fmt.Printf("🤝 Contributors: %s\n", strings.Join(info.ContributingTeams, ", "))
-							} else {
-								fmt.Println("🤝 Contributors: None")
-							}
-
-							return nil
-						},
+						Name:   "add-contributor",
+						Usage:  "Add a contributing team to an asset",
+						Action: a.assetsTeamsAddContributorAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "asset",
-								Usage:    "Asset name",
-								Required: true,
-							},
+							&cli.StringFlag{Name: "asset", Usage: "Asset name", Required: true},
+							&cli.StringFlag{Name: "team", Usage: "Team name to add as contributor", Required: true},
 						},
 					},
 					{
-						Name:  "add-contributor",
-						Usage: "Add a contributing team to an asset",
-						Action: func(ctx *cli.Context) error {
-							assetName := ctx.String("asset")
-							teamName := ctx.String("team")
-
-							if err := a.assetService.AddContributingTeam(assetName, teamName); err != nil {
-								return err
-							}
-
-							fmt.Printf("✓ Added '%s' as contributor to asset '%s'\n", teamName, assetName)
-							return nil
-						},
+						Name:   "remove-contributor",
+						Usage:  "Remove a contributing team from an asset",
+						Action: a.assetsTeamsRemoveContributorAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "asset",
-								Usage:    "Asset name",
-								Required: true,
-							},
-							&cli.StringFlag{
-								Name:     "team",
-								Usage:    "Team name to add as contributor",
-								Required: true,
-							},
-						},
-					},
-					{
-						Name:  "remove-contributor",
-						Usage: "Remove a contributing team from an asset",
-						Action: func(ctx *cli.Context) error {
-							assetName := ctx.String("asset")
-							teamName := ctx.String("team")
-
-							if err := a.assetService.RemoveContributingTeam(assetName, teamName); err != nil {
-								return err
-							}
-
-							fmt.Printf("✓ Removed '%s' as contributor from asset '%s'\n", teamName, assetName)
-							return nil
-						},
-						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "asset",
-								Usage:    "Asset name",
-								Required: true,
-							},
-							&cli.StringFlag{
-								Name:     "team",
-								Usage:    "Team name to remove as contributor",
-								Required: true,
-							},
+							&cli.StringFlag{Name: "asset", Usage: "Asset name", Required: true},
+							&cli.StringFlag{Name: "team", Usage: "Team name to remove as contributor", Required: true},
 						},
 					},
 				},
@@ -904,5 +731,139 @@ func (a *App) assetsKeywordsAction(ctx *cli.Context) error {
 		return err
 	}
 	fmt.Printf("Generated keywords for asset: %s\n", name)
+	return nil
+}
+
+// assetsDocUpdateAction backs `assetcap assets documentation update`.
+// Pre-checks the asset exists so a typo produces a clear "not found"
+// instead of a misleading downstream error.
+func (a *App) assetsDocUpdateAction(ctx *cli.Context) error {
+	assetName := ctx.String("asset")
+	if _, err := a.assetService.GetAsset(assetName); err != nil {
+		return err
+	}
+	if err := a.assetService.UpdateDocumentation(assetName); err != nil {
+		return err
+	}
+	fmt.Printf("Marked documentation as updated for asset %s\n", assetName)
+	return nil
+}
+
+// assetsTasksIncrementAction backs `assetcap assets tasks increment`.
+func (a *App) assetsTasksIncrementAction(ctx *cli.Context) error {
+	assetName := ctx.String("asset")
+	if _, err := a.assetService.GetAsset(assetName); err != nil {
+		return err
+	}
+	if err := a.assetService.IncrementTaskCount(assetName); err != nil {
+		return err
+	}
+	fmt.Printf("Incremented task count for asset %s\n", assetName)
+	return nil
+}
+
+// assetsTasksDecrementAction backs `assetcap assets tasks decrement`.
+func (a *App) assetsTasksDecrementAction(ctx *cli.Context) error {
+	assetName := ctx.String("asset")
+	if _, err := a.assetService.GetAsset(assetName); err != nil {
+		return err
+	}
+	if err := a.assetService.DecrementTaskCount(assetName); err != nil {
+		return err
+	}
+	fmt.Printf("Decremented task count for asset %s\n", assetName)
+	return nil
+}
+
+// assetsTeamsAssignAction backs `assetcap assets teams assign`.
+func (a *App) assetsTeamsAssignAction(ctx *cli.Context) error {
+	assetName := ctx.String("asset")
+	owningTeam := ctx.String("owner")
+	contributingTeams := parseCommaSeparated(ctx.String("contributors"))
+
+	if err := a.assetService.AssignTeam(assetName, owningTeam, contributingTeams); err != nil {
+		return err
+	}
+
+	fmt.Printf("✓ Successfully assigned teams to asset '%s'\n", assetName)
+	if owningTeam != "" {
+		fmt.Printf("  Owner: %s\n", owningTeam)
+	}
+	if len(contributingTeams) > 0 {
+		fmt.Printf("  Contributors: %s\n", strings.Join(contributingTeams, ", "))
+	}
+	return nil
+}
+
+// assetsTeamsListAction backs `assetcap assets teams list`.
+func (a *App) assetsTeamsListAction(_ *cli.Context) error {
+	assetTeams, err := a.assetService.GetAssetTeams()
+	if err != nil {
+		return err
+	}
+
+	if len(assetTeams) == 0 {
+		fmt.Println("No team assignments found")
+		return nil
+	}
+
+	fmt.Println("Asset Team Assignments:")
+	fmt.Println("═══════════════════════════════════════")
+	for _, info := range assetTeams {
+		fmt.Printf("📦 %s\n", info.AssetName)
+		if info.OwningTeam != "" {
+			fmt.Printf("  👤 Owner: %s\n", info.OwningTeam)
+		}
+		if len(info.ContributingTeams) > 0 {
+			fmt.Printf("  🤝 Contributors: %s\n", strings.Join(info.ContributingTeams, ", "))
+		}
+		fmt.Println()
+	}
+	return nil
+}
+
+// assetsTeamsShowAction backs `assetcap assets teams show`.
+func (a *App) assetsTeamsShowAction(ctx *cli.Context) error {
+	assetName := ctx.String("asset")
+	info, err := a.assetService.GetAssetTeamInfo(assetName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Team Assignments for '%s':\n", info.AssetName)
+	fmt.Println("─────────────────────────────────")
+	if info.OwningTeam != "" {
+		fmt.Printf("👤 Owner: %s\n", info.OwningTeam)
+	} else {
+		fmt.Println("👤 Owner: Not assigned")
+	}
+
+	if len(info.ContributingTeams) > 0 {
+		fmt.Printf("🤝 Contributors: %s\n", strings.Join(info.ContributingTeams, ", "))
+	} else {
+		fmt.Println("🤝 Contributors: None")
+	}
+	return nil
+}
+
+// assetsTeamsAddContributorAction backs `assetcap assets teams add-contributor`.
+func (a *App) assetsTeamsAddContributorAction(ctx *cli.Context) error {
+	assetName := ctx.String("asset")
+	teamName := ctx.String("team")
+	if err := a.assetService.AddContributingTeam(assetName, teamName); err != nil {
+		return err
+	}
+	fmt.Printf("✓ Added '%s' as contributor to asset '%s'\n", teamName, assetName)
+	return nil
+}
+
+// assetsTeamsRemoveContributorAction backs `assetcap assets teams remove-contributor`.
+func (a *App) assetsTeamsRemoveContributorAction(ctx *cli.Context) error {
+	assetName := ctx.String("asset")
+	teamName := ctx.String("team")
+	if err := a.assetService.RemoveContributingTeam(assetName, teamName); err != nil {
+		return err
+	}
+	fmt.Printf("✓ Removed '%s' as contributor from asset '%s'\n", teamName, assetName)
 	return nil
 }

--- a/cmd/assets_nested_actions_test.go
+++ b/cmd/assets_nested_actions_test.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	assetsapp "github.com/helmedeiros/digital-asset-capitalization/internal/assets/application"
+	assetdomain "github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
+)
+
+// stubAssetServiceForNested extends stubAssetServiceForActions with
+// the methods called by the documentation/tasks/teams subcommand
+// trees. We keep it separate so the existing PR 4 stub stays scoped
+// to the simple Actions.
+type stubAssetServiceForNested struct {
+	unimplementedAssetService
+
+	asset    *assetdomain.Asset
+	assetErr error
+
+	updateDocErr error
+	incErr       error
+	decErr       error
+
+	assignErr error
+
+	listTeams    []assetsapp.AssetTeamInfo
+	listTeamsErr error
+
+	teamInfo    *assetsapp.AssetTeamInfo
+	teamInfoErr error
+
+	addErr error
+	rmErr  error
+}
+
+func (s *stubAssetServiceForNested) GetAsset(string) (*assetdomain.Asset, error) {
+	return s.asset, s.assetErr
+}
+func (s *stubAssetServiceForNested) UpdateDocumentation(string) error { return s.updateDocErr }
+func (s *stubAssetServiceForNested) IncrementTaskCount(string) error  { return s.incErr }
+func (s *stubAssetServiceForNested) DecrementTaskCount(string) error  { return s.decErr }
+func (s *stubAssetServiceForNested) AssignTeam(string, string, []string) error {
+	return s.assignErr
+}
+func (s *stubAssetServiceForNested) GetAssetTeams() ([]assetsapp.AssetTeamInfo, error) {
+	return s.listTeams, s.listTeamsErr
+}
+func (s *stubAssetServiceForNested) GetAssetTeamInfo(string) (*assetsapp.AssetTeamInfo, error) {
+	return s.teamInfo, s.teamInfoErr
+}
+func (s *stubAssetServiceForNested) AddContributingTeam(string, string) error {
+	return s.addErr
+}
+func (s *stubAssetServiceForNested) RemoveContributingTeam(string, string) error {
+	return s.rmErr
+}
+
+// documentation/update
+
+func TestApp_assetsDocUpdateAction_AssetNotFound(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForNested{assetErr: errors.New("nope")}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search"}, nil)
+	err := a.assetsDocUpdateAction(ctx)
+	require.Error(t, err)
+	assert.Equal(t, "nope", err.Error())
+}
+
+func TestApp_assetsDocUpdateAction_UpdateErrorBubbles(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForNested{
+		asset:        &assetdomain.Asset{Name: "Search"},
+		updateDocErr: errors.New("disk"),
+	}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search"}, nil)
+	err := a.assetsDocUpdateAction(ctx)
+	require.Error(t, err)
+	assert.Equal(t, "disk", err.Error())
+}
+
+func TestApp_assetsDocUpdateAction_Success(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForNested{asset: &assetdomain.Asset{Name: "Search"}}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search"}, nil)
+	out, err := captureStdout(t, func() error { return a.assetsDocUpdateAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Marked documentation as updated for asset Search")
+}
+
+// tasks/increment
+
+func TestApp_assetsTasksIncrementAction_AssetNotFound(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForNested{assetErr: errors.New("nope")}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search"}, nil)
+	err := a.assetsTasksIncrementAction(ctx)
+	require.Error(t, err)
+}
+
+func TestApp_assetsTasksIncrementAction_IncrementErrorBubbles(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForNested{
+		asset:  &assetdomain.Asset{Name: "Search"},
+		incErr: errors.New("overflow"),
+	}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search"}, nil)
+	err := a.assetsTasksIncrementAction(ctx)
+	require.Error(t, err)
+	assert.Equal(t, "overflow", err.Error())
+}
+
+func TestApp_assetsTasksIncrementAction_Success(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForNested{asset: &assetdomain.Asset{Name: "Search"}}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search"}, nil)
+	out, err := captureStdout(t, func() error { return a.assetsTasksIncrementAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Incremented task count for asset Search")
+}
+
+// tasks/decrement
+
+func TestApp_assetsTasksDecrementAction_AssetNotFound(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForNested{assetErr: errors.New("nope")}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search"}, nil)
+	err := a.assetsTasksDecrementAction(ctx)
+	require.Error(t, err)
+}
+
+func TestApp_assetsTasksDecrementAction_DecrementErrorBubbles(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForNested{
+		asset:  &assetdomain.Asset{Name: "Search"},
+		decErr: errors.New("underflow"),
+	}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search"}, nil)
+	err := a.assetsTasksDecrementAction(ctx)
+	require.Error(t, err)
+}
+
+func TestApp_assetsTasksDecrementAction_Success(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForNested{asset: &assetdomain.Asset{Name: "Search"}}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search"}, nil)
+	out, err := captureStdout(t, func() error { return a.assetsTasksDecrementAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Decremented task count for asset Search")
+}
+
+// teams/assign
+
+func TestApp_assetsTeamsAssignAction_ServiceErrorBubbles(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForNested{assignErr: errors.New("conflict")}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"asset": "Search", "owner": "Voyager", "contributors": "Catalog,Indexer"},
+		nil,
+	)
+	err := a.assetsTeamsAssignAction(ctx)
+	require.Error(t, err)
+	assert.Equal(t, "conflict", err.Error())
+}
+
+func TestApp_assetsTeamsAssignAction_PrintsContributors(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForNested{}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"asset": "Search", "owner": "Voyager", "contributors": "Catalog,Indexer"},
+		nil,
+	)
+	out, err := captureStdout(t, func() error { return a.assetsTeamsAssignAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "assigned teams to asset 'Search'")
+	assert.Contains(t, out, "Owner: Voyager")
+	assert.Contains(t, out, "Catalog, Indexer")
+}
+
+func TestApp_assetsTeamsAssignAction_OwnerOnlyNoContributors(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForNested{}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"asset": "Search", "owner": "Voyager"},
+		nil,
+	)
+	out, err := captureStdout(t, func() error { return a.assetsTeamsAssignAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Owner: Voyager")
+	assert.NotContains(t, out, "Contributors:")
+}
+
+// teams/list
+
+func TestApp_assetsTeamsListAction_EmptyList(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForNested{}}
+	out, err := captureStdout(t, func() error { return a.assetsTeamsListAction(nil) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "No team assignments found")
+}
+
+func TestApp_assetsTeamsListAction_RendersAssignments(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForNested{
+		listTeams: []assetsapp.AssetTeamInfo{
+			{AssetName: "Search", OwningTeam: "Voyager", ContributingTeams: []string{"Catalog"}},
+			{AssetName: "Payments", OwningTeam: "Pay"},
+		},
+	}}
+	out, err := captureStdout(t, func() error { return a.assetsTeamsListAction(nil) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Search")
+	assert.Contains(t, out, "Payments")
+	assert.Contains(t, out, "Voyager")
+}
+
+func TestApp_assetsTeamsListAction_ServiceErrorBubbles(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForNested{listTeamsErr: errors.New("disk")}}
+	err := a.assetsTeamsListAction(nil)
+	require.Error(t, err)
+}
+
+// teams/show
+
+func TestApp_assetsTeamsShowAction_NotAssigned(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForNested{
+		teamInfo: &assetsapp.AssetTeamInfo{AssetName: "Search"},
+	}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search"}, nil)
+	out, err := captureStdout(t, func() error { return a.assetsTeamsShowAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Owner: Not assigned")
+	assert.Contains(t, out, "Contributors: None")
+}
+
+func TestApp_assetsTeamsShowAction_RendersBoth(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForNested{
+		teamInfo: &assetsapp.AssetTeamInfo{
+			AssetName:         "Search",
+			OwningTeam:        "Voyager",
+			ContributingTeams: []string{"Catalog", "Indexer"},
+		},
+	}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search"}, nil)
+	out, err := captureStdout(t, func() error { return a.assetsTeamsShowAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Owner: Voyager")
+	assert.Contains(t, out, "Catalog, Indexer")
+}
+
+func TestApp_assetsTeamsShowAction_ServiceErrorBubbles(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForNested{teamInfoErr: errors.New("missing")}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search"}, nil)
+	err := a.assetsTeamsShowAction(ctx)
+	require.Error(t, err)
+}
+
+// teams/add-contributor
+
+func TestApp_assetsTeamsAddContributorAction_ServiceErrorBubbles(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForNested{addErr: errors.New("dup")}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search", "team": "Catalog"}, nil)
+	err := a.assetsTeamsAddContributorAction(ctx)
+	require.Error(t, err)
+}
+
+func TestApp_assetsTeamsAddContributorAction_Success(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForNested{}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search", "team": "Catalog"}, nil)
+	out, err := captureStdout(t, func() error { return a.assetsTeamsAddContributorAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Added 'Catalog' as contributor to asset 'Search'")
+}
+
+// teams/remove-contributor
+
+func TestApp_assetsTeamsRemoveContributorAction_ServiceErrorBubbles(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForNested{rmErr: errors.New("not present")}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search", "team": "Catalog"}, nil)
+	err := a.assetsTeamsRemoveContributorAction(ctx)
+	require.Error(t, err)
+}
+
+func TestApp_assetsTeamsRemoveContributorAction_Success(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForNested{}}
+	ctx := newContextWithFlags(t, map[string]string{"asset": "Search", "team": "Catalog"}, nil)
+	out, err := captureStdout(t, func() error { return a.assetsTeamsRemoveContributorAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Removed 'Catalog' as contributor from asset 'Search'")
+}


### PR DESCRIPTION
## Summary

Continues the cmd/ Action extraction series. Lifts the **8 nested assets Actions** — documentation/update, tasks/{increment, decrement}, teams/{assign, list, show, add-contributor, remove-contributor} — into named methods on \`*App\`.

All 8 are simple delegators to the AssetService, perfect for stub-driven tests.

## Coverage

| Group | Actions | Coverage |
|---|---|---|
| documentation | update | **100%** |
| tasks (nested) | increment, decrement | **100%** |
| teams | assign, list, show, add-contributor, remove-contributor | **100%** |
| **Project total** | | **82.6% → 83.3%** (+0.7pp) |

## Test design

- New \`stubAssetServiceForNested\` embeds \`unimplementedAssetService\` and opts in to the 8 methods these Actions call. Kept separate from \`stubAssetServiceForActions\` (PR #144) so each stub stays scoped.
- \`assetsTeamsAssignAction\` reuses the \`parseCommaSeparated\` helper introduced in PR #141 (sprint Actions); same comma-with-trim shape for \`--contributors\`.
- **24 new tests** cover: asset-not-found pre-checks, service-error bubble, happy paths (with stdout capture).

## Scientific validation
- All **8 nested \`--help\` surfaces** byte-identical to pre-refactor binary ✅
- \`go test -race ./...\` passes ✅
- \`golangci-lint run\` clean ✅