### PR TITLE
refactor(cmd): extract sync, publish, update-confluence into named methods

### DIFF
--- a/cmd/assets_commands.go
+++ b/cmd/assets_commands.go
@@ -46,167 +46,35 @@ func (a *App) createAssetsCommand() *cli.Command {
 				Action: a.assetsListAction,
 			},
 			{
-				Name:  "sync",
-				Usage: "Sync assets from Confluence",
-				Action: func(ctx *cli.Context) error {
-					space := ctx.String("space")
-					label := ctx.String("label")
-					debug := ctx.Bool("debug")
-
-					result, err := a.assetService.SyncFromConfluence(space, label, debug)
-					if err != nil {
-						if strings.Contains(err.Error(), "no assets found with label") {
-							fmt.Println(err)
-							return nil
-						}
-						return err
-					}
-
-					totalAssets := len(result.SyncedAssets) + len(result.NotSyncedAssets)
-					fmt.Printf("Successfully synced %d/%d assets from Confluence\n", len(result.SyncedAssets), totalAssets)
-
-					if len(result.NotSyncedAssets) > 0 {
-						fmt.Printf("\nWarning: %d assets could not be synced due to missing information:\n", len(result.NotSyncedAssets))
-						for _, asset := range result.NotSyncedAssets {
-							fmt.Printf("\n- %s:\n", asset.Name)
-							fmt.Printf("  Missing fields: %s\n", strings.Join(asset.MissingFields, ", "))
-							fmt.Println("  Available fields:")
-							for field, value := range asset.AvailableFields {
-								if value != "" {
-									fmt.Printf("    %s: %s\n", field, value)
-								}
-							}
-						}
-					}
-
-					return nil
-				},
+				Name:   "sync",
+				Usage:  "Sync assets from Confluence",
+				Action: a.assetsSyncAction,
 				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     "space",
-						Usage:    "Confluence space key(s). Single: 'MZN', Multiple: 'MZN,CAP,DOC', All: '*' or omit",
-						Required: false,
-					},
-					&cli.StringFlag{
-						Name:     "label",
-						Usage:    "Filter pages by label (e.g. cap-asset)",
-						Required: true,
-					},
-					&cli.BoolFlag{
-						Name:  "debug",
-						Usage: "Enable debug logging",
-						Value: false,
-					},
+					&cli.StringFlag{Name: "space", Usage: "Confluence space key(s). Single: 'MZN', Multiple: 'MZN,CAP,DOC', All: '*' or omit", Required: false},
+					&cli.StringFlag{Name: "label", Usage: "Filter pages by label (e.g. cap-asset)", Required: true},
+					&cli.BoolFlag{Name: "debug", Usage: "Enable debug logging", Value: false},
 				},
 			},
 			{
-				Name:  "publish",
-				Usage: "Publish an asset to Confluence as a new page",
-				Action: func(ctx *cli.Context) error {
-					name := ctx.String("name")
-					space := ctx.String("space")
-					parentPage := ctx.String("parent-page")
-					dryRun := ctx.Bool("dry-run")
-					debug := ctx.Bool("debug")
-
-					result, err := a.assetService.PublishToConfluence(context.Background(), name, space, parentPage, dryRun, debug)
-					if err != nil {
-						return err
-					}
-
-					if dryRun {
-						fmt.Printf("DRY RUN: Would create page for asset '%s' in space '%s'\n", result.AssetName, result.SpaceKey)
-						fmt.Printf("Labels to add: %v\n", result.Labels)
-						fmt.Printf("\nPreview of page content:\n")
-						fmt.Println("────────────────────────────────────────")
-						fmt.Println(result.Preview)
-						fmt.Println("────────────────────────────────────────")
-						return nil
-					}
-
-					fmt.Printf("Successfully published asset '%s' to Confluence\n", result.AssetName)
-					fmt.Printf("  Page ID: %s\n", result.PageID)
-					fmt.Printf("  Space: %s\n", result.SpaceKey)
-					fmt.Printf("  URL: %s\n", result.PageURL)
-					fmt.Printf("  Labels: %v\n", result.Labels)
-					if result.DocLinkSaved {
-						fmt.Printf("  DocLink updated in asset\n")
-					}
-					return nil
-				},
+				Name:   "publish",
+				Usage:  "Publish an asset to Confluence as a new page",
+				Action: a.assetsPublishAction,
 				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     "name",
-						Usage:    "Asset name to publish",
-						Required: true,
-					},
-					&cli.StringFlag{
-						Name:     "space",
-						Usage:    "Confluence space key (e.g., Conversion)",
-						Required: true,
-					},
-					&cli.StringFlag{
-						Name:  "parent-page",
-						Usage: "Parent page ID to create under (overrides team config)",
-					},
-					&cli.BoolFlag{
-						Name:  "dry-run",
-						Usage: "Preview without creating the page",
-						Value: false,
-					},
-					&cli.BoolFlag{
-						Name:  "debug",
-						Usage: "Enable debug output",
-						Value: false,
-					},
+					&cli.StringFlag{Name: "name", Usage: "Asset name to publish", Required: true},
+					&cli.StringFlag{Name: "space", Usage: "Confluence space key (e.g., Conversion)", Required: true},
+					&cli.StringFlag{Name: "parent-page", Usage: "Parent page ID to create under (overrides team config)"},
+					&cli.BoolFlag{Name: "dry-run", Usage: "Preview without creating the page", Value: false},
+					&cli.BoolFlag{Name: "debug", Usage: "Enable debug output", Value: false},
 				},
 			},
 			{
-				Name:  "update-confluence",
-				Usage: "Update an existing Confluence page with the asset's current content",
-				Action: func(ctx *cli.Context) error {
-					name := ctx.String("name")
-					dryRun := ctx.Bool("dry-run")
-					debug := ctx.Bool("debug")
-
-					result, err := a.assetService.UpdateConfluencePage(context.Background(), name, dryRun, debug)
-					if err != nil {
-						return err
-					}
-
-					if dryRun {
-						fmt.Printf("DRY RUN: Would update page for asset '%s'\n", result.AssetName)
-						fmt.Printf("  Page ID: %s\n", result.PageID)
-						fmt.Printf("  Space: %s\n", result.SpaceKey)
-						fmt.Printf("\nPreview of page content:\n")
-						fmt.Println("────────────────────────────────────────")
-						fmt.Println(result.Preview)
-						fmt.Println("────────────────────────────────────────")
-						return nil
-					}
-
-					fmt.Printf("Successfully updated Confluence page for asset '%s'\n", result.AssetName)
-					fmt.Printf("  Page ID: %s\n", result.PageID)
-					fmt.Printf("  Space: %s\n", result.SpaceKey)
-					fmt.Printf("  URL: %s\n", result.PageURL)
-					return nil
-				},
+				Name:   "update-confluence",
+				Usage:  "Update an existing Confluence page with the asset's current content",
+				Action: a.assetsUpdateConfluenceAction,
 				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     "name",
-						Usage:    "Asset name to update",
-						Required: true,
-					},
-					&cli.BoolFlag{
-						Name:  "dry-run",
-						Usage: "Preview without updating the page",
-						Value: false,
-					},
-					&cli.BoolFlag{
-						Name:  "debug",
-						Usage: "Enable debug output",
-						Value: false,
-					},
+					&cli.StringFlag{Name: "name", Usage: "Asset name to update", Required: true},
+					&cli.BoolFlag{Name: "dry-run", Usage: "Preview without updating the page", Value: false},
+					&cli.BoolFlag{Name: "debug", Usage: "Enable debug output", Value: false},
 				},
 			},
 			{
@@ -904,5 +772,105 @@ func (a *App) assetsKeywordsAction(ctx *cli.Context) error {
 		return err
 	}
 	fmt.Printf("Generated keywords for asset: %s\n", name)
+	return nil
+}
+
+// assetsSyncAction backs `assetcap assets sync`. Special-cases the
+// "no assets found with label" service error as an informational
+// success (since that's expected when running against an empty space)
+// while surfacing every other error to the caller.
+func (a *App) assetsSyncAction(ctx *cli.Context) error {
+	space := ctx.String("space")
+	label := ctx.String("label")
+	debug := ctx.Bool("debug")
+
+	result, err := a.assetService.SyncFromConfluence(space, label, debug)
+	if err != nil {
+		if strings.Contains(err.Error(), "no assets found with label") {
+			fmt.Println(err)
+			return nil
+		}
+		return err
+	}
+
+	totalAssets := len(result.SyncedAssets) + len(result.NotSyncedAssets)
+	fmt.Printf("Successfully synced %d/%d assets from Confluence\n", len(result.SyncedAssets), totalAssets)
+
+	if len(result.NotSyncedAssets) > 0 {
+		fmt.Printf("\nWarning: %d assets could not be synced due to missing information:\n", len(result.NotSyncedAssets))
+		for _, asset := range result.NotSyncedAssets {
+			fmt.Printf("\n- %s:\n", asset.Name)
+			fmt.Printf("  Missing fields: %s\n", strings.Join(asset.MissingFields, ", "))
+			fmt.Println("  Available fields:")
+			for field, value := range asset.AvailableFields {
+				if value != "" {
+					fmt.Printf("    %s: %s\n", field, value)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// assetsPublishAction backs `assetcap assets publish`.
+func (a *App) assetsPublishAction(ctx *cli.Context) error {
+	name := ctx.String("name")
+	space := ctx.String("space")
+	parentPage := ctx.String("parent-page")
+	dryRun := ctx.Bool("dry-run")
+	debug := ctx.Bool("debug")
+
+	result, err := a.assetService.PublishToConfluence(context.Background(), name, space, parentPage, dryRun, debug)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		fmt.Printf("DRY RUN: Would create page for asset '%s' in space '%s'\n", result.AssetName, result.SpaceKey)
+		fmt.Printf("Labels to add: %v\n", result.Labels)
+		fmt.Printf("\nPreview of page content:\n")
+		fmt.Println("────────────────────────────────────────")
+		fmt.Println(result.Preview)
+		fmt.Println("────────────────────────────────────────")
+		return nil
+	}
+
+	fmt.Printf("Successfully published asset '%s' to Confluence\n", result.AssetName)
+	fmt.Printf("  Page ID: %s\n", result.PageID)
+	fmt.Printf("  Space: %s\n", result.SpaceKey)
+	fmt.Printf("  URL: %s\n", result.PageURL)
+	fmt.Printf("  Labels: %v\n", result.Labels)
+	if result.DocLinkSaved {
+		fmt.Printf("  DocLink updated in asset\n")
+	}
+	return nil
+}
+
+// assetsUpdateConfluenceAction backs `assetcap assets update-confluence`.
+func (a *App) assetsUpdateConfluenceAction(ctx *cli.Context) error {
+	name := ctx.String("name")
+	dryRun := ctx.Bool("dry-run")
+	debug := ctx.Bool("debug")
+
+	result, err := a.assetService.UpdateConfluencePage(context.Background(), name, dryRun, debug)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		fmt.Printf("DRY RUN: Would update page for asset '%s'\n", result.AssetName)
+		fmt.Printf("  Page ID: %s\n", result.PageID)
+		fmt.Printf("  Space: %s\n", result.SpaceKey)
+		fmt.Printf("\nPreview of page content:\n")
+		fmt.Println("────────────────────────────────────────")
+		fmt.Println(result.Preview)
+		fmt.Println("────────────────────────────────────────")
+		return nil
+	}
+
+	fmt.Printf("Successfully updated Confluence page for asset '%s'\n", result.AssetName)
+	fmt.Printf("  Page ID: %s\n", result.PageID)
+	fmt.Printf("  Space: %s\n", result.SpaceKey)
+	fmt.Printf("  URL: %s\n", result.PageURL)
 	return nil
 }

--- a/cmd/assets_confluence_actions_test.go
+++ b/cmd/assets_confluence_actions_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	assetsapp "github.com/helmedeiros/digital-asset-capitalization/internal/assets/application"
+	assetdomain "github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
+)
+
+// stubAssetServiceForConfluence covers the 3 Confluence-side
+// AssetService methods consumed by sync/publish/update-confluence.
+// Embeds unimplementedAssetService so unexpected method calls panic.
+type stubAssetServiceForConfluence struct {
+	unimplementedAssetService
+
+	syncResult    *assetdomain.SyncResult
+	syncErr       error
+	publishResult *assetsapp.PublishToConfluenceResult
+	publishErr    error
+	updateResult  *assetsapp.PublishToConfluenceResult
+	updateErr     error
+}
+
+func (s *stubAssetServiceForConfluence) SyncFromConfluence(string, string, bool) (*assetdomain.SyncResult, error) {
+	return s.syncResult, s.syncErr
+}
+func (s *stubAssetServiceForConfluence) PublishToConfluence(context.Context, string, string, string, bool, bool) (*assetsapp.PublishToConfluenceResult, error) {
+	return s.publishResult, s.publishErr
+}
+func (s *stubAssetServiceForConfluence) UpdateConfluencePage(context.Context, string, bool, bool) (*assetsapp.PublishToConfluenceResult, error) {
+	return s.updateResult, s.updateErr
+}
+
+// sync
+
+func TestApp_assetsSyncAction_NoAssetsLabelIsInformationalSuccess(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForConfluence{
+		syncErr: errors.New("no assets found with label cap-asset"),
+	}}
+	ctx := newContextWithFlags(t, map[string]string{"space": "MZN", "label": "cap-asset"}, nil)
+	out, err := captureStdout(t, func() error { return a.assetsSyncAction(ctx) })
+	require.NoError(t, err, "this specific error swallows to a no-op success")
+	assert.Contains(t, out, "no assets found with label")
+}
+
+func TestApp_assetsSyncAction_GenericErrorBubbles(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForConfluence{syncErr: errors.New("auth failed")}}
+	ctx := newContextWithFlags(t, map[string]string{"label": "cap-asset"}, nil)
+	err := a.assetsSyncAction(ctx)
+	require.Error(t, err)
+	assert.Equal(t, "auth failed", err.Error())
+}
+
+func TestApp_assetsSyncAction_AllAssetsSyncedRendersCount(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForConfluence{
+		syncResult: &assetdomain.SyncResult{
+			SyncedAssets: []*assetdomain.Asset{{Name: "Search"}, {Name: "Payments"}},
+		},
+	}}
+	ctx := newContextWithFlags(t, map[string]string{"label": "cap-asset"}, nil)
+	out, err := captureStdout(t, func() error { return a.assetsSyncAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Successfully synced 2/2 assets")
+	assert.NotContains(t, out, "could not be synced")
+}
+
+func TestApp_assetsSyncAction_PartialSyncRendersNotSyncedDetails(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForConfluence{
+		syncResult: &assetdomain.SyncResult{
+			SyncedAssets: []*assetdomain.Asset{{Name: "Search"}},
+			NotSyncedAssets: []*assetdomain.NotSyncedAsset{
+				{
+					Name:            "Broken",
+					MissingFields:   []string{"Description", "Status"},
+					AvailableFields: map[string]string{"Name": "Broken", "Why": "experimental"},
+				},
+			},
+		},
+	}}
+	ctx := newContextWithFlags(t, map[string]string{"label": "cap-asset"}, nil)
+	out, err := captureStdout(t, func() error { return a.assetsSyncAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Successfully synced 1/2 assets")
+	assert.Contains(t, out, "1 assets could not be synced")
+	assert.Contains(t, out, "Broken")
+	assert.Contains(t, out, "Description, Status")
+	assert.Contains(t, out, "Why: experimental")
+}
+
+// publish
+
+func TestApp_assetsPublishAction_ServiceErrorBubbles(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForConfluence{publishErr: errors.New("403")}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"name": "Search", "space": "MZN"},
+		nil,
+	)
+	err := a.assetsPublishAction(ctx)
+	require.Error(t, err)
+}
+
+func TestApp_assetsPublishAction_DryRunRendersPreview(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForConfluence{
+		publishResult: &assetsapp.PublishToConfluenceResult{
+			AssetName: "Search",
+			SpaceKey:  "MZN",
+			Labels:    []string{"cap-asset"},
+			Preview:   "<p>preview body</p>",
+		},
+	}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"name": "Search", "space": "MZN"},
+		map[string]bool{"dry-run": true},
+	)
+	out, err := captureStdout(t, func() error { return a.assetsPublishAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "DRY RUN")
+	assert.Contains(t, out, "<p>preview body</p>")
+	assert.Contains(t, out, "cap-asset")
+}
+
+func TestApp_assetsPublishAction_LiveSuccessRendersURLAndDocLink(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForConfluence{
+		publishResult: &assetsapp.PublishToConfluenceResult{
+			AssetName:    "Search",
+			SpaceKey:     "MZN",
+			PageID:       "12345",
+			PageURL:      "https://example/wiki/12345",
+			Labels:       []string{"cap-asset"},
+			DocLinkSaved: true,
+		},
+	}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"name": "Search", "space": "MZN"},
+		nil,
+	)
+	out, err := captureStdout(t, func() error { return a.assetsPublishAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Successfully published asset 'Search' to Confluence")
+	assert.Contains(t, out, "Page ID: 12345")
+	assert.Contains(t, out, "https://example/wiki/12345")
+	assert.Contains(t, out, "DocLink updated in asset")
+}
+
+// update-confluence
+
+func TestApp_assetsUpdateConfluenceAction_ServiceErrorBubbles(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForConfluence{updateErr: errors.New("conflict")}}
+	ctx := newContextWithFlags(t, map[string]string{"name": "Search"}, nil)
+	err := a.assetsUpdateConfluenceAction(ctx)
+	require.Error(t, err)
+}
+
+func TestApp_assetsUpdateConfluenceAction_DryRunRendersPreview(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForConfluence{
+		updateResult: &assetsapp.PublishToConfluenceResult{
+			AssetName: "Search",
+			SpaceKey:  "MZN",
+			PageID:    "12345",
+			Preview:   "<p>preview body</p>",
+		},
+	}}
+	ctx := newContextWithFlags(t, map[string]string{"name": "Search"}, map[string]bool{"dry-run": true})
+	out, err := captureStdout(t, func() error { return a.assetsUpdateConfluenceAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "DRY RUN: Would update page for asset 'Search'")
+	assert.Contains(t, out, "<p>preview body</p>")
+}
+
+func TestApp_assetsUpdateConfluenceAction_LiveSuccessRendersURL(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{assetService: &stubAssetServiceForConfluence{
+		updateResult: &assetsapp.PublishToConfluenceResult{
+			AssetName: "Search",
+			SpaceKey:  "MZN",
+			PageID:    "12345",
+			PageURL:   "https://example/wiki/12345",
+		},
+	}}
+	ctx := newContextWithFlags(t, map[string]string{"name": "Search"}, nil)
+	out, err := captureStdout(t, func() error { return a.assetsUpdateConfluenceAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Successfully updated Confluence page for asset 'Search'")
+	assert.Contains(t, out, "Page ID: 12345")
+	assert.Contains(t, out, "https://example/wiki/12345")
+}


### PR DESCRIPTION
## Summary

Continues the cmd/ Action extraction series with the three **Confluence-side assets Actions**. All three call methods on \`a.assetService\` directly — stub-driven testable without any seam refactor.

## Coverage

| Action | Coverage | Notes |
|---|---|---|
| assetsSyncAction | **100%** | special-cases "no assets found with label" as informational success |
| assetsPublishAction | **100%** | renders DRY RUN preview vs live success with DocLink-updated marker |
| assetsUpdateConfluenceAction | **100%** | same dry-run/live success shape, simpler payload |

**12 new tests** drive every branch.

## Test design

New \`stubAssetServiceForConfluence\` covers the 3 service methods. The existing \`stubAssetServiceForActions\` (PR #144) and \`stubAssetServiceForNested\` (PR #148) stay scoped to their own Actions so each test file's blast radius is contained.

## Scientific validation
- All **4 \`--help\` surfaces** (sync, publish, update-confluence, plus unchanged sync-contributors baseline) byte-identical to pre-refactor binary ✅
- \`go test -race ./...\` passes ✅
- \`golangci-lint run\` clean ✅