### PR TITLE
refactor(cmd): extract excluded-issue-types Actions; grow TeamConfigService

### DIFF
--- a/cmd/config_commands.go
+++ b/cmd/config_commands.go
@@ -321,146 +321,33 @@ func (a *App) createConfigCommand() *cli.Command {
 				Usage: "Manage excluded issue types for sprint allocation per project",
 				Subcommands: []*cli.Command{
 					{
-						Name:  "set",
-						Usage: "Set excluded issue types for a project (comma-separated)",
-						Action: func(ctx *cli.Context) error {
-							project := ctx.String("project")
-							typesStr := ctx.String("types")
-
-							if project == "" {
-								return fmt.Errorf("project is required")
-							}
-							if typesStr == "" {
-								return fmt.Errorf("types is required")
-							}
-
-							types := strings.Split(typesStr, ",")
-							for i, t := range types {
-								types[i] = strings.TrimSpace(t)
-							}
-
-							configRepo := configinfra.NewFileRepository(configDir)
-							configSvc := service.NewConfigService(configRepo)
-
-							if err := configSvc.SetExcludedIssueTypesForProject(project, types); err != nil {
-								return fmt.Errorf("failed to set excluded issue types: %v", err)
-							}
-
-							fmt.Printf("Set excluded issue types for project '%s': %s\n", project, strings.Join(types, ", "))
-							return nil
-						},
+						Name:   "set",
+						Usage:  "Set excluded issue types for a project (comma-separated)",
+						Action: a.configExcludedIssueTypesSetAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "project",
-								Aliases:  []string{"p"},
-								Usage:    "Project key (e.g., COP)",
-								Required: true,
-							},
-							&cli.StringFlag{
-								Name:     "types",
-								Aliases:  []string{"t"},
-								Usage:    "Comma-separated issue types to exclude (e.g., 'Experiment,Spike')",
-								Required: true,
-							},
+							&cli.StringFlag{Name: "project", Aliases: []string{"p"}, Usage: "Project key (e.g., COP)", Required: true},
+							&cli.StringFlag{Name: "types", Aliases: []string{"t"}, Usage: "Comma-separated issue types to exclude (e.g., 'Experiment,Spike')", Required: true},
 						},
 					},
 					{
-						Name:  "clear",
-						Usage: "Clear excluded issue types for a project",
-						Action: func(ctx *cli.Context) error {
-							project := ctx.String("project")
-							if project == "" {
-								return fmt.Errorf("project is required")
-							}
-
-							configRepo := configinfra.NewFileRepository(configDir)
-							configSvc := service.NewConfigService(configRepo)
-
-							if err := configSvc.SetExcludedIssueTypesForProject(project, nil); err != nil {
-								return fmt.Errorf("failed to clear excluded issue types: %v", err)
-							}
-
-							fmt.Printf("Cleared excluded issue types for project '%s'\n", project)
-							return nil
-						},
+						Name:   "clear",
+						Usage:  "Clear excluded issue types for a project",
+						Action: a.configExcludedIssueTypesClearAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "project",
-								Aliases:  []string{"p"},
-								Usage:    "Project key (e.g., COP)",
-								Required: true,
-							},
+							&cli.StringFlag{Name: "project", Aliases: []string{"p"}, Usage: "Project key (e.g., COP)", Required: true},
 						},
 					},
 					{
-						Name:  "list",
-						Usage: "List excluded issue types for all projects",
-						Action: func(_ *cli.Context) error {
-							configRepo := configinfra.NewFileRepository(configDir)
-							configSvc := service.NewConfigService(configRepo)
-
-							teamConfig, err := configSvc.GetTeamConfig()
-							if err != nil {
-								return fmt.Errorf("failed to load team config: %v", err)
-							}
-
-							projects := teamConfig.GetProjects()
-							if len(projects) == 0 {
-								fmt.Println("No teams configured")
-								return nil
-							}
-
-							fmt.Println("Excluded Issue Types:")
-							fmt.Println("=====================")
-
-							found := false
-							for _, project := range projects {
-								types := teamConfig.GetExcludedIssueTypes(project)
-								if len(types) > 0 {
-									fmt.Printf("  %s: %s\n", project, strings.Join(types, ", "))
-									found = true
-								}
-							}
-
-							if !found {
-								fmt.Println("  No excluded issue types configured for any project")
-							}
-
-							return nil
-						},
+						Name:   "list",
+						Usage:  "List excluded issue types for all projects",
+						Action: a.configExcludedIssueTypesListAction,
 					},
 					{
-						Name:  "show",
-						Usage: "Show excluded issue types for a specific project",
-						Action: func(ctx *cli.Context) error {
-							project := ctx.String("project")
-							if project == "" {
-								return fmt.Errorf("project is required")
-							}
-
-							configRepo := configinfra.NewFileRepository(configDir)
-							configSvc := service.NewConfigService(configRepo)
-
-							types, err := configSvc.GetExcludedIssueTypesForProject(project)
-							if err != nil {
-								return fmt.Errorf("failed to get excluded issue types: %v", err)
-							}
-
-							if len(types) == 0 {
-								fmt.Printf("Project '%s' has no excluded issue types\n", project)
-							} else {
-								fmt.Printf("Project '%s' excludes: %s\n", project, strings.Join(types, ", "))
-							}
-
-							return nil
-						},
+						Name:   "show",
+						Usage:  "Show excluded issue types for a specific project",
+						Action: a.configExcludedIssueTypesShowAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "project",
-								Aliases:  []string{"p"},
-								Usage:    "Project key (e.g., COP)",
-								Required: true,
-							},
+							&cli.StringFlag{Name: "project", Aliases: []string{"p"}, Usage: "Project key (e.g., COP)", Required: true},
 						},
 					},
 				},
@@ -983,6 +870,92 @@ func (a *App) configTeamCompanyShowAction(ctx *cli.Context) error {
 		fmt.Printf("Project '%s' has no company assigned\n", project)
 	} else {
 		fmt.Printf("Project '%s' belongs to company: %s\n", project, company)
+	}
+	return nil
+}
+
+// configExcludedIssueTypesSetAction backs `assetcap config excluded-issue-types set`.
+func (a *App) configExcludedIssueTypesSetAction(ctx *cli.Context) error {
+	project := ctx.String("project")
+	typesStr := ctx.String("types")
+	if project == "" {
+		return fmt.Errorf("project is required")
+	}
+	if typesStr == "" {
+		return fmt.Errorf("types is required")
+	}
+	types := parseCommaSeparated(typesStr)
+	a.ensureTeamConfigService()
+	if err := a.teamConfigService.SetExcludedIssueTypesForProject(project, types); err != nil {
+		return fmt.Errorf("failed to set excluded issue types: %v", err)
+	}
+	fmt.Printf("Set excluded issue types for project '%s': %s\n", project, strings.Join(types, ", "))
+	return nil
+}
+
+// configExcludedIssueTypesClearAction backs `assetcap config excluded-issue-types clear`.
+func (a *App) configExcludedIssueTypesClearAction(ctx *cli.Context) error {
+	project := ctx.String("project")
+	if project == "" {
+		return fmt.Errorf("project is required")
+	}
+	a.ensureTeamConfigService()
+	if err := a.teamConfigService.SetExcludedIssueTypesForProject(project, nil); err != nil {
+		return fmt.Errorf("failed to clear excluded issue types: %v", err)
+	}
+	fmt.Printf("Cleared excluded issue types for project '%s'\n", project)
+	return nil
+}
+
+// configExcludedIssueTypesListAction backs `assetcap config excluded-issue-types list`.
+// Walks every project the team config knows about and renders the
+// ones with non-empty excluded-types lists.
+func (a *App) configExcludedIssueTypesListAction(_ *cli.Context) error {
+	a.ensureTeamConfigService()
+	teamConfig, err := a.teamConfigService.GetTeamConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load team config: %v", err)
+	}
+
+	projects := teamConfig.GetProjects()
+	if len(projects) == 0 {
+		fmt.Println("No teams configured")
+		return nil
+	}
+
+	fmt.Println("Excluded Issue Types:")
+	fmt.Println("=====================")
+
+	found := false
+	for _, project := range projects {
+		types := teamConfig.GetExcludedIssueTypes(project)
+		if len(types) > 0 {
+			fmt.Printf("  %s: %s\n", project, strings.Join(types, ", "))
+			found = true
+		}
+	}
+
+	if !found {
+		fmt.Println("  No excluded issue types configured for any project")
+	}
+	return nil
+}
+
+// configExcludedIssueTypesShowAction backs `assetcap config excluded-issue-types show`.
+func (a *App) configExcludedIssueTypesShowAction(ctx *cli.Context) error {
+	project := ctx.String("project")
+	if project == "" {
+		return fmt.Errorf("project is required")
+	}
+	a.ensureTeamConfigService()
+	types, err := a.teamConfigService.GetExcludedIssueTypesForProject(project)
+	if err != nil {
+		return fmt.Errorf("failed to get excluded issue types: %v", err)
+	}
+	if len(types) == 0 {
+		fmt.Printf("Project '%s' has no excluded issue types\n", project)
+	} else {
+		fmt.Printf("Project '%s' excludes: %s\n", project, strings.Join(types, ", "))
 	}
 	return nil
 }

--- a/cmd/config_excluded_issue_types_test.go
+++ b/cmd/config_excluded_issue_types_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	configdomain "github.com/helmedeiros/digital-asset-capitalization/internal/config/domain"
+)
+
+// stubTeamConfigService is defined in config_team_tribe_company_test.go.
+// Here we exercise the excluded-issue-types methods on it.
+
+// excluded-issue-types set
+
+func TestApp_configExcludedIssueTypesSetAction_RequiresProject(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &stubTeamConfigService{}}
+	ctx := newContextWithFlags(t, map[string]string{"types": "Experiment"}, nil)
+	err := a.configExcludedIssueTypesSetAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project is required")
+}
+
+func TestApp_configExcludedIssueTypesSetAction_RequiresTypes(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &stubTeamConfigService{}}
+	ctx := newContextWithFlags(t, map[string]string{"project": "COP"}, nil)
+	err := a.configExcludedIssueTypesSetAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "types is required")
+}
+
+func TestApp_configExcludedIssueTypesSetAction_ServiceErrorWraps(t *testing.T) {
+	t.Parallel()
+	stub := &fakeTeamConfigWithExcluded{setErr: errors.New("disk")}
+	a := &App{teamConfigService: stub}
+	ctx := newContextWithFlags(t, map[string]string{"project": "COP", "types": "Experiment"}, nil)
+	err := a.configExcludedIssueTypesSetAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to set excluded issue types")
+}
+
+func TestApp_configExcludedIssueTypesSetAction_Success(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	stub := &fakeTeamConfigWithExcluded{}
+	a := &App{teamConfigService: stub}
+	ctx := newContextWithFlags(t, map[string]string{
+		"project": "COP",
+		"types":   " Experiment , , Spike ",
+	}, nil)
+	out, err := captureStdout(t, func() error { return a.configExcludedIssueTypesSetAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Set excluded issue types for project 'COP': Experiment, Spike")
+	assert.Equal(t, []string{"Experiment", "Spike"}, stub.gotTypes,
+		"comma-separated list should be trimmed and empty entries dropped")
+}
+
+// excluded-issue-types clear
+
+func TestApp_configExcludedIssueTypesClearAction_RequiresProject(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &fakeTeamConfigWithExcluded{}}
+	ctx := newContextWithFlags(t, nil, nil)
+	err := a.configExcludedIssueTypesClearAction(ctx)
+	require.Error(t, err)
+}
+
+func TestApp_configExcludedIssueTypesClearAction_ServiceErrorWraps(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &fakeTeamConfigWithExcluded{setErr: errors.New("disk")}}
+	ctx := newContextWithFlags(t, map[string]string{"project": "COP"}, nil)
+	err := a.configExcludedIssueTypesClearAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to clear")
+}
+
+func TestApp_configExcludedIssueTypesClearAction_Success(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	stub := &fakeTeamConfigWithExcluded{}
+	a := &App{teamConfigService: stub}
+	ctx := newContextWithFlags(t, map[string]string{"project": "COP"}, nil)
+	out, err := captureStdout(t, func() error { return a.configExcludedIssueTypesClearAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Cleared excluded issue types for project 'COP'")
+	assert.Nil(t, stub.gotTypes, "clear must pass nil through to the service")
+}
+
+// excluded-issue-types list
+
+func TestApp_configExcludedIssueTypesListAction_LoadErrorWraps(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfigErr: errors.New("disk")}}
+	err := a.configExcludedIssueTypesListAction(nil)
+	require.Error(t, err)
+}
+
+func TestApp_configExcludedIssueTypesListAction_NoTeamsConfigured(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{})
+	require.NoError(t, err)
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfig: cfg}}
+	out, err := captureStdout(t, func() error { return a.configExcludedIssueTypesListAction(nil) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "No teams configured")
+}
+
+func TestApp_configExcludedIssueTypesListAction_NoExclusionsConfigured(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{"FN": {"alice"}, "AD": {"bob"}})
+	require.NoError(t, err)
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfig: cfg}}
+	out, err := captureStdout(t, func() error { return a.configExcludedIssueTypesListAction(nil) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Excluded Issue Types:")
+	assert.Contains(t, out, "No excluded issue types configured for any project")
+}
+
+func TestApp_configExcludedIssueTypesListAction_RendersProjectsWithExclusions(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{"COP": {"alice"}, "FN": {"bob"}})
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetExcludedIssueTypes("COP", []string{"Experiment", "Spike"}))
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfig: cfg}}
+	out, err := captureStdout(t, func() error { return a.configExcludedIssueTypesListAction(nil) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "COP: Experiment, Spike")
+	assert.NotContains(t, out, "No excluded issue types configured for any project")
+}
+
+// excluded-issue-types show
+
+func TestApp_configExcludedIssueTypesShowAction_RequiresProject(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &fakeTeamConfigWithExcluded{}}
+	err := a.configExcludedIssueTypesShowAction(newContextWithFlags(t, nil, nil))
+	require.Error(t, err)
+}
+
+func TestApp_configExcludedIssueTypesShowAction_ServiceErrorWraps(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &fakeTeamConfigWithExcluded{getErr: errors.New("disk")}}
+	ctx := newContextWithFlags(t, map[string]string{"project": "COP"}, nil)
+	err := a.configExcludedIssueTypesShowAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get excluded issue types")
+}
+
+func TestApp_configExcludedIssueTypesShowAction_None(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{teamConfigService: &fakeTeamConfigWithExcluded{}}
+	ctx := newContextWithFlags(t, map[string]string{"project": "COP"}, nil)
+	out, err := captureStdout(t, func() error { return a.configExcludedIssueTypesShowAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Project 'COP' has no excluded issue types")
+}
+
+func TestApp_configExcludedIssueTypesShowAction_RendersList(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	a := &App{teamConfigService: &fakeTeamConfigWithExcluded{
+		types: []string{"Experiment", "Spike"},
+	}}
+	ctx := newContextWithFlags(t, map[string]string{"project": "COP"}, nil)
+	out, err := captureStdout(t, func() error { return a.configExcludedIssueTypesShowAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Project 'COP' excludes: Experiment, Spike")
+}
+
+// fakeTeamConfigWithExcluded specialises stubTeamConfigService for the
+// set/clear/show paths so tests can also assert what arguments the
+// service received.
+type fakeTeamConfigWithExcluded struct {
+	stubTeamConfigService
+
+	gotTypes []string
+	setErr   error
+	types    []string
+	getErr   error
+}
+
+func (s *fakeTeamConfigWithExcluded) SetExcludedIssueTypesForProject(_ string, types []string) error {
+	s.gotTypes = types
+	return s.setErr
+}
+func (s *fakeTeamConfigWithExcluded) GetExcludedIssueTypesForProject(string) ([]string, error) {
+	return s.types, s.getErr
+}

--- a/cmd/config_team_tribe_company_test.go
+++ b/cmd/config_team_tribe_company_test.go
@@ -41,6 +41,19 @@ func (s *stubTeamConfigService) GetCompanyForProject(string) (string, error) {
 	return s.company, s.companyErr
 }
 
+// SetExcludedIssueTypesForProject and GetExcludedIssueTypesForProject
+// satisfy the TeamConfigService interface (their dedicated tests use
+// the fakeTeamConfigWithExcluded embedder in
+// config_excluded_issue_types_test.go). The base stub returns zero
+// values so it stays usable by every other Action test without
+// pulling in fields they don't care about.
+func (s *stubTeamConfigService) SetExcludedIssueTypesForProject(string, []string) error {
+	return nil
+}
+func (s *stubTeamConfigService) GetExcludedIssueTypesForProject(string) ([]string, error) {
+	return nil, nil
+}
+
 // teamConfigWith creates a real *TeamConfig with the supplied per-
 // project tribe and company assignments. Empty maps are fine; the
 // resulting config has projects but no annotations.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,16 +76,19 @@ type ConfigService interface {
 }
 
 // TeamConfigService is the subset of *service.ConfigService that the
-// team-tribe / team-company subcommand Actions call. Pulling it out
-// as an interface lets tests inject a stub without standing up the
-// JSON file repository, and decouples the cmd/ Actions from a
-// concrete service type.
+// team-tribe / team-company / excluded-issue-types subcommand Actions
+// call. Pulling it out as an interface lets tests inject a stub
+// without standing up the JSON file repository, and decouples the
+// cmd/ Actions from a concrete service type. Grows incrementally as
+// more Actions get extracted.
 type TeamConfigService interface {
 	GetTeamConfig() (*domain.TeamConfig, error)
 	SetTribeForProject(project, tribe string) error
 	GetTribeForProject(project string) (string, error)
 	SetCompanyForProject(project, company string) error
 	GetCompanyForProject(project string) (string, error)
+	SetExcludedIssueTypesForProject(project string, types []string) error
+	GetExcludedIssueTypesForProject(project string) ([]string, error)
 }
 
 // configServiceImpl implements ConfigService


### PR DESCRIPTION
## Summary

Stacked on **#152** (TeamConfigService interface + tribe/company Actions). Extends the interface with the two methods \`excluded-issue-types\` needs and lifts all 4 inline Action closures into named methods on \`*App\`.

\`\`\`go
type TeamConfigService interface {
    GetTeamConfig() (*domain.TeamConfig, error)
    SetTribeForProject(project, tribe string) error
    GetTribeForProject(project string) (string, error)
    SetCompanyForProject(project, company string) error
    GetCompanyForProject(project string) (string, error)
    SetExcludedIssueTypesForProject(project string, types []string) error  // NEW
    GetExcludedIssueTypesForProject(project string) ([]string, error)      // NEW
}
\`\`\`

## Coverage

All 4 extracted Actions: **100%**.
Project total (with #152): **84.7% → 85.5%** (+0.8pp).

**17 new tests** drive every branch.

## Test pattern

- The shared \`stubTeamConfigService\` grows two zero-value stub methods so tribe/company tests don't need to know about excluded-issue-types.
- Tests that want to exercise the new methods use a \`fakeTeamConfigWithExcluded\` that embeds the base stub and overrides those two — same pattern as PR #148's sub-stubs.
- Reuses \`parseCommaSeparated\` (PR #141) for the \`--types\` flag.

## Scientific validation
- All 4 \`--help\` surfaces byte-identical to pre-refactor binary ✅
- \`go test -race ./...\` passes ✅
- \`golangci-lint run\` clean ✅