### PR TITLE
refactor(cmd): extract board-work-streams Actions

### DIFF
--- a/cmd/config_board_work_streams_test.go
+++ b/cmd/config_board_work_streams_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+
+	configdomain "github.com/helmedeiros/digital-asset-capitalization/internal/config/domain"
+)
+
+// fakeTeamConfigWithBoards extends stubTeamConfigService with a
+// recording SetBoardWorkStream and a custom error injection point.
+// Same embedding pattern as fakeTeamConfigWithExcluded.
+type fakeTeamConfigWithBoards struct {
+	stubTeamConfigService
+
+	gotProject    string
+	gotBoardID    int
+	gotWorkStream string
+	setErr        error
+}
+
+func (s *fakeTeamConfigWithBoards) SetBoardWorkStream(project string, boardID int, ws string) error {
+	s.gotProject = project
+	s.gotBoardID = boardID
+	s.gotWorkStream = ws
+	return s.setErr
+}
+
+// board-work-streams set
+
+func TestApp_configBoardWorkStreamsSetAction_RequiresProject(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &fakeTeamConfigWithBoards{}}
+	ctx := newContextWithFlags(t,
+		map[string]string{"work-stream": "Product"},
+		nil,
+	)
+	err := a.configBoardWorkStreamsSetAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project is required")
+}
+
+func TestApp_configBoardWorkStreamsSetAction_RequiresBoardID(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &fakeTeamConfigWithBoards{}}
+	// boardID defaults to 0 when unset.
+	ctx := newContextWithFlags(t,
+		map[string]string{"project": "COP", "work-stream": "Product"},
+		nil,
+	)
+	err := a.configBoardWorkStreamsSetAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "board ID is required")
+}
+
+func TestApp_configBoardWorkStreamsSetAction_RequiresWorkStream(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &fakeTeamConfigWithBoards{}}
+	ctx := newContextWithIntFlag(t, map[string]string{"project": "COP"}, "board", 5119)
+	err := a.configBoardWorkStreamsSetAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "work-stream is required")
+}
+
+func TestApp_configBoardWorkStreamsSetAction_ServiceErrorWraps(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &fakeTeamConfigWithBoards{setErr: errors.New("disk")}}
+	ctx := newContextWithIntAndStrings(t,
+		map[string]string{"project": "COP", "work-stream": "Product"},
+		"board", 5119,
+	)
+	err := a.configBoardWorkStreamsSetAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to set board work stream")
+}
+
+func TestApp_configBoardWorkStreamsSetAction_Success(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	stub := &fakeTeamConfigWithBoards{}
+	a := &App{teamConfigService: stub}
+	ctx := newContextWithIntAndStrings(t,
+		map[string]string{"project": "COP", "work-stream": "Product"},
+		"board", 5119,
+	)
+	out, err := captureStdout(t, func() error { return a.configBoardWorkStreamsSetAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Set board 5119 -> 'Product' for project 'COP'")
+	assert.Equal(t, "COP", stub.gotProject)
+	assert.Equal(t, 5119, stub.gotBoardID)
+	assert.Equal(t, "Product", stub.gotWorkStream)
+}
+
+// board-work-streams show
+
+func TestApp_configBoardWorkStreamsShowAction_RequiresProject(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &stubTeamConfigService{}}
+	err := a.configBoardWorkStreamsShowAction(newContextWithFlags(t, nil, nil))
+	require.Error(t, err)
+}
+
+func TestApp_configBoardWorkStreamsShowAction_LoadErrorWraps(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfigErr: errors.New("disk")}}
+	ctx := newContextWithFlags(t, map[string]string{"project": "COP"}, nil)
+	err := a.configBoardWorkStreamsShowAction(ctx)
+	require.Error(t, err)
+}
+
+func TestApp_configBoardWorkStreamsShowAction_NoMappings(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{"COP": {"alice"}})
+	require.NoError(t, err)
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfig: cfg}}
+	ctx := newContextWithFlags(t, map[string]string{"project": "COP"}, nil)
+	out, err := captureStdout(t, func() error { return a.configBoardWorkStreamsShowAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Project 'COP' has no board-to-workstream mappings")
+}
+
+func TestApp_configBoardWorkStreamsShowAction_RendersMappings(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{"COP": {"alice"}})
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetBoardWorkStreams("COP", map[int]string{5119: "Product"}))
+
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfig: cfg}}
+	ctx := newContextWithFlags(t, map[string]string{"project": "COP"}, nil)
+	out, err := captureStdout(t, func() error { return a.configBoardWorkStreamsShowAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Board Work Streams for 'COP':")
+	assert.Contains(t, out, "Board 5119 -> Product")
+}
+
+// board-work-streams list
+
+func TestApp_configBoardWorkStreamsListAction_LoadErrorWraps(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfigErr: errors.New("disk")}}
+	err := a.configBoardWorkStreamsListAction(nil)
+	require.Error(t, err)
+}
+
+func TestApp_configBoardWorkStreamsListAction_NoTeams(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{})
+	require.NoError(t, err)
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfig: cfg}}
+	out, err := captureStdout(t, func() error { return a.configBoardWorkStreamsListAction(nil) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "No teams configured")
+}
+
+func TestApp_configBoardWorkStreamsListAction_NoMappingsAcrossProjects(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{"COP": {"alice"}, "FN": {"bob"}})
+	require.NoError(t, err)
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfig: cfg}}
+	out, err := captureStdout(t, func() error { return a.configBoardWorkStreamsListAction(nil) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Board Work Streams:")
+	assert.Contains(t, out, "No board-to-workstream mappings configured")
+}
+
+func TestApp_configBoardWorkStreamsListAction_RendersProjectsWithMappings(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{"COP": {"alice"}, "FN": {"bob"}})
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetBoardWorkStreams("COP", map[int]string{5119: "Product"}))
+
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfig: cfg}}
+	out, err := captureStdout(t, func() error { return a.configBoardWorkStreamsListAction(nil) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "COP:")
+	assert.Contains(t, out, "Board 5119 -> Product")
+}
+
+// newContextWithIntFlag is a small helper for the int-only flag tests.
+// urfave/cli requires Int flags to be registered separately from String
+// flags on the FlagSet.
+func newContextWithIntFlag(t *testing.T, strFlags map[string]string, intName string, intVal int) *cli.Context {
+	t.Helper()
+	return newContextWithIntAndStrings(t, strFlags, intName, intVal)
+}
+
+// newContextWithIntAndStrings is the workhorse for the int-flag tests.
+// Same pattern as newContextWithFlags but with one additional int flag.
+func newContextWithIntAndStrings(t *testing.T, strFlags map[string]string, intName string, intVal int) *cli.Context {
+	t.Helper()
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	for k, v := range strFlags {
+		set.String(k, v, "")
+	}
+	set.Int(intName, intVal, "")
+	return cli.NewContext(nil, set, nil)
+}

--- a/cmd/config_commands.go
+++ b/cmd/config_commands.go
@@ -189,130 +189,27 @@ func (a *App) createConfigCommand() *cli.Command {
 				Usage: "Manage board-to-workstream mappings per project",
 				Subcommands: []*cli.Command{
 					{
-						Name:  "set",
-						Usage: "Set work stream for a board in a project",
-						Action: func(ctx *cli.Context) error {
-							project := ctx.String("project")
-							boardID := ctx.Int("board")
-							workStream := ctx.String("work-stream")
-
-							if project == "" {
-								return fmt.Errorf("project is required")
-							}
-							if boardID == 0 {
-								return fmt.Errorf("board ID is required")
-							}
-							if workStream == "" {
-								return fmt.Errorf("work-stream is required")
-							}
-
-							configRepo := configinfra.NewFileRepository(configDir)
-							configSvc := service.NewConfigService(configRepo)
-
-							if err := configSvc.SetBoardWorkStream(project, boardID, workStream); err != nil {
-								return fmt.Errorf("failed to set board work stream: %v", err)
-							}
-
-							fmt.Printf("Set board %d -> '%s' for project '%s'\n", boardID, workStream, project)
-							return nil
-						},
+						Name:   "set",
+						Usage:  "Set work stream for a board in a project",
+						Action: a.configBoardWorkStreamsSetAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "project",
-								Aliases:  []string{"p"},
-								Usage:    "Project key (e.g., COP)",
-								Required: true,
-							},
-							&cli.IntFlag{
-								Name:     "board",
-								Aliases:  []string{"b"},
-								Usage:    "Board ID (e.g., 5119)",
-								Required: true,
-							},
-							&cli.StringFlag{
-								Name:     "work-stream",
-								Aliases:  []string{"ws"},
-								Usage:    "Work stream name (e.g., Product, Operational)",
-								Required: true,
-							},
+							&cli.StringFlag{Name: "project", Aliases: []string{"p"}, Usage: "Project key (e.g., COP)", Required: true},
+							&cli.IntFlag{Name: "board", Aliases: []string{"b"}, Usage: "Board ID (e.g., 5119)", Required: true},
+							&cli.StringFlag{Name: "work-stream", Aliases: []string{"ws"}, Usage: "Work stream name (e.g., Product, Operational)", Required: true},
 						},
 					},
 					{
-						Name:  "show",
-						Usage: "Show board-to-workstream mappings for a specific project",
-						Action: func(ctx *cli.Context) error {
-							project := ctx.String("project")
-							if project == "" {
-								return fmt.Errorf("project is required")
-							}
-
-							configRepo := configinfra.NewFileRepository(configDir)
-							configSvc := service.NewConfigService(configRepo)
-
-							teamConfig, err := configSvc.GetTeamConfig()
-							if err != nil {
-								return fmt.Errorf("failed to load team config: %v", err)
-							}
-
-							mapping := teamConfig.GetBoardWorkStreams(project)
-							if len(mapping) == 0 {
-								fmt.Printf("Project '%s' has no board-to-workstream mappings\n", project)
-							} else {
-								fmt.Printf("Board Work Streams for '%s':\n", project)
-								for boardID, ws := range mapping {
-									fmt.Printf("  Board %d -> %s\n", boardID, ws)
-								}
-							}
-							return nil
-						},
+						Name:   "show",
+						Usage:  "Show board-to-workstream mappings for a specific project",
+						Action: a.configBoardWorkStreamsShowAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "project",
-								Aliases:  []string{"p"},
-								Usage:    "Project key (e.g., COP)",
-								Required: true,
-							},
+							&cli.StringFlag{Name: "project", Aliases: []string{"p"}, Usage: "Project key (e.g., COP)", Required: true},
 						},
 					},
 					{
-						Name:  "list",
-						Usage: "List board-to-workstream mappings for all projects",
-						Action: func(_ *cli.Context) error {
-							configRepo := configinfra.NewFileRepository(configDir)
-							configSvc := service.NewConfigService(configRepo)
-
-							teamConfig, err := configSvc.GetTeamConfig()
-							if err != nil {
-								return fmt.Errorf("failed to load team config: %v", err)
-							}
-
-							projects := teamConfig.GetProjects()
-							if len(projects) == 0 {
-								fmt.Println("No teams configured")
-								return nil
-							}
-
-							fmt.Println("Board Work Streams:")
-							fmt.Println("===================")
-
-							found := false
-							for _, project := range projects {
-								mapping := teamConfig.GetBoardWorkStreams(project)
-								if len(mapping) > 0 {
-									fmt.Printf("  %s:\n", project)
-									for boardID, ws := range mapping {
-										fmt.Printf("    Board %d -> %s\n", boardID, ws)
-									}
-									found = true
-								}
-							}
-
-							if !found {
-								fmt.Println("  No board-to-workstream mappings configured")
-							}
-
-							return nil
-						},
+						Name:   "list",
+						Usage:  "List board-to-workstream mappings for all projects",
+						Action: a.configBoardWorkStreamsListAction,
 					},
 				},
 			},
@@ -956,6 +853,86 @@ func (a *App) configExcludedIssueTypesShowAction(ctx *cli.Context) error {
 		fmt.Printf("Project '%s' has no excluded issue types\n", project)
 	} else {
 		fmt.Printf("Project '%s' excludes: %s\n", project, strings.Join(types, ", "))
+	}
+	return nil
+}
+
+// configBoardWorkStreamsSetAction backs `assetcap config board-work-streams set`.
+func (a *App) configBoardWorkStreamsSetAction(ctx *cli.Context) error {
+	project := ctx.String("project")
+	boardID := ctx.Int("board")
+	workStream := ctx.String("work-stream")
+	if project == "" {
+		return fmt.Errorf("project is required")
+	}
+	if boardID == 0 {
+		return fmt.Errorf("board ID is required")
+	}
+	if workStream == "" {
+		return fmt.Errorf("work-stream is required")
+	}
+	a.ensureTeamConfigService()
+	if err := a.teamConfigService.SetBoardWorkStream(project, boardID, workStream); err != nil {
+		return fmt.Errorf("failed to set board work stream: %v", err)
+	}
+	fmt.Printf("Set board %d -> '%s' for project '%s'\n", boardID, workStream, project)
+	return nil
+}
+
+// configBoardWorkStreamsShowAction backs `assetcap config board-work-streams show`.
+func (a *App) configBoardWorkStreamsShowAction(ctx *cli.Context) error {
+	project := ctx.String("project")
+	if project == "" {
+		return fmt.Errorf("project is required")
+	}
+	a.ensureTeamConfigService()
+	teamConfig, err := a.teamConfigService.GetTeamConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load team config: %v", err)
+	}
+	mapping := teamConfig.GetBoardWorkStreams(project)
+	if len(mapping) == 0 {
+		fmt.Printf("Project '%s' has no board-to-workstream mappings\n", project)
+	} else {
+		fmt.Printf("Board Work Streams for '%s':\n", project)
+		for boardID, ws := range mapping {
+			fmt.Printf("  Board %d -> %s\n", boardID, ws)
+		}
+	}
+	return nil
+}
+
+// configBoardWorkStreamsListAction backs `assetcap config board-work-streams list`.
+func (a *App) configBoardWorkStreamsListAction(_ *cli.Context) error {
+	a.ensureTeamConfigService()
+	teamConfig, err := a.teamConfigService.GetTeamConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load team config: %v", err)
+	}
+
+	projects := teamConfig.GetProjects()
+	if len(projects) == 0 {
+		fmt.Println("No teams configured")
+		return nil
+	}
+
+	fmt.Println("Board Work Streams:")
+	fmt.Println("===================")
+
+	found := false
+	for _, project := range projects {
+		mapping := teamConfig.GetBoardWorkStreams(project)
+		if len(mapping) > 0 {
+			fmt.Printf("  %s:\n", project)
+			for boardID, ws := range mapping {
+				fmt.Printf("    Board %d -> %s\n", boardID, ws)
+			}
+			found = true
+		}
+	}
+
+	if !found {
+		fmt.Println("  No board-to-workstream mappings configured")
 	}
 	return nil
 }

--- a/cmd/config_team_tribe_company_test.go
+++ b/cmd/config_team_tribe_company_test.go
@@ -40,6 +40,9 @@ func (s *stubTeamConfigService) SetCompanyForProject(string, string) error {
 func (s *stubTeamConfigService) GetCompanyForProject(string) (string, error) {
 	return s.company, s.companyErr
 }
+func (s *stubTeamConfigService) SetBoardWorkStream(string, int, string) error {
+	return nil
+}
 
 // SetExcludedIssueTypesForProject and GetExcludedIssueTypesForProject
 // satisfy the TeamConfigService interface (their dedicated tests use

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -89,6 +89,7 @@ type TeamConfigService interface {
 	GetCompanyForProject(project string) (string, error)
 	SetExcludedIssueTypesForProject(project string, types []string) error
 	GetExcludedIssueTypesForProject(project string) ([]string, error)
+	SetBoardWorkStream(project string, boardID int, workStream string) error
 }
 
 // configServiceImpl implements ConfigService


### PR DESCRIPTION
## Summary

Extracts the 3 \`config board-work-streams\` inline closures into named methods on \`*App\`. Extends the \`TeamConfigService\` interface (from #152, grown again in #153) with \`SetBoardWorkStream\`.

## Coverage

All 3 extracted Actions: **100%**.

**13 new tests** drive every branch.

## Test design

- New \`fakeTeamConfigWithBoards\` embeds \`stubTeamConfigService\` and records what was passed to \`SetBoardWorkStream\` — same pattern as #153's \`fakeTeamConfigWithExcluded\`.
- Adds \`newContextWithIntFlag\` / \`newContextWithIntAndStrings\` test helpers; urfave/cli requires Int flags to be registered separately from String flags on the FlagSet.

## Scientific validation
- All 3 \`--help\` surfaces byte-identical to pre-refactor binary ✅
- \`go test -race ./...\` passes ✅
- \`golangci-lint run\` clean ✅