### PR TITLE
refactor(cmd): extract team-timeline Actions into named methods

### DIFF
--- a/cmd/config_commands.go
+++ b/cmd/config_commands.go
@@ -254,172 +254,31 @@ func (a *App) createConfigCommand() *cli.Command {
 				Usage: "Manage team member timeline (join/leave dates) for time-aware sprint allocation",
 				Subcommands: []*cli.Command{
 					{
-						Name:  "show",
-						Usage: "Show team timeline for a project",
-						Action: func(ctx *cli.Context) error {
-							project := ctx.String("project")
-							if project == "" {
-								return fmt.Errorf("project is required")
-							}
-
-							configRepo := configinfra.NewFileRepository(configDir)
-							configSvc := service.NewConfigService(configRepo)
-
-							teamConfig, err := configSvc.GetTeamConfig()
-							if err != nil {
-								return fmt.Errorf("failed to load team config: %v", err)
-							}
-
-							timeline := teamConfig.GetTeamTimeline(project)
-							if len(timeline) == 0 {
-								fmt.Printf("Project '%s' has no team timeline configured\n", project)
-								fmt.Println("Using flat team list for all sprints")
-								members, exists := teamConfig.GetTeam(project)
-								if exists {
-									fmt.Printf("Current team: %s\n", strings.Join(members, ", "))
-								}
-								return nil
-							}
-
-							fmt.Printf("Team Timeline for '%s':\n", project)
-							fmt.Println("===========================")
-							for _, p := range timeline {
-								status := "active"
-								leftStr := ""
-								if p.Left != nil {
-									status = "departed"
-									leftStr = p.Left.Format("2006-01-02")
-								}
-								fmt.Printf("  %-25s joined: %s  left: %-12s [%s]\n",
-									p.Member, p.Joined.Format("2006-01-02"), leftStr, status)
-							}
-
-							active := teamConfig.DeriveActiveTeamFromTimeline(project)
-							fmt.Printf("\nActive members (%d): %s\n", len(active), strings.Join(active, ", "))
-
-							return nil
-						},
+						Name:   "show",
+						Usage:  "Show team timeline for a project",
+						Action: a.configTeamTimelineShowAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "project",
-								Aliases:  []string{"p"},
-								Usage:    "Project key",
-								Required: true,
-							},
+							&cli.StringFlag{Name: "project", Aliases: []string{"p"}, Usage: "Project key", Required: true},
 						},
 					},
 					{
-						Name:  "add",
-						Usage: "Add a member to the team timeline with a join date",
-						Action: func(ctx *cli.Context) error {
-							project := ctx.String("project")
-							member := ctx.String("member")
-							joinedStr := ctx.String("joined")
-
-							if project == "" || member == "" || joinedStr == "" {
-								return fmt.Errorf("project, member, and joined date are required")
-							}
-
-							joined, err := time.Parse("2006-01-02", joinedStr)
-							if err != nil {
-								return fmt.Errorf("invalid date format, use YYYY-MM-DD: %v", err)
-							}
-
-							configRepo := configinfra.NewFileRepository(configDir)
-							configSvc := service.NewConfigService(configRepo)
-
-							teamConfig, err := configSvc.GetTeamConfig()
-							if err != nil {
-								return fmt.Errorf("failed to load team config: %v", err)
-							}
-
-							if err := teamConfig.AddMemberWithDates(project, member, joined); err != nil {
-								return fmt.Errorf("failed to add member: %v", err)
-							}
-
-							if err := configSvc.SaveTeamConfig(teamConfig); err != nil {
-								return fmt.Errorf("failed to save team config: %v", err)
-							}
-
-							fmt.Printf("Added '%s' to project '%s' timeline (joined: %s)\n", member, project, joinedStr)
-							return nil
-						},
+						Name:   "add",
+						Usage:  "Add a member to the team timeline with a join date",
+						Action: a.configTeamTimelineAddAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "project",
-								Aliases:  []string{"p"},
-								Usage:    "Project key",
-								Required: true,
-							},
-							&cli.StringFlag{
-								Name:     "member",
-								Aliases:  []string{"m"},
-								Usage:    "Team member name",
-								Required: true,
-							},
-							&cli.StringFlag{
-								Name:     "joined",
-								Aliases:  []string{"j"},
-								Usage:    "Join date (YYYY-MM-DD)",
-								Required: true,
-							},
+							&cli.StringFlag{Name: "project", Aliases: []string{"p"}, Usage: "Project key", Required: true},
+							&cli.StringFlag{Name: "member", Aliases: []string{"m"}, Usage: "Team member name", Required: true},
+							&cli.StringFlag{Name: "joined", Aliases: []string{"j"}, Usage: "Join date (YYYY-MM-DD)", Required: true},
 						},
 					},
 					{
-						Name:  "remove",
-						Usage: "Set a member's departure date in the team timeline",
-						Action: func(ctx *cli.Context) error {
-							project := ctx.String("project")
-							member := ctx.String("member")
-							leftStr := ctx.String("left")
-
-							if project == "" || member == "" || leftStr == "" {
-								return fmt.Errorf("project, member, and left date are required")
-							}
-
-							left, err := time.Parse("2006-01-02", leftStr)
-							if err != nil {
-								return fmt.Errorf("invalid date format, use YYYY-MM-DD: %v", err)
-							}
-
-							configRepo := configinfra.NewFileRepository(configDir)
-							configSvc := service.NewConfigService(configRepo)
-
-							teamConfig, err := configSvc.GetTeamConfig()
-							if err != nil {
-								return fmt.Errorf("failed to load team config: %v", err)
-							}
-
-							if err := teamConfig.SetMemberLeft(project, member, left); err != nil {
-								return fmt.Errorf("failed to set departure: %v", err)
-							}
-
-							if err := configSvc.SaveTeamConfig(teamConfig); err != nil {
-								return fmt.Errorf("failed to save team config: %v", err)
-							}
-
-							fmt.Printf("Set '%s' departure from project '%s' (left: %s)\n", member, project, leftStr)
-							return nil
-						},
+						Name:   "remove",
+						Usage:  "Set a member's departure date in the team timeline",
+						Action: a.configTeamTimelineRemoveAction,
 						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "project",
-								Aliases:  []string{"p"},
-								Usage:    "Project key",
-								Required: true,
-							},
-							&cli.StringFlag{
-								Name:     "member",
-								Aliases:  []string{"m"},
-								Usage:    "Team member name",
-								Required: true,
-							},
-							&cli.StringFlag{
-								Name:     "left",
-								Aliases:  []string{"l"},
-								Usage:    "Departure date (YYYY-MM-DD)",
-								Required: true,
-							},
+							&cli.StringFlag{Name: "project", Aliases: []string{"p"}, Usage: "Project key", Required: true},
+							&cli.StringFlag{Name: "member", Aliases: []string{"m"}, Usage: "Team member name", Required: true},
+							&cli.StringFlag{Name: "left", Aliases: []string{"l"}, Usage: "Departure date (YYYY-MM-DD)", Required: true},
 						},
 					},
 				},
@@ -934,5 +793,113 @@ func (a *App) configBoardWorkStreamsListAction(_ *cli.Context) error {
 	if !found {
 		fmt.Println("  No board-to-workstream mappings configured")
 	}
+	return nil
+}
+
+// configTeamTimelineShowAction backs `assetcap config team-timeline show`.
+// Falls back to the flat team list when no per-member timeline is
+// configured, so a fresh project doesn't surprise the user with an
+// empty-looking output.
+func (a *App) configTeamTimelineShowAction(ctx *cli.Context) error {
+	project := ctx.String("project")
+	if project == "" {
+		return fmt.Errorf("project is required")
+	}
+	a.ensureTeamConfigService()
+	teamConfig, err := a.teamConfigService.GetTeamConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load team config: %v", err)
+	}
+
+	timeline := teamConfig.GetTeamTimeline(project)
+	if len(timeline) == 0 {
+		fmt.Printf("Project '%s' has no team timeline configured\n", project)
+		fmt.Println("Using flat team list for all sprints")
+		members, exists := teamConfig.GetTeam(project)
+		if exists {
+			fmt.Printf("Current team: %s\n", strings.Join(members, ", "))
+		}
+		return nil
+	}
+
+	fmt.Printf("Team Timeline for '%s':\n", project)
+	fmt.Println("===========================")
+	for _, p := range timeline {
+		status := "active"
+		leftStr := ""
+		if p.Left != nil {
+			status = "departed"
+			leftStr = p.Left.Format("2006-01-02")
+		}
+		fmt.Printf("  %-25s joined: %s  left: %-12s [%s]\n",
+			p.Member, p.Joined.Format("2006-01-02"), leftStr, status)
+	}
+
+	active := teamConfig.DeriveActiveTeamFromTimeline(project)
+	fmt.Printf("\nActive members (%d): %s\n", len(active), strings.Join(active, ", "))
+	return nil
+}
+
+// configTeamTimelineAddAction backs `assetcap config team-timeline add`.
+func (a *App) configTeamTimelineAddAction(ctx *cli.Context) error {
+	project := ctx.String("project")
+	member := ctx.String("member")
+	joinedStr := ctx.String("joined")
+	if project == "" || member == "" || joinedStr == "" {
+		return fmt.Errorf("project, member, and joined date are required")
+	}
+
+	joined, err := time.Parse("2006-01-02", joinedStr)
+	if err != nil {
+		return fmt.Errorf("invalid date format, use YYYY-MM-DD: %v", err)
+	}
+
+	a.ensureTeamConfigService()
+	teamConfig, err := a.teamConfigService.GetTeamConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load team config: %v", err)
+	}
+
+	if err := teamConfig.AddMemberWithDates(project, member, joined); err != nil {
+		return fmt.Errorf("failed to add member: %v", err)
+	}
+
+	if err := a.teamConfigService.SaveTeamConfig(teamConfig); err != nil {
+		return fmt.Errorf("failed to save team config: %v", err)
+	}
+
+	fmt.Printf("Added '%s' to project '%s' timeline (joined: %s)\n", member, project, joinedStr)
+	return nil
+}
+
+// configTeamTimelineRemoveAction backs `assetcap config team-timeline remove`.
+func (a *App) configTeamTimelineRemoveAction(ctx *cli.Context) error {
+	project := ctx.String("project")
+	member := ctx.String("member")
+	leftStr := ctx.String("left")
+	if project == "" || member == "" || leftStr == "" {
+		return fmt.Errorf("project, member, and left date are required")
+	}
+
+	left, err := time.Parse("2006-01-02", leftStr)
+	if err != nil {
+		return fmt.Errorf("invalid date format, use YYYY-MM-DD: %v", err)
+	}
+
+	a.ensureTeamConfigService()
+	teamConfig, err := a.teamConfigService.GetTeamConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load team config: %v", err)
+	}
+
+	if err := teamConfig.SetMemberLeft(project, member, left); err != nil {
+		return fmt.Errorf("failed to set departure: %v", err)
+	}
+
+	if err := a.teamConfigService.SaveTeamConfig(teamConfig); err != nil {
+		return fmt.Errorf("failed to save team config: %v", err)
+	}
+
+	fmt.Printf("Set '%s' departure from project '%s' (left: %s)\n", member, project, leftStr)
 	return nil
 }

--- a/cmd/config_team_timeline_test.go
+++ b/cmd/config_team_timeline_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	configdomain "github.com/helmedeiros/digital-asset-capitalization/internal/config/domain"
+)
+
+// fakeTeamConfigWithSave embeds stubTeamConfigService and adds
+// recording for SaveTeamConfig + an injectable save error so the
+// add/remove Actions can be tested end-to-end. Same embedding
+// pattern as fakeTeamConfigWithExcluded.
+type fakeTeamConfigWithSave struct {
+	stubTeamConfigService
+
+	savedConfig *configdomain.TeamConfig
+	saveErr     error
+}
+
+func (s *fakeTeamConfigWithSave) SaveTeamConfig(cfg *configdomain.TeamConfig) error {
+	s.savedConfig = cfg
+	return s.saveErr
+}
+
+// team-timeline show
+
+func TestApp_configTeamTimelineShowAction_RequiresProject(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &stubTeamConfigService{}}
+	err := a.configTeamTimelineShowAction(newContextWithFlags(t, nil, nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project is required")
+}
+
+func TestApp_configTeamTimelineShowAction_LoadErrorWraps(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfigErr: errors.New("disk")}}
+	ctx := newContextWithFlags(t, map[string]string{"project": "FN"}, nil)
+	err := a.configTeamTimelineShowAction(ctx)
+	require.Error(t, err)
+}
+
+func TestApp_configTeamTimelineShowAction_NoTimelineFallsBackToFlatTeam(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{"FN": {"alice", "bob"}})
+	require.NoError(t, err)
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfig: cfg}}
+	ctx := newContextWithFlags(t, map[string]string{"project": "FN"}, nil)
+	out, err := captureStdout(t, func() error { return a.configTeamTimelineShowAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "no team timeline configured")
+	assert.Contains(t, out, "Using flat team list")
+	assert.Contains(t, out, "alice, bob")
+}
+
+func TestApp_configTeamTimelineShowAction_NoTimelineNoTeamSilent(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{})
+	require.NoError(t, err)
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfig: cfg}}
+	ctx := newContextWithFlags(t, map[string]string{"project": "FN"}, nil)
+	out, err := captureStdout(t, func() error { return a.configTeamTimelineShowAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "no team timeline configured")
+	// No "Current team:" line since GetTeam returns (_, false).
+	assert.NotContains(t, out, "Current team:")
+}
+
+func TestApp_configTeamTimelineShowAction_RendersTimelineWithActiveAndDeparted(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{"FN": {"alice", "bob"}})
+	require.NoError(t, err)
+	joined := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, cfg.AddMemberWithDates("FN", "alice", joined))
+	require.NoError(t, cfg.AddMemberWithDates("FN", "bob", joined))
+	left := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, cfg.SetMemberLeft("FN", "bob", left))
+
+	a := &App{teamConfigService: &stubTeamConfigService{teamConfig: cfg}}
+	ctx := newContextWithFlags(t, map[string]string{"project": "FN"}, nil)
+	out, err := captureStdout(t, func() error { return a.configTeamTimelineShowAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Team Timeline for 'FN':")
+	assert.Contains(t, out, "alice")
+	assert.Contains(t, out, "[active]")
+	assert.Contains(t, out, "bob")
+	assert.Contains(t, out, "[departed]")
+	assert.Contains(t, out, "2026-06-01")
+	assert.Contains(t, out, "Active members")
+}
+
+// team-timeline add
+
+func TestApp_configTeamTimelineAddAction_RequiresAllFlags(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		flags map[string]string
+	}{
+		{"no project", map[string]string{"member": "alice", "joined": "2026-01-01"}},
+		{"no member", map[string]string{"project": "FN", "joined": "2026-01-01"}},
+		{"no joined", map[string]string{"project": "FN", "member": "alice"}},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			a := &App{teamConfigService: &fakeTeamConfigWithSave{}}
+			err := a.configTeamTimelineAddAction(newContextWithFlags(t, c.flags, nil))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "are required")
+		})
+	}
+}
+
+func TestApp_configTeamTimelineAddAction_InvalidDate(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &fakeTeamConfigWithSave{}}
+	ctx := newContextWithFlags(t, map[string]string{
+		"project": "FN", "member": "alice", "joined": "yesterday",
+	}, nil)
+	err := a.configTeamTimelineAddAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid date format")
+}
+
+func TestApp_configTeamTimelineAddAction_LoadErrorWraps(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &fakeTeamConfigWithSave{
+		stubTeamConfigService: stubTeamConfigService{teamConfigErr: errors.New("disk")},
+	}}
+	ctx := newContextWithFlags(t, map[string]string{
+		"project": "FN", "member": "alice", "joined": "2026-01-01",
+	}, nil)
+	err := a.configTeamTimelineAddAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load team config")
+}
+
+func TestApp_configTeamTimelineAddAction_SaveErrorWraps(t *testing.T) {
+	t.Parallel()
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{"FN": {"alice"}})
+	require.NoError(t, err)
+	a := &App{teamConfigService: &fakeTeamConfigWithSave{
+		stubTeamConfigService: stubTeamConfigService{teamConfig: cfg},
+		saveErr:               errors.New("disk"),
+	}}
+	ctx := newContextWithFlags(t, map[string]string{
+		"project": "FN", "member": "alice", "joined": "2026-01-01",
+	}, nil)
+	err = a.configTeamTimelineAddAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save team config")
+}
+
+func TestApp_configTeamTimelineAddAction_Success(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{"FN": {"alice"}})
+	require.NoError(t, err)
+	stub := &fakeTeamConfigWithSave{
+		stubTeamConfigService: stubTeamConfigService{teamConfig: cfg},
+	}
+	a := &App{teamConfigService: stub}
+	ctx := newContextWithFlags(t, map[string]string{
+		"project": "FN", "member": "alice", "joined": "2026-01-01",
+	}, nil)
+	out, err := captureStdout(t, func() error { return a.configTeamTimelineAddAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Added 'alice' to project 'FN' timeline")
+	assert.Same(t, cfg, stub.savedConfig, "SaveTeamConfig should be called with the loaded TeamConfig")
+}
+
+// team-timeline remove
+
+func TestApp_configTeamTimelineRemoveAction_RequiresAllFlags(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &fakeTeamConfigWithSave{}}
+	err := a.configTeamTimelineRemoveAction(newContextWithFlags(t, nil, nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "are required")
+}
+
+func TestApp_configTeamTimelineRemoveAction_InvalidDate(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &fakeTeamConfigWithSave{}}
+	ctx := newContextWithFlags(t, map[string]string{
+		"project": "FN", "member": "alice", "left": "yesterday",
+	}, nil)
+	err := a.configTeamTimelineRemoveAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid date format")
+}
+
+func TestApp_configTeamTimelineRemoveAction_LoadErrorWraps(t *testing.T) {
+	t.Parallel()
+	a := &App{teamConfigService: &fakeTeamConfigWithSave{
+		stubTeamConfigService: stubTeamConfigService{teamConfigErr: errors.New("disk")},
+	}}
+	ctx := newContextWithFlags(t, map[string]string{
+		"project": "FN", "member": "alice", "left": "2026-01-01",
+	}, nil)
+	err := a.configTeamTimelineRemoveAction(ctx)
+	require.Error(t, err)
+}
+
+func TestApp_configTeamTimelineRemoveAction_MemberNotInTimeline(t *testing.T) {
+	t.Parallel()
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{"FN": {"alice"}})
+	require.NoError(t, err)
+	// No AddMemberWithDates → SetMemberLeft returns an error.
+	a := &App{teamConfigService: &fakeTeamConfigWithSave{
+		stubTeamConfigService: stubTeamConfigService{teamConfig: cfg},
+	}}
+	ctx := newContextWithFlags(t, map[string]string{
+		"project": "FN", "member": "alice", "left": "2026-01-01",
+	}, nil)
+	err = a.configTeamTimelineRemoveAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to set departure")
+}
+
+func TestApp_configTeamTimelineRemoveAction_Success(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	cfg, err := configdomain.NewTeamConfig(map[string][]string{"FN": {"alice"}})
+	require.NoError(t, err)
+	require.NoError(t, cfg.AddMemberWithDates("FN", "alice",
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)))
+	stub := &fakeTeamConfigWithSave{
+		stubTeamConfigService: stubTeamConfigService{teamConfig: cfg},
+	}
+	a := &App{teamConfigService: stub}
+	ctx := newContextWithFlags(t, map[string]string{
+		"project": "FN", "member": "alice", "left": "2026-06-01",
+	}, nil)
+	out, err := captureStdout(t, func() error { return a.configTeamTimelineRemoveAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Set 'alice' departure from project 'FN'")
+	assert.Same(t, cfg, stub.savedConfig)
+}

--- a/cmd/config_team_tribe_company_test.go
+++ b/cmd/config_team_tribe_company_test.go
@@ -30,7 +30,8 @@ type stubTeamConfigService struct {
 func (s *stubTeamConfigService) GetTeamConfig() (*configdomain.TeamConfig, error) {
 	return s.teamConfig, s.teamConfigErr
 }
-func (s *stubTeamConfigService) SetTribeForProject(string, string) error { return s.setTribeErr }
+func (s *stubTeamConfigService) SaveTeamConfig(*configdomain.TeamConfig) error { return nil }
+func (s *stubTeamConfigService) SetTribeForProject(string, string) error       { return s.setTribeErr }
 func (s *stubTeamConfigService) GetTribeForProject(string) (string, error) {
 	return s.tribe, s.tribeErr
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -83,6 +83,7 @@ type ConfigService interface {
 // more Actions get extracted.
 type TeamConfigService interface {
 	GetTeamConfig() (*domain.TeamConfig, error)
+	SaveTeamConfig(*domain.TeamConfig) error
 	SetTribeForProject(project, tribe string) error
 	GetTribeForProject(project string) (string, error)
 	SetCompanyForProject(project, company string) error


### PR DESCRIPTION
## Summary
- Inline team-timeline show/add/remove closures in `createConfigCommand` were not unit-testable. Extract into `a.configTeamTimelineShowAction` / `AddAction` / `RemoveAction` on `*App`.
- Grow `TeamConfigService` with `SaveTeamConfig` so the add/remove paths can persist the mutated `TeamConfig` the same way the old inline code did.
- New `cmd/config_team_timeline_test.go` drives every branch (required-field validation, date parse error, load/save error wraps, member-not-in-timeline from `SetMemberLeft`, show fallback to flat team list, and the timeline render with active/departed members).

## Validation
- `make pre-push`: 0 lint issues, coverage 86.5% (gate 78%).
- CLI surface: byte-identical `--help` output for `config team-timeline {show,add,remove}` before and after extraction.

## Test plan
- [x] `go test -race ./cmd/...` passes
- [x] `golangci-lint run ./...` clean
- [x] Coverage gate green
- [x] `--help` golden diff identical for the 3 subcommands