### PR TITLE
refactor(cmd): extract sync-team Action with injectable use case

### DIFF
--- a/cmd/config_commands.go
+++ b/cmd/config_commands.go
@@ -45,52 +45,9 @@ func (a *App) createConfigCommand() *cli.Command {
 				Action: a.configValidateAction,
 			},
 			{
-				Name:  "sync-team",
-				Usage: "Synchronize team members from JIRA for a project",
-				Action: func(ctx *cli.Context) error {
-					projectKey := ctx.String("project")
-					if projectKey == "" {
-						return fmt.Errorf("project key is required")
-					}
-
-					// Create JIRA team sync adapter
-					teamSyncAdapter, err := configinfra.NewJiraTeamSyncAdapter(a.configService)
-					if err != nil {
-						return fmt.Errorf("failed to create team sync adapter: %v", err)
-					}
-
-					// Create team sync use case
-					configRepo := configinfra.NewFileRepository(configDir)
-					syncTeamUseCase := usecase.NewSyncTeamFromJira(teamSyncAdapter, configRepo)
-
-					// Execute team synchronization
-					result, err := syncTeamUseCase.Execute(projectKey)
-					if err != nil {
-						return fmt.Errorf("failed to sync team: %v", err)
-					}
-
-					// Display results
-					fmt.Printf("✅ Team synchronization completed for project %s\n", projectKey)
-					fmt.Printf("Source: %s\n", result.Source)
-					fmt.Printf("Total members: %d\n", result.TotalMembers)
-
-					if len(result.AddedMembers) > 0 {
-						fmt.Printf("Added members: %s\n", strings.Join(result.AddedMembers, ", "))
-					}
-
-					if len(result.RemovedMembers) > 0 {
-						fmt.Printf("Removed members: %s\n", strings.Join(result.RemovedMembers, ", "))
-					}
-
-					if result.HasErrors() {
-						fmt.Printf("⚠️  Warnings/Errors:\n")
-						for _, syncErr := range result.Errors {
-							fmt.Printf("  - %s (%s)\n", syncErr.Message, syncErr.Type)
-						}
-					}
-
-					return nil
-				},
+				Name:   "sync-team",
+				Usage:  "Synchronize team members from JIRA for a project",
+				Action: a.configSyncTeamAction,
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:     "project",
@@ -901,5 +858,76 @@ func (a *App) configTeamTimelineRemoveAction(ctx *cli.Context) error {
 	}
 
 	fmt.Printf("Set '%s' departure from project '%s' (left: %s)\n", member, project, leftStr)
+	return nil
+}
+
+// ensureSyncTeamService lazily constructs the JIRA-backed
+// SyncTeamFromJira use case via a.syncTeamServiceFactory (which
+// tests can override) and stashes the result on App. Mirrors
+// ensureTeamConfigService, but exposes the construction error
+// because *configinfra.JiraTeamSyncAdapter requires env vars and
+// can fail.
+func (a *App) ensureSyncTeamService() error {
+	if a.syncTeamService != nil {
+		return nil
+	}
+	factory := a.syncTeamServiceFactory
+	if factory == nil {
+		factory = a.defaultSyncTeamServiceFactory
+	}
+	svc, err := factory()
+	if err != nil {
+		return err
+	}
+	a.syncTeamService = svc
+	return nil
+}
+
+// defaultSyncTeamServiceFactory wires the JIRA adapter + file
+// repository + use case the same way the original inline Action did.
+func (a *App) defaultSyncTeamServiceFactory() (SyncTeamFromJiraService, error) {
+	teamSyncAdapter, err := configinfra.NewJiraTeamSyncAdapter(a.configService)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create team sync adapter: %v", err)
+	}
+	configRepo := configinfra.NewFileRepository(configDir)
+	return usecase.NewSyncTeamFromJira(teamSyncAdapter, configRepo), nil
+}
+
+// configSyncTeamAction backs `assetcap config sync-team`.
+func (a *App) configSyncTeamAction(ctx *cli.Context) error {
+	projectKey := ctx.String("project")
+	if projectKey == "" {
+		return fmt.Errorf("project key is required")
+	}
+
+	if err := a.ensureSyncTeamService(); err != nil {
+		return err
+	}
+
+	result, err := a.syncTeamService.Execute(projectKey)
+	if err != nil {
+		return fmt.Errorf("failed to sync team: %v", err)
+	}
+
+	fmt.Printf("✅ Team synchronization completed for project %s\n", projectKey)
+	fmt.Printf("Source: %s\n", result.Source)
+	fmt.Printf("Total members: %d\n", result.TotalMembers)
+
+	if len(result.AddedMembers) > 0 {
+		fmt.Printf("Added members: %s\n", strings.Join(result.AddedMembers, ", "))
+	}
+
+	if len(result.RemovedMembers) > 0 {
+		fmt.Printf("Removed members: %s\n", strings.Join(result.RemovedMembers, ", "))
+	}
+
+	if result.HasErrors() {
+		fmt.Printf("⚠️  Warnings/Errors:\n")
+		for _, syncErr := range result.Errors {
+			fmt.Printf("  - %s (%s)\n", syncErr.Message, syncErr.Type)
+		}
+	}
+
 	return nil
 }

--- a/cmd/config_sync_team_test.go
+++ b/cmd/config_sync_team_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	configdomain "github.com/helmedeiros/digital-asset-capitalization/internal/config/domain"
+)
+
+// stubSyncTeamService is the hand-rolled in-package stub for
+// SyncTeamFromJiraService. Records the projectKey passed to Execute
+// and returns the injected result / err.
+type stubSyncTeamService struct {
+	projectKey string
+	result     *configdomain.TeamSyncResult
+	err        error
+}
+
+func (s *stubSyncTeamService) Execute(projectKey string) (*configdomain.TeamSyncResult, error) {
+	s.projectKey = projectKey
+	return s.result, s.err
+}
+
+func TestApp_configSyncTeamAction_RequiresProject(t *testing.T) {
+	t.Parallel()
+	a := &App{syncTeamService: &stubSyncTeamService{}}
+	err := a.configSyncTeamAction(newContextWithFlags(t, nil, nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project key is required")
+}
+
+func TestApp_configSyncTeamAction_FactoryErrorPropagates(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("adapter boom")
+	a := &App{
+		syncTeamServiceFactory: func() (SyncTeamFromJiraService, error) {
+			return nil, wantErr
+		},
+	}
+	ctx := newContextWithFlags(t, map[string]string{"project": "FN"}, nil)
+	err := a.configSyncTeamAction(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestApp_configSyncTeamAction_ExecuteErrorWraps(t *testing.T) {
+	t.Parallel()
+	a := &App{syncTeamService: &stubSyncTeamService{err: errors.New("jira down")}}
+	ctx := newContextWithFlags(t, map[string]string{"project": "FN"}, nil)
+	err := a.configSyncTeamAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to sync team")
+}
+
+func TestApp_configSyncTeamAction_SuccessMinimal(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	stub := &stubSyncTeamService{result: &configdomain.TeamSyncResult{
+		Source:       "jira",
+		TotalMembers: 3,
+	}}
+	a := &App{syncTeamService: stub}
+	ctx := newContextWithFlags(t, map[string]string{"project": "FN"}, nil)
+	out, err := captureStdout(t, func() error { return a.configSyncTeamAction(ctx) })
+	require.NoError(t, err)
+	assert.Equal(t, "FN", stub.projectKey)
+	assert.Contains(t, out, "Team synchronization completed for project FN")
+	assert.Contains(t, out, "Source: jira")
+	assert.Contains(t, out, "Total members: 3")
+	assert.NotContains(t, out, "Added members:")
+	assert.NotContains(t, out, "Removed members:")
+	assert.NotContains(t, out, "Warnings/Errors:")
+}
+
+func TestApp_configSyncTeamAction_SuccessWithDiffAndErrors(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	stub := &stubSyncTeamService{result: &configdomain.TeamSyncResult{
+		Source:         "jira",
+		TotalMembers:   2,
+		AddedMembers:   []string{"alice", "bob"},
+		RemovedMembers: []string{"carol"},
+		Errors: []configdomain.TeamSyncError{
+			{Message: "rate limited", Type: "network"},
+		},
+	}}
+	a := &App{syncTeamService: stub}
+	ctx := newContextWithFlags(t, map[string]string{"project": "FN"}, nil)
+	out, err := captureStdout(t, func() error { return a.configSyncTeamAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Added members: alice, bob")
+	assert.Contains(t, out, "Removed members: carol")
+	assert.Contains(t, out, "Warnings/Errors:")
+	assert.Contains(t, out, "rate limited (network)")
+}
+
+func TestApp_ensureSyncTeamService_IdempotentAndUsesFactory(t *testing.T) {
+	t.Parallel()
+	stub := &stubSyncTeamService{}
+	calls := 0
+	a := &App{
+		syncTeamServiceFactory: func() (SyncTeamFromJiraService, error) {
+			calls++
+			return stub, nil
+		},
+	}
+	require.NoError(t, a.ensureSyncTeamService())
+	require.Same(t, stub, a.syncTeamService)
+	require.NoError(t, a.ensureSyncTeamService())
+	assert.Equal(t, 1, calls, "factory should only run on the first call")
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,18 +55,20 @@ var (
 
 // App holds all the application dependencies
 type App struct {
-	assetService       assetsapp.AssetService
-	taskService        tasksapp.TaskService
-	sprintService      sprintapp.SprintService
-	configService      ConfigService
-	teamConfigService  TeamConfigService
-	investmentService  *investmentservice.InvestmentService
-	deploymentService  *deploymentsapp.DeploymentService
-	deploymentRepo     deploymentports.DeploymentRepository
-	teamResolver       *configapp.TeamResolverService
-	taskRepo           taskports.TaskRepository
-	taskClassifier     taskports.TaskClassifier
-	allocationLockRepo taskports.SprintLockRepository
+	assetService           assetsapp.AssetService
+	taskService            tasksapp.TaskService
+	sprintService          sprintapp.SprintService
+	configService          ConfigService
+	teamConfigService      TeamConfigService
+	syncTeamService        SyncTeamFromJiraService
+	syncTeamServiceFactory func() (SyncTeamFromJiraService, error)
+	investmentService      *investmentservice.InvestmentService
+	deploymentService      *deploymentsapp.DeploymentService
+	deploymentRepo         deploymentports.DeploymentRepository
+	teamResolver           *configapp.TeamResolverService
+	taskRepo               taskports.TaskRepository
+	taskClassifier         taskports.TaskClassifier
+	allocationLockRepo     taskports.SprintLockRepository
 }
 
 // ConfigService interface for configuration operations
@@ -91,6 +93,14 @@ type TeamConfigService interface {
 	SetExcludedIssueTypesForProject(project string, types []string) error
 	GetExcludedIssueTypesForProject(project string) ([]string, error)
 	SetBoardWorkStream(project string, boardID int, workStream string) error
+}
+
+// SyncTeamFromJiraService is the subset of *usecase.SyncTeamFromJira
+// that the `config sync-team` Action needs. Pulling it out as an
+// interface lets tests inject a stub without standing up the JIRA
+// adapter (which depends on env vars and reaches the network).
+type SyncTeamFromJiraService interface {
+	Execute(projectKey string) (*domain.TeamSyncResult, error)
 }
 
 // configServiceImpl implements ConfigService


### PR DESCRIPTION
## Summary
- The `sync-team` inline closure constructed `configinfra.NewJiraTeamSyncAdapter` + `usecase.NewSyncTeamFromJira` directly, hard-coding env-var + network dependencies. That made the success-path stdout formatting uncoverable.
- Introduce a `SyncTeamFromJiraService` interface (single `Execute` method) plus a `syncTeamServiceFactory` hook on `*App`. Extract the closure into `a.configSyncTeamAction`. `ensureSyncTeamService` runs the factory once; `defaultSyncTeamServiceFactory` keeps the original JIRA wiring in production.
- New `cmd/config_sync_team_test.go` covers required-flag, factory error, Execute error wrap, success with minimal/full result, and the ensure-service idempotency contract.

## Validation
- `make pre-push`: 0 lint issues, coverage 86.6% (gate 78%).
- `--help` for `config sync-team` byte-identical before/after extraction.

## Test plan
- [x] `go test -race ./cmd/...` passes
- [x] `golangci-lint run ./...` clean
- [x] Coverage gate green
- [x] CLI surface preserved