### PR TITLE
refactor(cmd): extract assets sync-contributors Action

### DIFF
--- a/cmd/assets_commands.go
+++ b/cmd/assets_commands.go
@@ -274,125 +274,9 @@ func (a *App) createAssetsCommand() *cli.Command {
 				},
 			},
 			{
-				Name:  "sync-contributors",
-				Usage: "Synchronize asset contributors from JIRA task assignments with optional filtering",
-				Action: func(ctx *cli.Context) error {
-					dryRun := ctx.Bool("dry-run")
-					maxResults := ctx.Int("max-results")
-					projectKey := ctx.String("project")
-					sprintName := ctx.String("sprint")
-					teamName := ctx.String("team")
-					assetName := ctx.String("asset")
-
-					// Create JIRA query adapter
-					jiraQueryAdapter, err := assetsinfra.NewJiraQueryAdapter(a.configService)
-					if err != nil {
-						return fmt.Errorf("failed to create JIRA query adapter: %v", err)
-					}
-
-					// Create team config adapter
-					configRepo := configinfra.NewFileRepository(configDir)
-					teamConfigAdapter := assetsinfra.NewTeamConfigAdapter(configRepo)
-
-					// Create asset repository
-					repoConfig := assetsinfra.RepositoryConfig{
-						Directory: assetsDir,
-						Filename:  assetsFile,
-						FileMode:  0644,
-						DirMode:   0755,
-					}
-					assetRepo := assetsinfra.NewJSONRepository(repoConfig)
-
-					// Create use case
-					syncUseCase := assetsusecase.NewSyncAssetContributorsFromJiraUseCase(
-						assetRepo,
-						jiraQueryAdapter,
-						teamConfigAdapter,
-					)
-
-					// Execute sync
-					input := assetsusecase.SyncContributorsInput{
-						DryRun:     dryRun,
-						MaxResults: maxResults,
-						ProjectKey: projectKey,
-						SprintName: sprintName,
-						TeamName:   teamName,
-						AssetName:  assetName,
-					}
-
-					result, err := syncUseCase.Execute(context.Background(), input)
-					if err != nil {
-						return fmt.Errorf("failed to sync contributors: %v", err)
-					}
-
-					// Display results with context
-					if projectKey != "" || sprintName != "" || teamName != "" || assetName != "" {
-						fmt.Printf("🎯 Filtered sync")
-						if projectKey != "" {
-							fmt.Printf(" project:%s", projectKey)
-						}
-						if sprintName != "" {
-							fmt.Printf(" sprint:%s", sprintName)
-						}
-						if teamName != "" {
-							fmt.Printf(" team:%s", teamName)
-						}
-						if assetName != "" {
-							fmt.Printf(" asset:%s", assetName)
-						}
-						fmt.Println()
-					}
-
-					fmt.Printf("🔍 Analyzed %d JIRA tasks with asset labels\n", result.TotalTasks)
-					fmt.Printf("📦 Processed %d assets\n", len(result.AssetsProcessed))
-
-					if dryRun {
-						fmt.Println("\n🔍 DRY RUN - No changes were made")
-					} else {
-						fmt.Printf("✅ Updated %d assets\n", result.AssetsUpdated)
-					}
-
-					// Show details for each asset
-					for _, assetResult := range result.AssetsProcessed {
-						fmt.Printf("\n📦 %s (analyzed %d tasks)\n", assetResult.AssetName, assetResult.TasksAnalyzed)
-
-						if assetResult.Error != "" {
-							fmt.Printf("  ❌ Error: %s\n", assetResult.Error)
-							continue
-						}
-
-						if len(assetResult.TeamsFound) > 0 {
-							fmt.Printf("  🔍 Teams found: %s\n", strings.Join(assetResult.TeamsFound, ", "))
-						}
-
-						if len(assetResult.CurrentContributors) > 0 {
-							fmt.Printf("  👥 Current contributors: %s\n", strings.Join(assetResult.CurrentContributors, ", "))
-						}
-
-						if len(assetResult.NewContributors) > 0 {
-							fmt.Printf("  ➕ New contributors: %s\n", strings.Join(assetResult.NewContributors, ", "))
-						}
-
-						if len(assetResult.RemovedContributors) > 0 {
-							fmt.Printf("  ➖ Removed contributors: %s\n", strings.Join(assetResult.RemovedContributors, ", "))
-						}
-
-						if assetResult.Updated {
-							fmt.Printf("  ✅ Updated\n")
-						} else if !dryRun {
-							fmt.Printf("  ⏸️  No changes needed\n")
-						}
-					}
-
-					if len(result.Errors) > 0 {
-						fmt.Printf("\n⚠️  Errors encountered:\n")
-						for _, error := range result.Errors {
-							fmt.Printf("  - %s\n", error)
-						}
-					}
-
-					return nil
-				},
+				Name:   "sync-contributors",
+				Usage:  "Synchronize asset contributors from JIRA task assignments with optional filtering",
+				Action: a.assetsSyncContributorsAction,
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
 						Name:  "dry-run",
@@ -833,5 +717,142 @@ func (a *App) assetsUpdateConfluenceAction(ctx *cli.Context) error {
 	fmt.Printf("  Page ID: %s\n", result.PageID)
 	fmt.Printf("  Space: %s\n", result.SpaceKey)
 	fmt.Printf("  URL: %s\n", result.PageURL)
+	return nil
+}
+
+// ensureSyncContributorsService lazily builds the JIRA + team-config
+// + asset-repo + use-case graph via a.syncContributorsServiceFactory
+// (which tests can override) and stashes the result on App. Mirrors
+// ensureSyncTeamService; exposes the construction error because
+// *assetsinfra.JiraQueryAdapter requires env vars and can fail.
+func (a *App) ensureSyncContributorsService() error {
+	if a.syncContributorsService != nil {
+		return nil
+	}
+	factory := a.syncContributorsServiceFactory
+	if factory == nil {
+		factory = a.defaultSyncContributorsServiceFactory
+	}
+	svc, err := factory()
+	if err != nil {
+		return err
+	}
+	a.syncContributorsService = svc
+	return nil
+}
+
+// defaultSyncContributorsServiceFactory wires the JIRA query
+// adapter + team-config adapter + JSON asset repository + the use
+// case the same way the original inline Action did.
+func (a *App) defaultSyncContributorsServiceFactory() (SyncAssetContributorsService, error) {
+	jiraQueryAdapter, err := assetsinfra.NewJiraQueryAdapter(a.configService)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JIRA query adapter: %v", err)
+	}
+	configRepo := configinfra.NewFileRepository(configDir)
+	teamConfigAdapter := assetsinfra.NewTeamConfigAdapter(configRepo)
+	assetRepo := assetsinfra.NewJSONRepository(assetsinfra.RepositoryConfig{
+		Directory: assetsDir,
+		Filename:  assetsFile,
+		FileMode:  0644,
+		DirMode:   0755,
+	})
+	return assetsusecase.NewSyncAssetContributorsFromJiraUseCase(
+		assetRepo,
+		jiraQueryAdapter,
+		teamConfigAdapter,
+	), nil
+}
+
+// assetsSyncContributorsAction backs `assetcap assets sync-contributors`.
+func (a *App) assetsSyncContributorsAction(ctx *cli.Context) error {
+	dryRun := ctx.Bool("dry-run")
+	projectKey := ctx.String("project")
+	sprintName := ctx.String("sprint")
+	teamName := ctx.String("team")
+	assetName := ctx.String("asset")
+
+	if err := a.ensureSyncContributorsService(); err != nil {
+		return err
+	}
+
+	input := assetsusecase.SyncContributorsInput{
+		DryRun:     dryRun,
+		MaxResults: ctx.Int("max-results"),
+		ProjectKey: projectKey,
+		SprintName: sprintName,
+		TeamName:   teamName,
+		AssetName:  assetName,
+	}
+
+	result, err := a.syncContributorsService.Execute(context.Background(), input)
+	if err != nil {
+		return fmt.Errorf("failed to sync contributors: %v", err)
+	}
+
+	if projectKey != "" || sprintName != "" || teamName != "" || assetName != "" {
+		fmt.Printf("🎯 Filtered sync")
+		if projectKey != "" {
+			fmt.Printf(" project:%s", projectKey)
+		}
+		if sprintName != "" {
+			fmt.Printf(" sprint:%s", sprintName)
+		}
+		if teamName != "" {
+			fmt.Printf(" team:%s", teamName)
+		}
+		if assetName != "" {
+			fmt.Printf(" asset:%s", assetName)
+		}
+		fmt.Println()
+	}
+
+	fmt.Printf("🔍 Analyzed %d JIRA tasks with asset labels\n", result.TotalTasks)
+	fmt.Printf("📦 Processed %d assets\n", len(result.AssetsProcessed))
+
+	if dryRun {
+		fmt.Println("\n🔍 DRY RUN - No changes were made")
+	} else {
+		fmt.Printf("✅ Updated %d assets\n", result.AssetsUpdated)
+	}
+
+	for _, assetResult := range result.AssetsProcessed {
+		fmt.Printf("\n📦 %s (analyzed %d tasks)\n", assetResult.AssetName, assetResult.TasksAnalyzed)
+
+		if assetResult.Error != "" {
+			fmt.Printf("  ❌ Error: %s\n", assetResult.Error)
+			continue
+		}
+
+		if len(assetResult.TeamsFound) > 0 {
+			fmt.Printf("  🔍 Teams found: %s\n", strings.Join(assetResult.TeamsFound, ", "))
+		}
+
+		if len(assetResult.CurrentContributors) > 0 {
+			fmt.Printf("  👥 Current contributors: %s\n", strings.Join(assetResult.CurrentContributors, ", "))
+		}
+
+		if len(assetResult.NewContributors) > 0 {
+			fmt.Printf("  ➕ New contributors: %s\n", strings.Join(assetResult.NewContributors, ", "))
+		}
+
+		if len(assetResult.RemovedContributors) > 0 {
+			fmt.Printf("  ➖ Removed contributors: %s\n", strings.Join(assetResult.RemovedContributors, ", "))
+		}
+
+		if assetResult.Updated {
+			fmt.Printf("  ✅ Updated\n")
+		} else if !dryRun {
+			fmt.Printf("  ⏸️  No changes needed\n")
+		}
+	}
+
+	if len(result.Errors) > 0 {
+		fmt.Printf("\n⚠️  Errors encountered:\n")
+		for _, syncErr := range result.Errors {
+			fmt.Printf("  - %s\n", syncErr)
+		}
+	}
+
 	return nil
 }

--- a/cmd/assets_sync_contributors_test.go
+++ b/cmd/assets_sync_contributors_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	assetsusecase "github.com/helmedeiros/digital-asset-capitalization/internal/assets/application/usecase"
+)
+
+// stubSyncContributorsService records the input passed to Execute
+// and returns the injected result / err.
+type stubSyncContributorsService struct {
+	gotInput assetsusecase.SyncContributorsInput
+	result   *assetsusecase.SyncContributorsResult
+	err      error
+}
+
+func (s *stubSyncContributorsService) Execute(_ context.Context, input assetsusecase.SyncContributorsInput) (*assetsusecase.SyncContributorsResult, error) {
+	s.gotInput = input
+	return s.result, s.err
+}
+
+func TestApp_assetsSyncContributorsAction_FactoryErrorPropagates(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("adapter boom")
+	a := &App{
+		syncContributorsServiceFactory: func() (SyncAssetContributorsService, error) {
+			return nil, wantErr
+		},
+	}
+	err := a.assetsSyncContributorsAction(newContextWithFlags(t, nil, nil))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestApp_assetsSyncContributorsAction_ExecuteErrorWraps(t *testing.T) {
+	t.Parallel()
+	a := &App{syncContributorsService: &stubSyncContributorsService{err: errors.New("jira down")}}
+	err := a.assetsSyncContributorsAction(newContextWithFlags(t, nil, nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to sync contributors")
+}
+
+func TestApp_assetsSyncContributorsAction_DryRunUnfiltered(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	stub := &stubSyncContributorsService{result: &assetsusecase.SyncContributorsResult{
+		TotalTasks:    5,
+		AssetsUpdated: 0,
+		AssetsProcessed: []assetsusecase.AssetContributorSyncResult{{
+			AssetName: "PaymentGateway", TasksAnalyzed: 5,
+			TeamsFound:          []string{"FN"},
+			CurrentContributors: []string{"alice"},
+			NewContributors:     []string{"bob"},
+			RemovedContributors: []string{"carol"},
+		}},
+	}}
+	a := &App{syncContributorsService: stub}
+	ctx := newContextWithFlags(t, nil, map[string]bool{"dry-run": true})
+	out, err := captureStdout(t, func() error { return a.assetsSyncContributorsAction(ctx) })
+	require.NoError(t, err)
+	assert.True(t, stub.gotInput.DryRun)
+	assert.NotContains(t, out, "Filtered sync")
+	assert.Contains(t, out, "Analyzed 5 JIRA tasks")
+	assert.Contains(t, out, "Processed 1 assets")
+	assert.Contains(t, out, "DRY RUN - No changes were made")
+	assert.Contains(t, out, "PaymentGateway")
+	assert.Contains(t, out, "Teams found: FN")
+	assert.Contains(t, out, "Current contributors: alice")
+	assert.Contains(t, out, "New contributors: bob")
+	assert.Contains(t, out, "Removed contributors: carol")
+	// Updated is false + dryRun true → neither "Updated" nor "No changes needed".
+	assert.NotContains(t, out, "Updated\n")
+	assert.NotContains(t, out, "No changes needed")
+}
+
+func TestApp_assetsSyncContributorsAction_FilteredRealRunWithErrorsAndStatuses(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	stub := &stubSyncContributorsService{result: &assetsusecase.SyncContributorsResult{
+		TotalTasks:    10,
+		AssetsUpdated: 1,
+		AssetsProcessed: []assetsusecase.AssetContributorSyncResult{
+			{AssetName: "PaymentGateway", TasksAnalyzed: 6, Updated: true},
+			{AssetName: "Checkout", TasksAnalyzed: 4, Updated: false},
+			{AssetName: "Failing", TasksAnalyzed: 0, Error: "permission denied"},
+		},
+		Errors: []string{"global rate limit hit"},
+	}}
+	a := &App{syncContributorsService: stub}
+	ctx := newContextWithFlags(t, map[string]string{
+		"project": "FN", "sprint": "Alpha", "team": "Pricing", "asset": "PaymentGateway",
+	}, nil)
+	out, err := captureStdout(t, func() error { return a.assetsSyncContributorsAction(ctx) })
+	require.NoError(t, err)
+	assert.Equal(t, "FN", stub.gotInput.ProjectKey)
+	assert.Equal(t, "Alpha", stub.gotInput.SprintName)
+	assert.Equal(t, "Pricing", stub.gotInput.TeamName)
+	assert.Equal(t, "PaymentGateway", stub.gotInput.AssetName)
+	assert.Contains(t, out, "Filtered sync project:FN sprint:Alpha team:Pricing asset:PaymentGateway")
+	assert.Contains(t, out, "Updated 1 assets")
+	assert.Contains(t, out, "PaymentGateway")
+	// Updated branch is hit.
+	assert.Contains(t, out, "✅ Updated\n")
+	// Not updated, real run → "No changes needed" branch.
+	assert.Contains(t, out, "No changes needed")
+	// Error-on-asset branch.
+	assert.Contains(t, out, "❌ Error: permission denied")
+	// Errors-encountered footer.
+	assert.Contains(t, out, "Errors encountered:")
+	assert.Contains(t, out, "global rate limit hit")
+}
+
+func TestApp_ensureSyncContributorsService_IdempotentAndUsesFactory(t *testing.T) {
+	t.Parallel()
+	stub := &stubSyncContributorsService{}
+	calls := 0
+	a := &App{
+		syncContributorsServiceFactory: func() (SyncAssetContributorsService, error) {
+			calls++
+			return stub, nil
+		},
+	}
+	require.NoError(t, a.ensureSyncContributorsService())
+	require.Same(t, stub, a.syncContributorsService)
+	require.NoError(t, a.ensureSyncContributorsService())
+	assert.Equal(t, 1, calls, "factory should only run on the first call")
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	assetsapp "github.com/helmedeiros/digital-asset-capitalization/internal/assets/application"
+	assetsusecase "github.com/helmedeiros/digital-asset-capitalization/internal/assets/application/usecase"
 	assetsinfra "github.com/helmedeiros/digital-asset-capitalization/internal/assets/infrastructure"
 	assetid "github.com/helmedeiros/digital-asset-capitalization/internal/assets/infrastructure/id"
 	"github.com/helmedeiros/digital-asset-capitalization/internal/assets/infrastructure/llama"
@@ -57,20 +58,22 @@ var (
 
 // App holds all the application dependencies
 type App struct {
-	assetService           assetsapp.AssetService
-	taskService            tasksapp.TaskService
-	sprintService          sprintapp.SprintService
-	configService          ConfigService
-	teamConfigService      TeamConfigService
-	syncTeamService        SyncTeamFromJiraService
-	syncTeamServiceFactory func() (SyncTeamFromJiraService, error)
-	investmentService      InvestmentService
-	deploymentService      *deploymentsapp.DeploymentService
-	deploymentRepo         deploymentports.DeploymentRepository
-	teamResolver           *configapp.TeamResolverService
-	taskRepo               taskports.TaskRepository
-	taskClassifier         taskports.TaskClassifier
-	allocationLockRepo     taskports.SprintLockRepository
+	assetService                   assetsapp.AssetService
+	taskService                    tasksapp.TaskService
+	sprintService                  sprintapp.SprintService
+	configService                  ConfigService
+	teamConfigService              TeamConfigService
+	syncTeamService                SyncTeamFromJiraService
+	syncTeamServiceFactory         func() (SyncTeamFromJiraService, error)
+	syncContributorsService        SyncAssetContributorsService
+	syncContributorsServiceFactory func() (SyncAssetContributorsService, error)
+	investmentService              InvestmentService
+	deploymentService              *deploymentsapp.DeploymentService
+	deploymentRepo                 deploymentports.DeploymentRepository
+	teamResolver                   *configapp.TeamResolverService
+	taskRepo                       taskports.TaskRepository
+	taskClassifier                 taskports.TaskClassifier
+	allocationLockRepo             taskports.SprintLockRepository
 }
 
 // ConfigService interface for configuration operations
@@ -103,6 +106,16 @@ type TeamConfigService interface {
 // adapter (which depends on env vars and reaches the network).
 type SyncTeamFromJiraService interface {
 	Execute(projectKey string) (*domain.TeamSyncResult, error)
+}
+
+// SyncAssetContributorsService is the subset of
+// *assetsusecase.SyncAssetContributorsFromJiraUseCase that the
+// `assets sync-contributors` Action calls. Extracting it as an
+// interface lets tests drive the Action against a stub instead of
+// constructing the full JIRA query adapter + team-config adapter +
+// asset repository graph.
+type SyncAssetContributorsService interface {
+	Execute(ctx context.Context, input assetsusecase.SyncContributorsInput) (*assetsusecase.SyncContributorsResult, error)
 }
 
 // InvestmentService is the subset of


### PR DESCRIPTION
## Summary
- The `assets sync-contributors` inline closure constructed `NewJiraQueryAdapter` + `FileRepository` + `TeamConfigAdapter` + `JSONRepository` + the use case directly. That hard-coded the JIRA / file dependencies and left the formatting + filtering branches uncovered.
- Introduce `SyncAssetContributorsService` (single `Execute` method) plus `syncContributorsServiceFactory` on `*App`. Extract the closure into `a.assetsSyncContributorsAction`. `ensureSyncContributorsService` runs the factory once; the default factory keeps the original wiring.
- New `cmd/assets_sync_contributors_test.go` covers factory error, Execute error wrap, unfiltered dry-run, filtered real-run (with Updated / No-changes / per-asset Error / global Errors footer), plus the ensure-service idempotency contract.

## Validation
- `make pre-push`: 0 lint issues, coverage 88.2% (gate 78%).
- `--help` byte-identical for `assets sync-contributors`.

## Test plan
- [x] `go test -race ./cmd/...` passes
- [x] `golangci-lint run ./...` clean
- [x] Coverage gate green
- [x] CLI surface preserved