### PR TITLE
refactor(cmd): extract assets sync-and-enrich Action

### DIFF
--- a/cmd/assets_commands.go
+++ b/cmd/assets_commands.go
@@ -152,88 +152,9 @@ func (a *App) createAssetsCommand() *cli.Command {
 				},
 			},
 			{
-				Name:  "sync-and-enrich",
-				Usage: "Sync assets from Confluence and enrich them with keywords and fields using AI",
-				Action: func(ctx *cli.Context) error {
-					spaceKey := ctx.String("space")
-					label := ctx.String("label")
-					debug := ctx.Bool("debug")
-					enrichKeywords := ctx.Bool("keywords")
-					enrichFields := ctx.StringSlice("fields")
-					dryRun := ctx.Bool("dry-run")
-					maxConcurrent := ctx.Int("max-concurrent")
-					if maxConcurrent < 1 {
-						maxConcurrent = 1
-					}
-					// field-filter is reserved for the future bulk use case path;
-					// the inline enrichment here always touches every synced asset.
-					_ = ctx.String("field-filter")
-
-					// Validate required parameters
-					if label == "" {
-						return fmt.Errorf("label is required")
-					}
-
-					fmt.Printf("Starting sync-and-enrich workflow...\n")
-					fmt.Printf("Space: %s, Label: %s, Keywords: %v, Fields: %v, MaxConcurrent: %d\n", spaceKey, label, enrichKeywords, enrichFields, maxConcurrent)
-
-					if dryRun {
-						fmt.Printf("DRY RUN: Would sync assets and enrich with keywords=%v, fields=%v\n", enrichKeywords, enrichFields)
-						return nil
-					}
-
-					// Step 1: Sync assets
-					fmt.Printf("Step 1: Syncing assets from Confluence...\n")
-					result, err := a.assetService.SyncFromConfluence(spaceKey, label, debug)
-					if err != nil {
-						return fmt.Errorf("failed to sync assets: %w", err)
-					}
-
-					fmt.Printf("Synced %d assets\n", len(result.SyncedAssets))
-
-					// Step 2: Enrich keywords if requested
-					if enrichKeywords && len(result.SyncedAssets) > 0 {
-						fmt.Printf("Step 2: Generating keywords for synced assets (max %d in flight)...\n", maxConcurrent)
-						eg := new(errgroup.Group)
-						eg.SetLimit(maxConcurrent)
-						for _, asset := range result.SyncedAssets {
-							asset := asset
-							eg.Go(func() error {
-								if err := a.assetService.GenerateKeywords(asset.Name); err != nil {
-									fmt.Printf("Warning: Failed to generate keywords for %s: %v\n", asset.Name, err)
-								} else {
-									fmt.Printf("Generated keywords for: %s\n", asset.Name)
-								}
-								return nil
-							})
-						}
-						_ = eg.Wait()
-					}
-
-					// Step 3: Enrich fields if requested
-					if len(enrichFields) > 0 && len(result.SyncedAssets) > 0 {
-						fmt.Printf("Step 3: Enriching fields %v for synced assets (max %d in flight)...\n", enrichFields, maxConcurrent)
-						eg := new(errgroup.Group)
-						eg.SetLimit(maxConcurrent)
-						for _, asset := range result.SyncedAssets {
-							for _, field := range enrichFields {
-								asset, field := asset, field
-								eg.Go(func() error {
-									if err := a.assetService.EnrichAsset(asset.Name, field); err != nil {
-										fmt.Printf("Warning: Failed to enrich %s field for %s: %v\n", field, asset.Name, err)
-									} else {
-										fmt.Printf("Enriched %s field for: %s\n", field, asset.Name)
-									}
-									return nil
-								})
-							}
-						}
-						_ = eg.Wait()
-					}
-
-					fmt.Printf("Sync-and-enrich workflow completed successfully!\n")
-					return nil
-				},
+				Name:   "sync-and-enrich",
+				Usage:  "Sync assets from Confluence and enrich them with keywords and fields using AI",
+				Action: a.assetsSyncAndEnrichAction,
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:     "space",
@@ -854,5 +775,86 @@ func (a *App) assetsSyncContributorsAction(ctx *cli.Context) error {
 		}
 	}
 
+	return nil
+}
+
+// assetsSyncAndEnrichAction backs `assetcap assets sync-and-enrich`.
+// The errgroup-based fan-out is the original inline implementation
+// lifted verbatim into a named method, with concurrency capped at
+// max-concurrent (clamped to >= 1).
+func (a *App) assetsSyncAndEnrichAction(ctx *cli.Context) error {
+	spaceKey := ctx.String("space")
+	label := ctx.String("label")
+	debug := ctx.Bool("debug")
+	enrichKeywords := ctx.Bool("keywords")
+	enrichFields := ctx.StringSlice("fields")
+	dryRun := ctx.Bool("dry-run")
+	maxConcurrent := ctx.Int("max-concurrent")
+	if maxConcurrent < 1 {
+		maxConcurrent = 1
+	}
+	// field-filter is reserved for the future bulk use case path;
+	// the inline enrichment here always touches every synced asset.
+	_ = ctx.String("field-filter")
+
+	if label == "" {
+		return fmt.Errorf("label is required")
+	}
+
+	fmt.Printf("Starting sync-and-enrich workflow...\n")
+	fmt.Printf("Space: %s, Label: %s, Keywords: %v, Fields: %v, MaxConcurrent: %d\n", spaceKey, label, enrichKeywords, enrichFields, maxConcurrent)
+
+	if dryRun {
+		fmt.Printf("DRY RUN: Would sync assets and enrich with keywords=%v, fields=%v\n", enrichKeywords, enrichFields)
+		return nil
+	}
+
+	fmt.Printf("Step 1: Syncing assets from Confluence...\n")
+	result, err := a.assetService.SyncFromConfluence(spaceKey, label, debug)
+	if err != nil {
+		return fmt.Errorf("failed to sync assets: %w", err)
+	}
+
+	fmt.Printf("Synced %d assets\n", len(result.SyncedAssets))
+
+	if enrichKeywords && len(result.SyncedAssets) > 0 {
+		fmt.Printf("Step 2: Generating keywords for synced assets (max %d in flight)...\n", maxConcurrent)
+		eg := new(errgroup.Group)
+		eg.SetLimit(maxConcurrent)
+		for _, asset := range result.SyncedAssets {
+			asset := asset
+			eg.Go(func() error {
+				if err := a.assetService.GenerateKeywords(asset.Name); err != nil {
+					fmt.Printf("Warning: Failed to generate keywords for %s: %v\n", asset.Name, err)
+				} else {
+					fmt.Printf("Generated keywords for: %s\n", asset.Name)
+				}
+				return nil
+			})
+		}
+		_ = eg.Wait()
+	}
+
+	if len(enrichFields) > 0 && len(result.SyncedAssets) > 0 {
+		fmt.Printf("Step 3: Enriching fields %v for synced assets (max %d in flight)...\n", enrichFields, maxConcurrent)
+		eg := new(errgroup.Group)
+		eg.SetLimit(maxConcurrent)
+		for _, asset := range result.SyncedAssets {
+			for _, field := range enrichFields {
+				asset, field := asset, field
+				eg.Go(func() error {
+					if err := a.assetService.EnrichAsset(asset.Name, field); err != nil {
+						fmt.Printf("Warning: Failed to enrich %s field for %s: %v\n", field, asset.Name, err)
+					} else {
+						fmt.Printf("Enriched %s field for: %s\n", field, asset.Name)
+					}
+					return nil
+				})
+			}
+		}
+		_ = eg.Wait()
+	}
+
+	fmt.Printf("Sync-and-enrich workflow completed successfully!\n")
 	return nil
 }

--- a/cmd/assets_sync_and_enrich_test.go
+++ b/cmd/assets_sync_and_enrich_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	assetdomain "github.com/helmedeiros/digital-asset-capitalization/internal/assets/domain"
+)
+
+// stubAssetServiceForSyncAndEnrich is a concurrent-safe stub for the
+// sync-and-enrich Action. The Action fans out GenerateKeywords and
+// EnrichAsset calls via errgroup with a configurable concurrency
+// limit, so the recording fields are guarded by a mutex.
+type stubAssetServiceForSyncAndEnrich struct {
+	unimplementedAssetService
+
+	syncResult *assetdomain.SyncResult
+	syncErr    error
+
+	mu              sync.Mutex
+	syncCalls       int
+	syncSpace       string
+	syncLabel       string
+	syncDebug       bool
+	keywordsCalled  []string
+	keywordsErrFor  map[string]error
+	enrichCalled    []enrichCall
+	enrichErrForKey map[string]error
+}
+
+type enrichCall struct {
+	name, field string
+}
+
+func (s *stubAssetServiceForSyncAndEnrich) SyncFromConfluence(space, label string, debug bool) (*assetdomain.SyncResult, error) {
+	s.mu.Lock()
+	s.syncCalls++
+	s.syncSpace = space
+	s.syncLabel = label
+	s.syncDebug = debug
+	s.mu.Unlock()
+	return s.syncResult, s.syncErr
+}
+
+func (s *stubAssetServiceForSyncAndEnrich) GenerateKeywords(name string) error {
+	s.mu.Lock()
+	s.keywordsCalled = append(s.keywordsCalled, name)
+	err := s.keywordsErrFor[name]
+	s.mu.Unlock()
+	return err
+}
+
+func (s *stubAssetServiceForSyncAndEnrich) EnrichAsset(name, field string) error {
+	s.mu.Lock()
+	s.enrichCalled = append(s.enrichCalled, enrichCall{name, field})
+	err := s.enrichErrForKey[name+":"+field]
+	s.mu.Unlock()
+	return err
+}
+
+func TestApp_assetsSyncAndEnrichAction_LabelRequired(t *testing.T) {
+	t.Parallel()
+	a := &App{assetService: &stubAssetServiceForSyncAndEnrich{}}
+	err := a.assetsSyncAndEnrichAction(newContextWithFlags(t, nil, nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "label is required")
+}
+
+func TestApp_assetsSyncAndEnrichAction_DryRunSkipsSync(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	stub := &stubAssetServiceForSyncAndEnrich{}
+	a := &App{assetService: stub}
+	ctx := newContextWithFlags(t,
+		map[string]string{"label": "cap-asset"},
+		map[string]bool{"dry-run": true, "keywords": true})
+	out, err := captureStdout(t, func() error { return a.assetsSyncAndEnrichAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Starting sync-and-enrich workflow")
+	assert.Contains(t, out, "DRY RUN: Would sync assets and enrich with keywords=true")
+	assert.Equal(t, 0, stub.syncCalls, "dry-run should not call SyncFromConfluence")
+}
+
+func TestApp_assetsSyncAndEnrichAction_SyncErrorWraps(t *testing.T) {
+	t.Parallel()
+	stub := &stubAssetServiceForSyncAndEnrich{syncErr: errors.New("confluence down")}
+	a := &App{assetService: stub}
+	ctx := newContextWithFlags(t, map[string]string{"label": "cap-asset"}, nil)
+	err := a.assetsSyncAndEnrichAction(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to sync assets")
+}
+
+func TestApp_assetsSyncAndEnrichAction_MaxConcurrentClampedToOne(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	stub := &stubAssetServiceForSyncAndEnrich{syncResult: &assetdomain.SyncResult{}}
+	a := &App{assetService: stub}
+	// max-concurrent=0 should clamp to 1.
+	ctx := newContextWithFlags(t,
+		map[string]string{"label": "cap-asset"},
+		nil)
+	out, err := captureStdout(t, func() error { return a.assetsSyncAndEnrichAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "MaxConcurrent: 1")
+	assert.Equal(t, 1, stub.syncCalls)
+	assert.Equal(t, "cap-asset", stub.syncLabel)
+}
+
+func TestApp_assetsSyncAndEnrichAction_KeywordsBranchHitsBothSuccessAndWarning(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	stub := &stubAssetServiceForSyncAndEnrich{
+		syncResult: &assetdomain.SyncResult{SyncedAssets: []*assetdomain.Asset{
+			{Name: "Alpha"}, {Name: "Beta"},
+		}},
+		keywordsErrFor: map[string]error{"Beta": errors.New("llama down")},
+	}
+	a := &App{assetService: stub}
+	ctx := newContextWithFlags(t,
+		map[string]string{"label": "cap-asset"},
+		map[string]bool{"keywords": true})
+	out, err := captureStdout(t, func() error { return a.assetsSyncAndEnrichAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Step 2: Generating keywords")
+	assert.Contains(t, out, "Generated keywords for: Alpha")
+	assert.Contains(t, out, "Warning: Failed to generate keywords for Beta: llama down")
+	sort.Strings(stub.keywordsCalled)
+	assert.Equal(t, []string{"Alpha", "Beta"}, stub.keywordsCalled)
+}
+
+func TestApp_assetsSyncAndEnrichAction_FieldsBranchHitsBothSuccessAndWarning(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	stub := &stubAssetServiceForSyncAndEnrich{
+		syncResult: &assetdomain.SyncResult{SyncedAssets: []*assetdomain.Asset{
+			{Name: "Alpha"},
+		}},
+		enrichErrForKey: map[string]error{"Alpha:why": errors.New("llama timeout")},
+	}
+	a := &App{assetService: stub}
+	// Two fields → enrich called twice for Alpha.
+	ctx := newContextWithStringSlices(t,
+		map[string]string{"label": "cap-asset"},
+		nil,
+		map[string][]string{"fields": {"description", "why"}})
+	out, err := captureStdout(t, func() error { return a.assetsSyncAndEnrichAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Step 3: Enriching fields")
+	assert.Contains(t, out, "Enriched description field for: Alpha")
+	assert.Contains(t, out, "Warning: Failed to enrich why field for Alpha: llama timeout")
+	require.Len(t, stub.enrichCalled, 2)
+}
+
+func TestApp_assetsSyncAndEnrichAction_NoSyncedAssetsSkipsBothEnrichmentSteps(t *testing.T) {
+	// no t.Parallel: prints to stdout
+	stub := &stubAssetServiceForSyncAndEnrich{
+		syncResult: &assetdomain.SyncResult{}, // empty SyncedAssets
+	}
+	a := &App{assetService: stub}
+	ctx := newContextWithStringSlices(t,
+		map[string]string{"label": "cap-asset"},
+		map[string]bool{"keywords": true},
+		map[string][]string{"fields": {"description"}})
+	out, err := captureStdout(t, func() error { return a.assetsSyncAndEnrichAction(ctx) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "Synced 0 assets")
+	assert.NotContains(t, out, "Step 2: Generating keywords")
+	assert.NotContains(t, out, "Step 3: Enriching fields")
+	assert.True(t, strings.Contains(out, "Sync-and-enrich workflow completed successfully!"))
+}

--- a/cmd/test_helpers_test.go
+++ b/cmd/test_helpers_test.go
@@ -12,12 +12,23 @@ import (
 // without the full cli.App boot. Shared across the command tests.
 func newContextWithFlags(t *testing.T, strFlags map[string]string, boolFlags map[string]bool) *cli.Context {
 	t.Helper()
+	return newContextWithStringSlices(t, strFlags, boolFlags, nil)
+}
+
+// newContextWithStringSlices extends newContextWithFlags with
+// StringSlice flag support (e.g. --fields description --fields why).
+func newContextWithStringSlices(t *testing.T, strFlags map[string]string, boolFlags map[string]bool, sliceFlags map[string][]string) *cli.Context {
+	t.Helper()
 	set := flag.NewFlagSet("test", flag.ContinueOnError)
 	for k, v := range strFlags {
 		set.String(k, v, "")
 	}
 	for k, v := range boolFlags {
 		set.Bool(k, v, "")
+	}
+	for k, vs := range sliceFlags {
+		ss := cli.NewStringSlice(vs...)
+		set.Var(ss, k, "")
 	}
 	return cli.NewContext(nil, set, nil)
 }


### PR DESCRIPTION
## Summary
- The `assets sync-and-enrich` inline closure was the last anonymous Action in `cmd/`. Its errgroup fan-out for keyword generation and field enrichment left every formatting and warning branch uncovered.
- Lift it verbatim into `a.assetsSyncAndEnrichAction`. `assetService` is already an interface, so a concurrent-safe stub embedded on `unimplementedAssetService` drives every branch.
- New `cmd/assets_sync_and_enrich_test.go` covers label-required, dry-run skips sync, sync error wrap, max-concurrent clamp to 1, keywords Step 2 (success + warning), fields Step 3 (success + warning), and the empty-SyncedAssets short-circuit.
- Extend `newContextWithFlags` with a sibling `newContextWithStringSlices` so `--fields` can carry repeated values; existing call sites unchanged.

## Validation
- `make pre-push`: 0 lint issues, coverage 88.6% (gate 78%).
- `--help` byte-identical for `assets sync-and-enrich`.
- Stub uses `sync.Mutex` for concurrent-safety under `-race`.

## Test plan
- [x] `go test -race ./cmd/...` passes
- [x] `golangci-lint run ./...` clean
- [x] Coverage gate green
- [x] CLI surface preserved